### PR TITLE
discogs_credits: 2 more fixtures + tolerant tag tokenizer

### DIFF
--- a/userscripts/discogs_credits/test/fixtures.json
+++ b/userscripts/discogs_credits/test/fixtures.json
@@ -2,36 +2,46 @@
     {
         "name": "Street Corner Symphonies, Volume 11",
         "url":  "https://musicbrainz.org/release/18cae3db-fa2c-493e-8e53-803bed92b8a5",
-        "tags": "compilation oldies many-existing-rels orchestra-bug"
+        "tags": "state-half compilation many-existing-rels bug-orchestra"
     },
     {
         "name": "Jugotronic EP",
         "url":  "https://musicbrainz.org/release/fd4c7ae2-39b7-4849-a021-856d67fb1e7b",
-        "tags": "ep small modern"
+        "tags": "state-empty small"
     },
     {
         "name": "Bosporus Bridges 3",
         "url":  "https://musicbrainz.org/release/24f4c94a-c51b-4f9b-b727-a09562c6e4b4",
-        "tags": "compilation small"
+        "tags": "state-empty compilation small"
     },
     {
         "name": "Bosporus Bridges 2",
         "url":  "https://musicbrainz.org/release/ba55d980-c3da-438a-bb13-16f4121d5f7a",
-        "tags": "compilation small"
+        "tags": "state-empty compilation small"
     },
     {
         "name": "Midwest Funk",
         "url":  "https://musicbrainz.org/release/62a764a8-cf05-459c-a358-2c65dbf0b729",
-        "tags": "compilation many-entities many-unresolved"
+        "tags": "state-low compilation many-entities many-unresolved"
     },
     {
         "name": "Spiritual Jazz Volume II",
         "url":  "https://musicbrainz.org/release/d3cb8510-d914-4a8d-8a2e-0b088d6a5827",
-        "tags": "compilation many-instruments"
+        "tags": "state-low compilation many-instruments"
     },
     {
         "name": "AnotherLateNight: Howie B.",
         "url":  "https://musicbrainz.org/release/5deefe9a-ea67-4d1d-a389-72d17fcd17a2",
-        "tags": "dj-mix many-rels"
+        "tags": "state-low compilation many-rels"
+    },
+    {
+        "name": "Frontera",
+        "url":  "https://musicbrainz.org/release/19da719d-00fd-4ef9-9df4-0aa6dd614353",
+        "tags": "state-empty small"
+    },
+    {
+        "name": "Lulu Rouge - Bless you",
+        "url":  "https://musicbrainz.org/release/a8eef154-5c43-4b0e-9b9c-9cc57d211805",
+        "tags": "state-empty small"
     }
 ]

--- a/userscripts/discogs_credits/test/run.mjs
+++ b/userscripts/discogs_credits/test/run.mjs
@@ -59,7 +59,9 @@ function matches(fixture, i) {
         if (!fixture.name.toLowerCase().includes(nameFilter.toLowerCase())) return false;
     }
     if (wantedTags) {
-        const fixTags = (fixture.tags || '').toLowerCase().split(/\s+/).filter(Boolean);
+        // Accept whitespace or comma as the per-fixture tag separator so authors
+        // can write either "a b c" or "a, b, c" without surprises.
+        const fixTags = (fixture.tags || '').toLowerCase().split(/[\s,]+/).filter(Boolean);
         if (!wantedTags.some(t => fixTags.includes(t))) return false;
     }
     return true;


### PR DESCRIPTION
Tiny follow-up to PR #16.

- `test/fixtures.json`:
  - 2 new fixtures: **Frontera** (release ID `19da719d-…`) and **Lulu Rouge - Bless you** (`a8eef154-…`)
  - Retagged the existing 7 with a `state-{empty,low,half}` prefix so the runner can target releases by how much MB data already exists (e.g. `--tags=state-empty` for clean-slate imports)
- `test/run.mjs`: tag tokenizer now accepts whitespace **or comma** as separator. Previously `"a, b"` tokenized as `["a,", "b"]` and `--tags=a` wouldn''t match.

Full 9-fixture suite is green locally (`OK all 9 fixture(s) pass.`, 2m 5s wall-clock).