### PR TITLE
Three function renames for clarity

### DIFF
--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -158,7 +158,7 @@
   async function fetchWithRetry(url, retries = 4) {
     return mbThrottle.fetchJson(url, retries);
   }
-  function hasDiscogsLinkDefined(mbid) {
+  function getDiscogsUrlForRelease(mbid) {
     const url = `/ws/js/release/${mbid}?fmt=json&inc=rels`;
     return fetch(url).then((body) => body.json()).then((json) => {
       const matchingRel = (json.relationships || []).find((rel) => {
@@ -1693,7 +1693,7 @@
       return !!resolvedRole;
     });
   }
-  function convertDiscogsArtistsToRolesRelationships(artists) {
+  function rolesFromDiscogsArtists(artists) {
     return artists?.reduce((rolesArr, artist) => {
       const roles = getArtistRoles(artist);
       if (Array.isArray(roles) && roles.length > 0) {
@@ -3793,7 +3793,7 @@
         const html = line.replace(/(https?:\/\/[^\s]+)/g, '<a href="$1" target="_blank" rel="noopener noreferrer nofollow">$1</a>');
         addLogLine(html);
       });
-      startImportRels(discogsUrl2, tracklistCb.checked, applyTracksCb.checked, createWorksCb.checked).finally(() => {
+      runImport(discogsUrl2, tracklistCb.checked, applyTracksCb.checked, createWorksCb.checked).finally(() => {
         importBtn.disabled = false;
         importBtn.textContent = "Import from Discogs";
         progressPct.textContent = "100%";
@@ -3832,9 +3832,9 @@
     } catch (e) {
     }
   })();
-  function startImportRels(discogsUrl2, processTracklist, applyToTracks, createWorks) {
+  function runImport(discogsUrl2, processTracklist, applyToTracks, createWorks) {
     return getDiscogsReleaseData(discogsUrl2).then((json) => {
-      let artistRoles = convertDiscogsArtistsToRolesRelationships(json.extraartists?.filter((artist) => !artist.tracks));
+      let artistRoles = rolesFromDiscogsArtists(json.extraartists?.filter((artist) => !artist.tracks));
       if (!_logs2._releaseInfoAdded) {
         _logs2._releaseInfoAdded = true;
         const trackCount = (json.tracklist || []).filter((t) => t.type_ === "track").length;
@@ -3874,7 +3874,7 @@
             return map;
           }
           return map.concat(
-            convertDiscogsArtistsToRolesRelationships(track.extraartists).map((rel) => {
+            rolesFromDiscogsArtists(track.extraartists).map((rel) => {
               return Object.assign({}, rel, {
                 track
               });
@@ -4091,7 +4091,7 @@
     const re = /musicbrainz\.org\/release\/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})\/edit-relationships/i;
     const m = window.location.href.match(re);
     if (!m) return;
-    hasDiscogsLinkDefined(m[1]).then((discogsUrl2) => {
+    getDiscogsUrlForRelease(m[1]).then((discogsUrl2) => {
       if (discogsUrl2) {
         insertDiscogsBar(discogsUrl2);
       }

--- a/userscripts/discogs_credits/src/api-mb.js
+++ b/userscripts/discogs_credits/src/api-mb.js
@@ -112,7 +112,7 @@ export async function fetchWithRetry(url, retries = 4) {
  * never starts (and the user sees no progress, which is the same UX as the
  * throttle pausing it).
  */
-export function hasDiscogsLinkDefined(mbid) {
+export function getDiscogsUrlForRelease(mbid) {
     const url = `/ws/js/release/${mbid}?fmt=json&inc=rels`;
     return fetch(url)
         .then(body => body.json())

--- a/userscripts/discogs_credits/src/discogs_credits.user.js
+++ b/userscripts/discogs_credits/src/discogs_credits.user.js
@@ -13,7 +13,7 @@
 // Side-effect imports (`./storage.js`, `./ui-bar.js`) trigger module init at
 // load time — opening IndexedDB and running the localStorage-cleanup IIFE.
 
-import { hasDiscogsLinkDefined } from './api-mb.js';
+import { getDiscogsUrlForRelease } from './api-mb.js';
 import { insertDiscogsBar }      from './ui-bar.js';
 import                                './storage.js';   // opens IndexedDB on load
 
@@ -70,7 +70,7 @@ $(document).ready(function () {
     const re = /musicbrainz\.org\/release\/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})\/edit-relationships/i;
     const m = window.location.href.match(re);
     if (!m) return;
-    hasDiscogsLinkDefined(m[1]).then(discogsUrl => {
+    getDiscogsUrlForRelease(m[1]).then(discogsUrl => {
         if (discogsUrl) {
             insertDiscogsBar(discogsUrl);
         }

--- a/userscripts/discogs_credits/src/mappers.js
+++ b/userscripts/discogs_credits/src/mappers.js
@@ -318,7 +318,7 @@ export function getArtistRoles(artist) {
 }
 
 /** Run `getArtistRoles` over every artist, flattening the results. */
-export function convertDiscogsArtistsToRolesRelationships(artists) {
+export function rolesFromDiscogsArtists(artists) {
     return artists?.reduce((rolesArr, artist) => {
         const roles = getArtistRoles(artist);
         if (Array.isArray(roles) && roles.length > 0) {

--- a/userscripts/discogs_credits/src/ui-bar.js
+++ b/userscripts/discogs_credits/src/ui-bar.js
@@ -2,13 +2,13 @@
 // `/edit-relationships` page when a Discogs URL is linked to the
 // release. Owns the bar styles (embedded so the userscript ships
 // self-contained), the option toggles, the "Import" button, and the
-// orchestration that runs after click (`startImportRels`).
+// orchestration that runs after click (`runImport`).
 //
 // Two pieces of module-private state are reused across re-runs of the
 // bar's onclick handler:
 //   _logs   — the <ul> the script appends per-line log messages to.
 //   _summary — the <p> shown above the log with the import summary.
-// They're set when insertDiscogsBar mounts the bar; startImportRels
+// They're set when insertDiscogsBar mounts the bar; runImport
 // reads them when populating the run output.
 //
 // One IIFE at the top cleans up stale `discogs-release-*` localStorage
@@ -28,7 +28,7 @@ import {
 }                                        from './api-discogs.js';
 import {
     convertPotentialDJMixers,
-    convertDiscogsArtistsToRolesRelationships,
+    rolesFromDiscogsArtists,
     getAllArtistTracks,
     getArtistRoles,
 }                                        from './mappers.js';
@@ -444,7 +444,7 @@ export function insertDiscogsBar(discogsUrl) {
             const html = line.replace(/(https?:\/\/[^\s]+)/g, '<a href="$1" target="_blank" rel="noopener noreferrer nofollow">$1</a>');
             addLogLine(html);
         });
-        startImportRels(discogsUrl, tracklistCb.checked, applyTracksCb.checked, createWorksCb.checked).finally(() => {
+        runImport(discogsUrl, tracklistCb.checked, applyTracksCb.checked, createWorksCb.checked).finally(() => {
             importBtn.disabled = false;
             importBtn.textContent = 'Import from Discogs';
             progressPct.textContent = '100%';
@@ -490,10 +490,10 @@ export function insertDiscogsBar(discogsUrl) {
         keysToRemove.forEach(k => localStorage.removeItem(k));
     } catch(e) {}
 })();
-function startImportRels(discogsUrl, processTracklist, applyToTracks, createWorks) {
+function runImport(discogsUrl, processTracklist, applyToTracks, createWorks) {
     return getDiscogsReleaseData(discogsUrl)
         .then(json => {
-            let artistRoles = convertDiscogsArtistsToRolesRelationships(json.extraartists?.filter(artist => !artist.tracks));
+            let artistRoles = rolesFromDiscogsArtists(json.extraartists?.filter(artist => !artist.tracks));
             // ── Raw Discogs JSON (collapsible, once per log session) ─────────────────
             if (!_logs._releaseInfoAdded) {
                 _logs._releaseInfoAdded = true;
@@ -532,7 +532,7 @@ function startImportRels(discogsUrl, processTracklist, applyToTracks, createWork
                             return map;
                         }
                         return map.concat(
-                            convertDiscogsArtistsToRolesRelationships(track.extraartists).map(rel => {
+                            rolesFromDiscogsArtists(track.extraartists).map(rel => {
                                 return Object.assign({}, rel, {
                                     track: track,
                                 });


### PR DESCRIPTION
Refs #32 — first batch of proposal F (renames per `dev/ANALYSIS.md §2.3`).

Targets the long-lived `refactor` branch, not `main`. (One final `refactor → main` PR ships #32 in full once all proposals land.)

## Renames

Three **pure** renames — no signature changes, no logic touched:

| Now | After | Why |
|---|---|---|
| `startImportRels` | `runImport` | Reads as the action, not the protocol it kicks off ("Rels") |
| `hasDiscogsLinkDefined` | `getDiscogsUrlForRelease` | The function returns the URL or null — its name should describe the *return value*, not the predicate question |
| `convertDiscogsArtistsToRolesRelationships` | `rolesFromDiscogsArtists` | Half the length, same meaning |

## Out of scope (separate chunks)

Other `ANALYSIS.md §2.3` entries are **structural** refactors that deserve their own commits:

- `checkMissingArtists` + `checkMissingCompanies` → single `resolveEntity(entity, type)` + `resolveAll(entities)` — collapses ~90% of duplicate code (proposal A.5).
- `instantFillRelationships` → `dispatchAllRelationships` split into four named children (`dispatchCompanies`, `dispatchReleaseArtists`, `dispatchTracklist`, `dispatchWorks`).
- `addLogLine` → `log.line` / `log.warn` / `log.error` — severity at the call site, drop HTML-in-strings.
- `getDiscogsLinkKey` + `link_infos` global → pure `parseDiscogsUrl(url) → {type, id, cleanUrl, key}`.

## Test plan

- [x] `pnpm run verify` — green.
- [x] Smoke fixture (Spiritual Jazz, 95 staged rels) — green.
