### PR TITLE
Map instrument "Rattle" to "shaken idiophone"

### DIFF
--- a/userscripts/discogs_credits/discogs_credits.js
+++ b/userscripts/discogs_credits/discogs_credits.js
@@ -3951,7 +3951,7 @@ const INSTRUMENTS = {
     Percussion: null,
     Rainstick: null,
     Ratchet: null,
-    Rattle: null,
+    Rattle: 'shaken idiophone',
     'Reco-reco': null,
     Repinique: null,
     Rototoms: null,


### PR DESCRIPTION
Let me know if I did this wrong. Currently "rattle" on discogs is mapped to [ankle rattlers](https://musicbrainz.org/instrument/7aed0189-ff99-4b43-8ff0-52ca5626d0b7). It should be the more general [shaken idiophone](https://musicbrainz.org/instrument/bd734382-68be-4b7b-adbd-cbdf35cdf740).