### PR TITLE
Pure parseDiscogsUrl replaces getDiscogsLinkKey + link_infos global

### DIFF
--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -283,22 +283,18 @@
   }
 
   // src/api-discogs.js
-  var link_infos = {};
-  function getDiscogsLinkKey(url) {
-    const re = /^https?:\/\/(?:www|api)\.discogs\.com\/(?:(?:(?!sell).+|sell.+)\/)?(master|release|artist|label)s?\/(\d+)(?:[^?#]*)(?:\?noanv=1|\?anv=[^=]+)?$/i;
-    const m = re.exec(url);
-    if (m !== null) {
-      const key = `${m[1]}/${m[2]}`;
-      if (!link_infos[key]) {
-        link_infos[key] = {
-          type: m[1],
-          id: m[2],
-          clean_url: `https://www.discogs.com/${m[1]}/${m[2]}`
-        };
-      }
-      return key;
-    }
-    return false;
+  var DISCOGS_URL_RE = /^https?:\/\/(?:www|api)\.discogs\.com\/(?:(?:(?!sell).+|sell.+)\/)?(master|release|artist|label)s?\/(\d+)(?:[^?#]*)(?:\?noanv=1|\?anv=[^=]+)?$/i;
+  function parseDiscogsUrl(url) {
+    const m = DISCOGS_URL_RE.exec(url);
+    if (!m) return null;
+    const type = m[1];
+    const id = m[2];
+    return {
+      type,
+      id,
+      key: `${type}/${id}`,
+      cleanUrl: `https://www.discogs.com/${type}/${id}`
+    };
   }
   var _releaseDataCache = /* @__PURE__ */ new Map();
   function getDiscogsReleaseData(url) {
@@ -1734,7 +1730,8 @@
       });
     }
     async function checkOne(artist) {
-      const key = getDiscogsLinkKey(artist.resource_url);
+      const parsed = parseDiscogsUrl(artist.resource_url);
+      const key = parsed?.key;
       const searchName = artist.name;
       const displayName = artist.anv && artist.anv.trim() || artist.name;
       const discogsHref = artist.resource_url.replace("https://api.discogs.com/artists/", "https://www.discogs.com/artist/");
@@ -1793,8 +1790,8 @@
         }
         return resolvedResult(mbUrl, a.name, a.disambiguation, "name");
       }
-      const urlJson = key && link_infos[key] ? await mbFetch(
-        `//musicbrainz.org/ws/2/url?resource=${encodeURIComponent(link_infos[key].clean_url)}&inc=artist-rels&fmt=json`
+      const urlJson = parsed ? await mbFetch(
+        `//musicbrainz.org/ws/2/url?resource=${encodeURIComponent(parsed.cleanUrl)}&inc=artist-rels&fmt=json`
       ) : null;
       if (urlJson?.relations?.length > 0) {
         const rel = urlJson.relations.find((r) => r.artist);
@@ -1879,7 +1876,8 @@
       const details = ENTITY_TYPE_MAP[company.entity_type_name];
       if (!details) return null;
       const entityType = details.entityType;
-      const key = getDiscogsLinkKey(company.resource_url);
+      const parsed = parseDiscogsUrl(company.resource_url);
+      const key = parsed?.key;
       const searchName = company.name;
       const displayName = company.name;
       const discogsHref = company.resource_url.replace(/https:\/\/api\.discogs\.com\/(\w+?)s\/(\d+)/, "https://www.discogs.com/$1/$2");
@@ -1983,8 +1981,8 @@
         };
       }
       const incRels = entityType === "place" ? "place-rels+label-rels" : `${entityType}-rels`;
-      const urlJson = key && link_infos[key] ? await mbFetch(
-        `//musicbrainz.org/ws/2/url?resource=${encodeURIComponent(link_infos[key].clean_url)}&inc=${incRels}&fmt=json`
+      const urlJson = parsed ? await mbFetch(
+        `//musicbrainz.org/ws/2/url?resource=${encodeURIComponent(parsed.cleanUrl)}&inc=${incRels}&fmt=json`
       ) : null;
       if (urlJson?.relations?.length > 0) {
         const rel = urlJson.relations.find((r) => r[entityType] || r["label"] || r["place"]);
@@ -2054,7 +2052,7 @@
     for (const r of _nullNames) {
       const rUrl = r.entity?.resource_url;
       try {
-        const idbKey = getDiscogsLinkKey(rUrl);
+        const idbKey = parseDiscogsUrl(rUrl)?.key;
         const rec = await readIdbRecord(idbKey);
         if (rec?.mb_name) {
           _preloadedNames.set(rUrl, { name: rec.mb_name, dis: rec.mb_disambiguation || "" });
@@ -2292,7 +2290,7 @@
         function setRowResolved(a) {
           const mbUrl = `//musicbrainz.org/${entityType}/${a.id}`;
           rowState.set(_entityKey, { mbUrl, mbName: a.name, mbDisambig: a.disambiguation || "", confirmed: true });
-          const _idbKey = r.entity?.resource_url ? getDiscogsLinkKey(r.entity.resource_url) : null;
+          const _idbKey = r.entity?.resource_url ? parseDiscogsUrl(r.entity.resource_url)?.key : null;
           if (_idbKey && db) {
             try {
               const _tx = db.transaction(["mblinks"], "readwrite");
@@ -3021,7 +3019,7 @@
     }
     async function getMbidForEntity(entity, entityType) {
       return new Promise((resolve, reject) => {
-        const key = getDiscogsLinkKey(entity.resource_url);
+        const key = parseDiscogsUrl(entity.resource_url)?.key;
         if (!key) return reject(`No Discogs key for ${entity.name}`);
         const tx = db.transaction(["mblinks"], "readonly");
         const req = tx.objectStore("mblinks").get(key);
@@ -3924,7 +3922,6 @@
         });
         if (!seenResourceUrls.has(url)) {
           seenResourceUrls.add(url);
-          if (role.artist?.resource_url) getDiscogsLinkKey(role.artist.resource_url);
           if (!role.artist?.resource_url && role.artist) role.artist._syntheticKey = url;
           uniqueArtists.push(role.artist);
         }
@@ -3940,7 +3937,6 @@
       json.companies.forEach((c) => {
         if (c.resource_url && !seenCompanyUrls.has(c.resource_url) && ENTITY_TYPE_MAP[c.entity_type_name]) {
           seenCompanyUrls.add(c.resource_url);
-          getDiscogsLinkKey(c.resource_url);
           uniqueCompanies.push(c);
         }
       });
@@ -4016,7 +4012,7 @@
         capturedConfirmedMap = confirmedMap;
         const cachePromises = [];
         confirmedMap.forEach((mbUrl, resourceUrl) => {
-          const key = getDiscogsLinkKey(resourceUrl);
+          const key = parseDiscogsUrl(resourceUrl)?.key;
           if (!key) return;
           cachePromises.push(new Promise((res) => {
             try {

--- a/userscripts/discogs_credits/src/api-discogs.js
+++ b/userscripts/discogs_credits/src/api-discogs.js
@@ -1,39 +1,33 @@
 // Discogs API wrappers and URL helpers.
-//
-// `link_infos` holds the parsed pieces of every Discogs URL the script has
-// seen this session, keyed by `${type}/${id}`. It's mutated by
-// `getDiscogsLinkKey` and read directly from many call sites — that's why
-// it's exported.
 
-/** Map of "<type>/<id>" → { type, id, clean_url }. Populated lazily by `getDiscogsLinkKey`. */
-export const link_infos = {};
+const DISCOGS_URL_RE = /^https?:\/\/(?:www|api)\.discogs\.com\/(?:(?:(?!sell).+|sell.+)\/)?(master|release|artist|label)s?\/(\d+)(?:[^?#]*)(?:\?noanv=1|\?anv=[^=]+)?$/i;
 
 /**
- * Parse a Discogs URL (api.discogs.com or www.discogs.com) into a key of the
- * form "<type>/<id>" and cache its pieces in `link_infos[key]`.
+ * Parse a Discogs URL (api.discogs.com or www.discogs.com) into its pieces.
  *
  * Recognises `master`, `release`, `artist`, `label` URLs in singular and
- * plural ("/labels/123" vs "/label/123") forms. Returns `false` when the URL
- * doesn't match.
+ * plural ("/labels/123" vs "/label/123") forms.
  *
- * Side effect: mutates `link_infos`. Idempotent — re-parsing the same URL
- * just returns the cached key.
+ * Returns `{type, id, key, cleanUrl}` on match, or `null` otherwise.
+ *
+ *   - `type`     — `'master' | 'release' | 'artist' | 'label'`
+ *   - `id`       — the numeric Discogs id, as a string
+ *   - `key`      — `"<type>/<id>"`, the IDB / localStorage key used elsewhere
+ *   - `cleanUrl` — canonical `https://www.discogs.com/<type>/<id>` form
+ *
+ * Pure: no side effects, no module state.
  */
-export function getDiscogsLinkKey(url) {
-    const re = /^https?:\/\/(?:www|api)\.discogs\.com\/(?:(?:(?!sell).+|sell.+)\/)?(master|release|artist|label)s?\/(\d+)(?:[^?#]*)(?:\?noanv=1|\?anv=[^=]+)?$/i;
-    const m = re.exec(url);
-    if (m !== null) {
-        const key = `${m[1]}/${m[2]}`;
-        if (!link_infos[key]) {
-            link_infos[key] = {
-                type: m[1],
-                id: m[2],
-                clean_url: `https://www.discogs.com/${m[1]}/${m[2]}`,
-            };
-        }
-        return key;
-    }
-    return false;
+export function parseDiscogsUrl(url) {
+    const m = DISCOGS_URL_RE.exec(url);
+    if (!m) return null;
+    const type = m[1];
+    const id   = m[2];
+    return {
+        type,
+        id,
+        key:      `${type}/${id}`,
+        cleanUrl: `https://www.discogs.com/${type}/${id}`,
+    };
 }
 
 // In-memory session cache for Discogs release JSON. Avoids localStorage

--- a/userscripts/discogs_credits/src/dispatch.js
+++ b/userscripts/discogs_credits/src/dispatch.js
@@ -7,7 +7,7 @@
 import { addLogLine }                  from './log.js';
 import { pageWindow }                   from './constants.js';
 import { db }                            from './storage.js';
-import { getDiscogsLinkKey }             from './api-discogs.js';
+import { parseDiscogsUrl }               from './api-discogs.js';
 import {
     mbThrottle,
     fetchMBEntity,
@@ -252,7 +252,7 @@ export async function instantFillRelationships(companies, artistRoles, tracklist
     // ── Helper: resolve MBID from IDB cache for a Discogs entity ─────────────
     async function getMbidForEntity(entity, entityType) {
         return new Promise((resolve, reject) => {
-            const key = getDiscogsLinkKey(entity.resource_url);
+            const key = parseDiscogsUrl(entity.resource_url)?.key;
             if (!key) return reject(`No Discogs key for ${entity.name}`);
             const tx = db.transaction(['mblinks'], 'readonly');
             const req = tx.objectStore('mblinks').get(key);

--- a/userscripts/discogs_credits/src/preflight.js
+++ b/userscripts/discogs_credits/src/preflight.js
@@ -13,7 +13,7 @@
 
 import { mbThrottle }                       from './api-mb.js';
 import { db }                                from './storage.js';
-import { getDiscogsLinkKey, link_infos }    from './api-discogs.js';
+import { parseDiscogsUrl }                  from './api-discogs.js';
 import { ENTITY_TYPE_MAP }                  from './data/entity-map.js';
 
 /**
@@ -69,7 +69,8 @@ export async function checkMissingArtists(artists, progressLi, bypassIdb) {
     }
 
     async function checkOne(artist) {
-        const key         = getDiscogsLinkKey(artist.resource_url);
+        const parsed      = parseDiscogsUrl(artist.resource_url);
+        const key         = parsed?.key;
         const searchName  = artist.name;
         const displayName = (artist.anv && artist.anv.trim()) || artist.name;
         const discogsHref = artist.resource_url
@@ -128,8 +129,8 @@ export async function checkMissingArtists(artists, progressLi, bypassIdb) {
         }
 
         // 3. URL lookup — needed when name search is ambiguous or empty
-        const urlJson = key && link_infos[key] ? await mbFetch(
-            `//musicbrainz.org/ws/2/url?resource=${encodeURIComponent(link_infos[key].clean_url)}&inc=artist-rels&fmt=json`
+        const urlJson = parsed ? await mbFetch(
+            `//musicbrainz.org/ws/2/url?resource=${encodeURIComponent(parsed.cleanUrl)}&inc=artist-rels&fmt=json`
         ) : null;
         if (urlJson?.relations?.length > 0) {
             const rel = urlJson.relations.find(r => r.artist);
@@ -234,7 +235,8 @@ export async function checkMissingCompanies(companies, progressLi, bypassIdb) {
         const details = ENTITY_TYPE_MAP[company.entity_type_name];
         if (!details) return null; // unmapped company type — skip
         const entityType  = details.entityType; // 'label' or 'place'
-        const key         = getDiscogsLinkKey(company.resource_url);
+        const parsed      = parseDiscogsUrl(company.resource_url);
+        const key         = parsed?.key;
         const searchName  = company.name;
         const displayName = company.name;
         // API uses plural paths (labels/, masters/) but website uses singular (label/, master/)
@@ -300,8 +302,8 @@ export async function checkMissingCompanies(companies, progressLi, bypassIdb) {
 
         // 3. URL lookup — for places also try label-rels (facilities are often stored as labels in MB)
         const incRels = entityType === 'place' ? 'place-rels+label-rels' : `${entityType}-rels`;
-        const urlJson = key && link_infos[key] ? await mbFetch(
-            `//musicbrainz.org/ws/2/url?resource=${encodeURIComponent(link_infos[key].clean_url)}&inc=${incRels}&fmt=json`
+        const urlJson = parsed ? await mbFetch(
+            `//musicbrainz.org/ws/2/url?resource=${encodeURIComponent(parsed.cleanUrl)}&inc=${incRels}&fmt=json`
         ) : null;
         if (urlJson?.relations?.length > 0) {
             const rel = urlJson.relations.find(r => r[entityType] || r['label'] || r['place']);

--- a/userscripts/discogs_credits/src/review-table.js
+++ b/userscripts/discogs_credits/src/review-table.js
@@ -6,7 +6,7 @@
 
 import { db, readIdbRecord }              from './storage.js';
 import { mbThrottle, fetchWithRetry }      from './api-mb.js';
-import { getDiscogsLinkKey, link_infos }   from './api-discogs.js';
+import { parseDiscogsUrl }                 from './api-discogs.js';
 import { guessSortName }                   from './mappers.js';
 import { getLogContainer }                 from './log.js';
 import { _hideBar }                        from './progress-bar.js';
@@ -36,7 +36,7 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
     for (const r of _nullNames) {
         const rUrl = r.entity?.resource_url;
         try {
-            const idbKey = getDiscogsLinkKey(rUrl);
+            const idbKey = parseDiscogsUrl(rUrl)?.key;
             const rec = await readIdbRecord(idbKey);
             if (rec?.mb_name) {
                 _preloadedNames.set(rUrl, { name: rec.mb_name, dis: rec.mb_disambiguation || '' });
@@ -312,7 +312,7 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
                 const mbUrl = `//musicbrainz.org/${entityType}/${a.id}`;
                 rowState.set(_entityKey, { mbUrl, mbName: a.name, mbDisambig: a.disambiguation || '', confirmed: true });
                 // Persist to IDB immediately so selection survives even without clicking Start import
-                const _idbKey = r.entity?.resource_url ? getDiscogsLinkKey(r.entity.resource_url) : null;
+                const _idbKey = r.entity?.resource_url ? parseDiscogsUrl(r.entity.resource_url)?.key : null;
                 if (_idbKey && db) {
                     try {
                         const _tx = db.transaction(['mblinks'], 'readwrite');

--- a/userscripts/discogs_credits/src/ui-bar.js
+++ b/userscripts/discogs_credits/src/ui-bar.js
@@ -22,7 +22,7 @@ import {
 }                                        from './log.js';
 import { _showBar, _hideBar }             from './progress-bar.js';
 import {
-    getDiscogsLinkKey,
+    parseDiscogsUrl,
     getDiscogsReleaseData,
     clearReleaseDataCache,
 }                                        from './api-discogs.js';
@@ -586,7 +586,10 @@ function runImport(discogsUrl, processTracklist, applyToTracks, createWorks) {
                 });
                 if (!seenResourceUrls.has(url)) {
                     seenResourceUrls.add(url);
-                    if (role.artist?.resource_url) getDiscogsLinkKey(role.artist.resource_url);
+                    // (was: `getDiscogsLinkKey(role.artist.resource_url)` for
+                    //  side-effect-populating the link_infos global; the
+                    //  preflight code now calls parseDiscogsUrl itself, so no
+                    //  pre-population needed.)
                     // Attach synthetic key for artists with no Discogs URL
                     if (!role.artist?.resource_url && role.artist) role.artist._syntheticKey = url;
                     uniqueArtists.push(role.artist);
@@ -606,7 +609,6 @@ function runImport(discogsUrl, processTracklist, applyToTracks, createWorks) {
             json.companies.forEach(c => {
                 if (c.resource_url && !seenCompanyUrls.has(c.resource_url) && ENTITY_TYPE_MAP[c.entity_type_name]) {
                     seenCompanyUrls.add(c.resource_url);
-                    getDiscogsLinkKey(c.resource_url);
                     uniqueCompanies.push(c);
                 }
             });
@@ -696,7 +698,7 @@ function runImport(discogsUrl, processTracklist, applyToTracks, createWorks) {
                     // by a 2-field `{discogs_id, mb_links}` put.
                     const cachePromises = [];
                     confirmedMap.forEach((mbUrl, resourceUrl) => {
-                        const key = getDiscogsLinkKey(resourceUrl);
+                        const key = parseDiscogsUrl(resourceUrl)?.key;
                         if (!key) return;
                         cachePromises.push(new Promise(res => {
                             try {


### PR DESCRIPTION
Refs #32 — second batch of proposal F. Targets `refactor`, not `main`.

## What

Was: `getDiscogsLinkKey(url) → key|false` mutated a module-level `link_infos` map; consumers later read `link_infos[key].clean_url` through it. Side-effect global, awkward two-step usage.

Now: `parseDiscogsUrl(url) → {type, id, key, cleanUrl} | null` is pure. Consumers parse once and use both fields from the returned object.

## Diff highlights

```js
// before
const key = getDiscogsLinkKey(artist.resource_url);
// ...later, far away...
const urlJson = key && link_infos[key]
    ? await mbFetch(`/ws/2/url?resource=${encodeURIComponent(link_infos[key].clean_url)}&inc=artist-rels&fmt=json`)
    : null;

// after
const parsed = parseDiscogsUrl(artist.resource_url);
const key = parsed?.key;
// ...later, in same scope...
const urlJson = parsed
    ? await mbFetch(`/ws/2/url?resource=${encodeURIComponent(parsed.cleanUrl)}&inc=artist-rels&fmt=json`)
    : null;
```

## Side wins

- Two `ui-bar.js` call sites were `getDiscogsLinkKey(url)` purely for side-effect — pre-populating `link_infos` so the preflight could later read `.clean_url`. With the pure function, preflight parses the URL itself; the side-effect-only calls are deleted. One real bug-class disposed of.
- `review-table.js` was importing `link_infos` but never using it. Removed.

## Test plan

- [x] `pnpm run verify` — green.
- [x] Smoke fixture (Spiritual Jazz: 95 staged rels) — green.
