### PR TITLE
Severity-aware log API replaces HTML-in-strings

### DIFF
--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -79,7 +79,7 @@
     }
   }
   var log = {
-    line: (msg) => _emit(msg, msg),
+    info: (msg) => _emit(msg, msg),
     warn: (msg) => _emit(`<span style="color:orange">WARN ${msg}</span>`, `WARN ${msg}`),
     error: (msg) => _emit(`<span style="color:red">ERR ${msg}</span>`, `ERR ${msg}`)
   };
@@ -198,7 +198,7 @@
       contains.sort((a, b) => ((a.name || "").length || 999) - ((b.name || "").length || 999));
       const best = contains[0];
       if ((best.name || "").toLowerCase() !== needle) {
-        log.line(`Fuzzy match: "${name}" \u2192 "${best.name}" (${type0}\u2192${type1})`);
+        log.info(`Fuzzy match: "${name}" \u2192 "${best.name}" (${type0}\u2192${type1})`);
       }
       return best.id;
     }
@@ -2688,21 +2688,21 @@
 
   // src/editor-state.js
   async function waitForMBEditor(timeoutMs = 15e3) {
-    log.line("Waiting for MB relationship editor\u2026");
+    log.info("Waiting for MB relationship editor\u2026");
     let waited = 0;
     while (waited < timeoutMs) {
       const MB = pageWindow.MB;
       const re = MB?.relationshipEditor;
       const st = re?.state;
       if (st?.entity) {
-        log.line(`Editor ready (${waited}ms). Release: "${st.entity.name}"`);
+        log.info(`Editor ready (${waited}ms). Release: "${st.entity.name}"`);
         return re;
       }
       if (waited % 2e3 === 0 && waited > 0) {
         const mbKeys = MB ? Object.keys(MB).join(", ") : "undefined";
         const reKeys = re ? Object.keys(re).join(", ") : "undefined";
         const stKeys = st ? Object.keys(st).join(", ") : "undefined";
-        log.line(`[${waited}ms] MB={${mbKeys}} re={${reKeys}} state={${stKeys}}`);
+        log.info(`[${waited}ms] MB={${mbKeys}} re={${reKeys}} state={${stKeys}}`);
       }
       await new Promise((r) => setTimeout(r, 200));
       waited += 200;
@@ -2730,7 +2730,7 @@
       }
     }
     const posLabel = trackPos != null && trackPos !== "" ? ` <span style="color:#888;font-size:0.85em">#${trackPos}</span>` : "";
-    log.line(`\u2192 <strong>${ltName}</strong>${attrDesc}${posLabel}: ${sourceEntity.name || sourceEntity.gid} \u2194 ${targetEntity.name || targetEntity.gid}${credit && credit !== (targetEntity.name || targetEntity.gid) ? ` (credited: ${credit})` : ""}`);
+    log.info(`\u2192 <strong>${ltName}</strong>${attrDesc}${posLabel}: ${sourceEntity.name || sourceEntity.gid} \u2194 ${targetEntity.name || targetEntity.gid}${credit && credit !== (targetEntity.name || targetEntity.gid) ? ` (credited: ${credit})` : ""}`);
     re.dispatch({
       type: "update-relationship-state",
       sourceEntity,
@@ -2878,7 +2878,7 @@
       "programming"
       // NOT 'mastering' — MB deprecated artist→recording mastering (link type 136).
     ]);
-    log.line(`Starting instant fill: ${companies.length} companies, ${artistRoles.length} release artist roles, ${tracklistRels.length} tracklist roles`);
+    log.info(`Starting instant fill: ${companies.length} companies, ${artistRoles.length} release artist roles, ${tracklistRels.length} tracklist roles`);
     const bar = document.querySelector(".discogs-bar");
     function tickProgress() {
       const done = added + skipped + failed;
@@ -2938,19 +2938,19 @@
           trackIndex++;
         }
       }
-      log.line(`Found ${trackCount} track(s) in editor state (${recordingByGid.size} with GID, ${recordingByPosition.size} position entries: ${[...recordingByPosition.keys()].join(",")}). relatedWorks: ${editorWorkByRecGid.size} pre-linked`);
+      log.info(`Found ${trackCount} track(s) in editor state (${recordingByGid.size} with GID, ${recordingByPosition.size} position entries: ${[...recordingByPosition.keys()].join(",")}). relatedWorks: ${editorWorkByRecGid.size} pre-linked`);
     } catch (e) {
       log.warn(`Iterating MB state: ${e.message}`);
     }
     const positionToGid = /* @__PURE__ */ new Map();
     try {
       const relMbid = releaseEntity.gid;
-      log.line(`WS2: fetching recordings for release ${relMbid}\u2026`);
+      log.info(`WS2: fetching recordings for release ${relMbid}\u2026`);
       const wsJson = await fetchWithRetry(`/ws/2/release/${relMbid}?inc=recordings&fmt=json`);
-      log.line(`WS2: response received`);
+      log.info(`WS2: response received`);
       if (wsJson) {
         const mediaCount = wsJson.media?.length ?? 0;
-        log.line(`WS2: ${mediaCount} medium/media in response`);
+        log.info(`WS2: ${mediaCount} medium/media in response`);
         const mediaArr = wsJson.media || [];
         const isMultiMedium2 = mediaArr.length > 1;
         for (const medium of mediaArr) {
@@ -2970,7 +2970,7 @@
             }
           }
         }
-        log.line(`WS2 position map: ${positionToGid.size} entries (${[...positionToGid.keys()].sort().join(", ")})`);
+        log.info(`WS2 position map: ${positionToGid.size} entries (${[...positionToGid.keys()].sort().join(", ")})`);
       }
     } catch (e) {
       log.warn(`WS2 recording fetch failed: ${e.message} \u2014 using editor state positions only`);
@@ -3184,7 +3184,7 @@
     if (applyToTracks && recordingByGid.size > 0) {
       const applicable = artistRoles.filter((role) => RECORDING_LINK_TYPES.has(role.linkType) && !WORK_ONLY_ARTIST_RELS.includes(role.linkType));
       if (applicable.length > 0) {
-        log.line(`Applying ${applicable.length} release credit(s) to ${recordingByGid.size} recording(s)\u2026`);
+        log.info(`Applying ${applicable.length} release credit(s) to ${recordingByGid.size} recording(s)\u2026`);
         for (const role of applicable) {
           let mbUrl;
           try {
@@ -3245,9 +3245,9 @@
           }
           return null;
         };
-        log.line(`Processing work relationships for ${workOnlyByGid.size} recording(s)\u2026`);
+        log.info(`Processing work relationships for ${workOnlyByGid.size} recording(s)\u2026`);
         const existingWorkByRecGid = editorWorkByRecGid;
-        log.line(`Editor state: ${existingWorkByRecGid.size} recording(s) already have a linked work`);
+        log.info(`Editor state: ${existingWorkByRecGid.size} recording(s) already have a linked work`);
         for (const [recGid, entries] of workOnlyByGid) {
           const recEntity = entries[0]?.recEntity ?? recordingByGid.get(recGid);
           const trackTitle = entries[0]?.role.track.title ?? recEntity?.name ?? recGid;
@@ -3258,7 +3258,7 @@
           if (hasExistingWork) {
             workEntity = editorWorkByRecGid.get(recGid);
             const wid = workEntity.gid || workEntity.id;
-            log.line(`Track ${trackPos} "${trackTitle}": work already linked (${workEntity.name || wid || "existing"}) \u2014 skipping creation`);
+            log.info(`Track ${trackPos} "${trackTitle}": work already linked (${workEntity.name || wid || "existing"}) \u2014 skipping creation`);
             if (!workEntity.gid && !workEntity.id) continue;
           }
           if (!workEntity) workEntity = getWorkFromEditorState(recEntity);
@@ -3313,7 +3313,7 @@
                 linkTypeID: recordingOfLinkTypeId
               }
             });
-            log.line(`Track ${trackPos} "${trackTitle}": created new work "${trackTitle}"`);
+            log.info(`Track ${trackPos} "${trackTitle}": created new work "${trackTitle}"`);
             added++;
             tickProgress();
             workEntity = getWorkFromEditorState(recEntity) || workEntity;
@@ -3382,7 +3382,7 @@
       const trackRelKey = `${role.track.position}|${role.linkType}|${mbUrl}|${attrKey}`;
       if (seenTrackRels.has(trackRelKey)) continue;
       seenTrackRels.add(trackRelKey);
-      log.line(`Track ${role.track.position} "${role.track.title}": adding <strong>${role.linkType}</strong> \u2014 ${credit}`);
+      log.info(`Track ${role.track.position} "${role.track.title}": adding <strong>${role.linkType}</strong> \u2014 ${credit}`);
       await processOne(recEntity, "artist", "recording", role.linkType, mbUrl, role.attributes || [], credit, role.track.position);
       tickProgress();
     }
@@ -3396,7 +3396,7 @@
       re.dispatch({ type: "update-edit-note", editNote: note });
     } catch (e) {
     }
-    log.line(`<strong>Done: ${added} added, ${existedRels} already existed, ${skipped} skipped, ${failed} failed</strong>`);
+    log.info(`<strong>Done: ${added} added, ${existedRels} already existed, ${skipped} skipped, ${failed} failed</strong>`);
   }
 
   // src/ui-bar.js
@@ -3794,7 +3794,7 @@
       editNote.split("\n").forEach((line) => {
         if (!line.trim()) return;
         const html = line.replace(/(https?:\/\/[^\s]+)/g, '<a href="$1" target="_blank" rel="noopener noreferrer nofollow">$1</a>');
-        log.line(html);
+        log.info(html);
       });
       runImport(discogsUrl2, tracklistCb.checked, applyTracksCb.checked, createWorksCb.checked).finally(() => {
         importBtn.disabled = false;
@@ -3868,7 +3868,7 @@
         li.querySelector("details").appendChild(pre);
         _logs2.appendChild(li);
       }
-      log.line(`Found ${json.companies.length + artistRoles.length} release relationships`);
+      log.info(`Found ${json.companies.length + artistRoles.length} release relationships`);
       artistRoles = artistRoles.concat(convertPotentialDJMixers(json));
       let tracklistRels = [];
       if (processTracklist) {
@@ -3903,7 +3903,7 @@
             }, [])
           );
         }
-        log.line(`Found ${tracklistRels.length} tracklist relationships`);
+        log.info(`Found ${tracklistRels.length} tracklist relationships`);
       }
       const allArtistRoles = artistRoles.concat(tracklistRels);
       const uniqueArtists = [];

--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -65,19 +65,24 @@
   function getLogContainer() {
     return _logs;
   }
-  function addLogLine(message) {
+  function _emit(html, plainText) {
     if (!_logs) return;
     const li = document.createElement("li");
     const d = /* @__PURE__ */ new Date();
     const pad = (n) => String(n).padStart(2, "0");
     const stamp = `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
-    li.innerHTML = `<span style="color:#999;font-family:ui-monospace,Menlo,Consolas,monospace;font-size:0.82em;">${stamp}</span> ${message}`;
+    li.innerHTML = `<span style="color:#999;font-family:ui-monospace,Menlo,Consolas,monospace;font-size:0.82em;">${stamp}</span> ${html}`;
     _logs.insertAdjacentElement("beforeend", li);
     const bar = document.querySelector(".discogs-bar");
     if (bar?._setProgress) {
-      bar._setProgress(null, message.replace(/<[^>]*>/g, "").trim().substring(0, 120));
+      bar._setProgress(null, plainText.replace(/<[^>]*>/g, "").trim().substring(0, 120));
     }
   }
+  var log = {
+    line: (msg) => _emit(msg, msg),
+    warn: (msg) => _emit(`<span style="color:orange">WARN ${msg}</span>`, `WARN ${msg}`),
+    error: (msg) => _emit(`<span style="color:red">ERR ${msg}</span>`, `ERR ${msg}`)
+  };
 
   // src/api-mb.js
   async function fetchMBEntity(mbid) {
@@ -170,7 +175,7 @@
   function resolveLinkTypeId(name, type0, type1) {
     const lt = pageWindow.MB?.linkedEntities?.link_type;
     if (!lt) {
-      addLogLine('<span style="color:red">ERR MB.linkedEntities.link_type not available</span>');
+      log.error("MB.linkedEntities.link_type not available");
       return null;
     }
     const needle = name.toLowerCase().trim();
@@ -193,7 +198,7 @@
       contains.sort((a, b) => ((a.name || "").length || 999) - ((b.name || "").length || 999));
       const best = contains[0];
       if ((best.name || "").toLowerCase() !== needle) {
-        addLogLine(`Fuzzy match: "${name}" \u2192 "${best.name}" (${type0}\u2192${type1})`);
+        log.line(`Fuzzy match: "${name}" \u2192 "${best.name}" (${type0}\u2192${type1})`);
       }
       return best.id;
     }
@@ -205,12 +210,12 @@
     const wrongPairHits = allByName.filter((v) => !(v.type0 === type0 && v.type1 === type1));
     if (deprecatedHit) {
       const altPairs = [...new Set(allByName.filter((v) => !v.deprecated).map((v) => `${v.type0}\u2192${v.type1}`))].join(", ");
-      addLogLine(`<span style="color:red">ERR "${name}" (${type0}\u2192${type1}) is deprecated by MB and would block the commit \u2014 skipping${altPairs ? `. Valid alternative(s): ${altPairs}` : ""}.</span>`);
+      log.error(`"${name}" (${type0}\u2192${type1}) is deprecated by MB and would block the commit \u2014 skipping${altPairs ? `. Valid alternative(s): ${altPairs}` : ""}.`);
     } else if (wrongPairHits.length > 0) {
       const hitDesc = wrongPairHits.map((v) => `${v.name}(${v.type0}\u2192${v.type1})`).join(", ");
-      addLogLine(`<span style="color:orange">WARN No "${name}" link type for (${type0}\u2192${type1}) \u2014 exists for other entity pairs: ${hitDesc} \u2014 skipping</span>`);
+      log.warn(`No "${name}" link type for (${type0}\u2192${type1}) \u2014 exists for other entity pairs: ${hitDesc} \u2014 skipping`);
     } else {
-      addLogLine(`<span style="color:orange">WARN Unknown link type "${name}" (${type0}\u2192${type1}). Available for this pair: ${availableNames || "none"}</span>`);
+      log.warn(`Unknown link type "${name}" (${type0}\u2192${type1}). Available for this pair: ${availableNames || "none"}`);
     }
     return null;
   }
@@ -2683,26 +2688,26 @@
 
   // src/editor-state.js
   async function waitForMBEditor(timeoutMs = 15e3) {
-    addLogLine("Waiting for MB relationship editor\u2026");
+    log.line("Waiting for MB relationship editor\u2026");
     let waited = 0;
     while (waited < timeoutMs) {
       const MB = pageWindow.MB;
       const re = MB?.relationshipEditor;
       const st = re?.state;
       if (st?.entity) {
-        addLogLine(`Editor ready (${waited}ms). Release: "${st.entity.name}"`);
+        log.line(`Editor ready (${waited}ms). Release: "${st.entity.name}"`);
         return re;
       }
       if (waited % 2e3 === 0 && waited > 0) {
         const mbKeys = MB ? Object.keys(MB).join(", ") : "undefined";
         const reKeys = re ? Object.keys(re).join(", ") : "undefined";
         const stKeys = st ? Object.keys(st).join(", ") : "undefined";
-        addLogLine(`[${waited}ms] MB={${mbKeys}} re={${reKeys}} state={${stKeys}}`);
+        log.line(`[${waited}ms] MB={${mbKeys}} re={${reKeys}} state={${stKeys}}`);
       }
       await new Promise((r) => setTimeout(r, 200));
       waited += 200;
     }
-    addLogLine('<span style="color:red">ERR MB editor not ready after 15s \u2014 aborting</span>');
+    log.error("MB editor not ready after 15s \u2014 aborting");
     return null;
   }
   function dispatchRelationship(re, sourceEntity, targetEntity, linkTypeID, credit, attributes, trackPos) {
@@ -2725,7 +2730,7 @@
       }
     }
     const posLabel = trackPos != null && trackPos !== "" ? ` <span style="color:#888;font-size:0.85em">#${trackPos}</span>` : "";
-    addLogLine(`\u2192 <strong>${ltName}</strong>${attrDesc}${posLabel}: ${sourceEntity.name || sourceEntity.gid} \u2194 ${targetEntity.name || targetEntity.gid}${credit && credit !== (targetEntity.name || targetEntity.gid) ? ` (credited: ${credit})` : ""}`);
+    log.line(`\u2192 <strong>${ltName}</strong>${attrDesc}${posLabel}: ${sourceEntity.name || sourceEntity.gid} \u2194 ${targetEntity.name || targetEntity.gid}${credit && credit !== (targetEntity.name || targetEntity.gid) ? ` (credited: ${credit})` : ""}`);
     re.dispatch({
       type: "update-relationship-state",
       sourceEntity,
@@ -2763,7 +2768,7 @@
           if (vl.includes(lower) || lower.includes(vl)) return v;
         }
       }
-      addLogLine(`<span style="color:orange">WARN Attribute "${name}" not found in MB \u2014 dropping attribute but keeping the rel</span>`);
+      log.warn(`Attribute "${name}" not found in MB \u2014 dropping attribute but keeping the rel`);
       return null;
     }
     function extractFnValue(fn) {
@@ -2799,7 +2804,7 @@
     try {
       return tree.fromDistinctAscArray(attrObjs);
     } catch (e) {
-      addLogLine(`<span style="color:orange">WARN Attribute tree build failed (${e.message}) \u2014 importing without attributes</span>`);
+      log.warn(`Attribute tree build failed (${e.message}) \u2014 importing without attributes`);
       return null;
     }
   }
@@ -2873,7 +2878,7 @@
       "programming"
       // NOT 'mastering' — MB deprecated artist→recording mastering (link type 136).
     ]);
-    addLogLine(`Starting instant fill: ${companies.length} companies, ${artistRoles.length} release artist roles, ${tracklistRels.length} tracklist roles`);
+    log.line(`Starting instant fill: ${companies.length} companies, ${artistRoles.length} release artist roles, ${tracklistRels.length} tracklist roles`);
     const bar = document.querySelector(".discogs-bar");
     function tickProgress() {
       const done = added + skipped + failed;
@@ -2933,19 +2938,19 @@
           trackIndex++;
         }
       }
-      addLogLine(`Found ${trackCount} track(s) in editor state (${recordingByGid.size} with GID, ${recordingByPosition.size} position entries: ${[...recordingByPosition.keys()].join(",")}). relatedWorks: ${editorWorkByRecGid.size} pre-linked`);
+      log.line(`Found ${trackCount} track(s) in editor state (${recordingByGid.size} with GID, ${recordingByPosition.size} position entries: ${[...recordingByPosition.keys()].join(",")}). relatedWorks: ${editorWorkByRecGid.size} pre-linked`);
     } catch (e) {
-      addLogLine(`<span style="color:orange">WARN Iterating MB state: ${e.message}</span>`);
+      log.warn(`Iterating MB state: ${e.message}`);
     }
     const positionToGid = /* @__PURE__ */ new Map();
     try {
       const relMbid = releaseEntity.gid;
-      addLogLine(`WS2: fetching recordings for release ${relMbid}\u2026`);
+      log.line(`WS2: fetching recordings for release ${relMbid}\u2026`);
       const wsJson = await fetchWithRetry(`/ws/2/release/${relMbid}?inc=recordings&fmt=json`);
-      addLogLine(`WS2: response received`);
+      log.line(`WS2: response received`);
       if (wsJson) {
         const mediaCount = wsJson.media?.length ?? 0;
-        addLogLine(`WS2: ${mediaCount} medium/media in response`);
+        log.line(`WS2: ${mediaCount} medium/media in response`);
         const mediaArr = wsJson.media || [];
         const isMultiMedium2 = mediaArr.length > 1;
         for (const medium of mediaArr) {
@@ -2965,10 +2970,10 @@
             }
           }
         }
-        addLogLine(`WS2 position map: ${positionToGid.size} entries (${[...positionToGid.keys()].sort().join(", ")})`);
+        log.line(`WS2 position map: ${positionToGid.size} entries (${[...positionToGid.keys()].sort().join(", ")})`);
       }
     } catch (e) {
-      addLogLine(`<span style="color:orange">WARN WS2 recording fetch failed: ${e.message} \u2014 using editor state positions only</span>`);
+      log.warn(`WS2 recording fetch failed: ${e.message} \u2014 using editor state positions only`);
     }
     const isMultiMedium = positionToGid.size > 0 && [...positionToGid.keys()].some((k) => /^[2-9]-/.test(k));
     function inferDiscFromVinylSide(pos) {
@@ -3002,7 +3007,7 @@
         if (gid) {
           const rec = recordingByGid.get(gid);
           if (rec) return rec;
-          addLogLine(`<span style="color:orange">WARN Recording ${gid} for track ${track.position} not in editor state</span>`);
+          log.warn(`Recording ${gid} for track ${track.position} not in editor state`);
           return null;
         }
       }
@@ -3013,7 +3018,7 @@
       if (trackCount > 0) {
         const ws2Keys = positionToGid.size ? [...positionToGid.keys()].join(", ") : "(empty)";
         const stateKeys = recordingByPosition.size ? [...recordingByPosition.keys()].join(", ") : "(empty)";
-        addLogLine(`<span style="color:orange">WARN No recording for track ${track.position} "${track.title}". WS2 keys: ${ws2Keys} | State keys: ${stateKeys}</span>`);
+        log.warn(`No recording for track ${track.position} "${track.title}". WS2 keys: ${ws2Keys} | State keys: ${stateKeys}`);
       }
       return null;
     }
@@ -3053,7 +3058,7 @@
     async function processOne(sourceEntity, entityType0, entityType1, linkTypeName, mbUrl, rawAttributes, credit, trackPos) {
       const mbid = mbUrl.replace(/.*\//, "").replace(/[^a-f0-9-]/gi, "").substring(0, 36);
       if (!mbid) {
-        addLogLine(`<span style="color:red">ERR Bad MBID URL: ${mbUrl}</span>`);
+        log.error(`Bad MBID URL: ${mbUrl}`);
         failed++;
         return;
       }
@@ -3080,7 +3085,7 @@
       try {
         targetEntity = await fetchMBEntity(mbid);
       } catch (e) {
-        addLogLine(`<span style="color:red">ERR Entity fetch failed for ${mbid}: ${e.message}</span>`);
+        log.error(`Entity fetch failed for ${mbid}: ${e.message}`);
         failed++;
         return;
       }
@@ -3107,7 +3112,7 @@
         if (reResolved) {
           resolvedLinkTypeID = reResolved;
         } else {
-          addLogLine(`<span style="color:orange">WARN Entity "${targetEntity.name}" is a ${targetEntity.entityType} but expected ${entityType0}/${entityType1} \u2014 link type "${linkTypeName}" may not apply</span>`);
+          log.warn(`Entity "${targetEntity.name}" is a ${targetEntity.entityType} but expected ${entityType0}/${entityType1} \u2014 link type "${linkTypeName}" may not apply`);
         }
       }
       if (relAlreadyExists(sourceEntity, resolvedLinkTypeID, targetEntity.gid, attrTree)) {
@@ -3123,7 +3128,7 @@
       const resolvedEt = resolvedEntityTypes.get(company.resource_url) || details.entityType;
       if (resolvedEt !== details.entityType) {
         if (details.entityType === "place" && resolvedEt === "label") {
-          addLogLine(`<span style="color:orange">WARN Skipped ${company.name}: MB has no "${details.linkType}" relationship for labels (only places). Add manually if needed.</span>`);
+          log.warn(`Skipped ${company.name}: MB has no "${details.linkType}" relationship for labels (only places). Add manually if needed.`);
           skipped++;
           tickProgress();
           continue;
@@ -3133,7 +3138,7 @@
       try {
         mbUrl = await getMbidForEntity(company, resolvedEt);
       } catch (e) {
-        addLogLine(`<span style="color:orange">WARN Skipped ${company.name} \u2014 not resolved in review</span>`);
+        log.warn(`Skipped ${company.name} \u2014 not resolved in review`);
         skipped++;
         tickProgress();
         continue;
@@ -3157,7 +3162,7 @@
         }
       }
       if (!mbUrl && !role.artist.resource_url) {
-        addLogLine(`<span style="color:orange">WARN Skipped ${role.artist.name} (${role.linkType}) \u2014 no Discogs page, not confirmed in review</span>`);
+        log.warn(`Skipped ${role.artist.name} (${role.linkType}) \u2014 no Discogs page, not confirmed in review`);
         skipped++;
         tickProgress();
         continue;
@@ -3166,7 +3171,7 @@
         try {
           mbUrl = await getMbidForEntity(role.artist, "artist");
         } catch (e) {
-          addLogLine(`<span style="color:orange">WARN Skipped ${role.artist.name} \u2014 not resolved in review (${role.linkType})</span>`);
+          log.warn(`Skipped ${role.artist.name} \u2014 not resolved in review (${role.linkType})`);
           skipped++;
           tickProgress();
           continue;
@@ -3179,13 +3184,13 @@
     if (applyToTracks && recordingByGid.size > 0) {
       const applicable = artistRoles.filter((role) => RECORDING_LINK_TYPES.has(role.linkType) && !WORK_ONLY_ARTIST_RELS.includes(role.linkType));
       if (applicable.length > 0) {
-        addLogLine(`Applying ${applicable.length} release credit(s) to ${recordingByGid.size} recording(s)\u2026`);
+        log.line(`Applying ${applicable.length} release credit(s) to ${recordingByGid.size} recording(s)\u2026`);
         for (const role of applicable) {
           let mbUrl;
           try {
             mbUrl = await getMbidForEntity(role.artist, "artist");
           } catch (e) {
-            addLogLine(`<span style="color:orange">WARN Skipped ${role.artist.name} (${role.linkType}) in applyToTracks \u2014 not resolved in review</span>`);
+            log.warn(`Skipped ${role.artist.name} (${role.linkType}) in applyToTracks \u2014 not resolved in review`);
             continue;
           }
           const credit = role.artist.anv?.trim() || role.artist.name;
@@ -3201,7 +3206,7 @@
       if (!WORK_ONLY_ARTIST_RELS.includes(role.linkType)) continue;
       const recEntity = getRecordingEntity(role.track);
       if (!recEntity) {
-        addLogLine(`<span style="color:red">ERR Work-only rel for track ${role.track.position} "${role.track.title}" \u2014 no recording found, skipped</span>`);
+        log.error(`Work-only rel for track ${role.track.position} "${role.track.title}" \u2014 no recording found, skipped`);
         failed++;
         continue;
       }
@@ -3227,7 +3232,7 @@
     }
     if (workOnlyByGid.size > 0) {
       if (!recordingOfLinkTypeId) {
-        addLogLine('<span style="color:red">ERR Could not resolve "performance" link type \u2014 work processing skipped</span>');
+        log.error('Could not resolve "performance" link type \u2014 work processing skipped');
       } else {
         let getWorkFromEditorState = function(recEntity) {
           try {
@@ -3240,9 +3245,9 @@
           }
           return null;
         };
-        addLogLine(`Processing work relationships for ${workOnlyByGid.size} recording(s)\u2026`);
+        log.line(`Processing work relationships for ${workOnlyByGid.size} recording(s)\u2026`);
         const existingWorkByRecGid = editorWorkByRecGid;
-        addLogLine(`Editor state: ${existingWorkByRecGid.size} recording(s) already have a linked work`);
+        log.line(`Editor state: ${existingWorkByRecGid.size} recording(s) already have a linked work`);
         for (const [recGid, entries] of workOnlyByGid) {
           const recEntity = entries[0]?.recEntity ?? recordingByGid.get(recGid);
           const trackTitle = entries[0]?.role.track.title ?? recEntity?.name ?? recGid;
@@ -3253,14 +3258,14 @@
           if (hasExistingWork) {
             workEntity = editorWorkByRecGid.get(recGid);
             const wid = workEntity.gid || workEntity.id;
-            addLogLine(`Track ${trackPos} "${trackTitle}": work already linked (${workEntity.name || wid || "existing"}) \u2014 skipping creation`);
+            log.line(`Track ${trackPos} "${trackTitle}": work already linked (${workEntity.name || wid || "existing"}) \u2014 skipping creation`);
             if (!workEntity.gid && !workEntity.id) continue;
           }
           if (!workEntity) workEntity = getWorkFromEditorState(recEntity);
           if (!workEntity) {
             if (!createWorks) {
               for (const { role } of entries) {
-                addLogLine(`<span style="color:red">ERR Track ${trackPos} "${trackTitle}": no work exists for ${role.linkType} (${role.artist.name}) \u2014 enable "Create missing works" or add work manually</span>`);
+                log.error(`Track ${trackPos} "${trackTitle}": no work exists for ${role.linkType} (${role.artist.name}) \u2014 enable "Create missing works" or add work manually`);
                 failed++;
               }
               continue;
@@ -3308,7 +3313,7 @@
                 linkTypeID: recordingOfLinkTypeId
               }
             });
-            addLogLine(`Track ${trackPos} "${trackTitle}": created new work "${trackTitle}"`);
+            log.line(`Track ${trackPos} "${trackTitle}": created new work "${trackTitle}"`);
             added++;
             tickProgress();
             workEntity = getWorkFromEditorState(recEntity) || workEntity;
@@ -3318,7 +3323,7 @@
             try {
               mbUrl = await getMbidForEntity(role.artist, "artist");
             } catch (e) {
-              addLogLine(`<span style="color:orange">WARN Skipped ${role.artist.name} \u2014 not resolved in review (${role.linkType})</span>`);
+              log.warn(`Skipped ${role.artist.name} \u2014 not resolved in review (${role.linkType})`);
               continue;
             }
             const credit = role.artist.anv?.trim() || role.artist.name;
@@ -3333,7 +3338,7 @@
                   dispatchRelationship(re, workEntity, artistEntity, linkTypeID, credit, buildAttributes(role.attributes || []));
                   added++;
                 } catch (e) {
-                  addLogLine(`<span style="color:red">ERR Failed to add ${role.linkType} for new work: ${e.message}</span>`);
+                  log.error(`Failed to add ${role.linkType} for new work: ${e.message}`);
                 }
               }
             }
@@ -3355,20 +3360,20 @@
         }
       }
       if (!mbUrl && !role.artist.resource_url) {
-        addLogLine(`<span style="color:orange">WARN Skipped ${role.artist.name} on track ${role.track.position} \u2014 no Discogs page, not confirmed</span>`);
+        log.warn(`Skipped ${role.artist.name} on track ${role.track.position} \u2014 no Discogs page, not confirmed`);
         continue;
       }
       if (!mbUrl) {
         try {
           mbUrl = await getMbidForEntity(role.artist, "artist");
         } catch (e) {
-          addLogLine(`<span style="color:orange">WARN Skipped ${role.artist.name} on track ${role.track.position} \u2014 not resolved in review</span>`);
+          log.warn(`Skipped ${role.artist.name} on track ${role.track.position} \u2014 not resolved in review`);
           continue;
         }
       }
       const recEntity = getRecordingEntity(role.track);
       if (!recEntity) {
-        addLogLine(`<span style="color:orange">WARN No recording found for track ${role.track.position} "${role.track.title}" \u2014 skipped</span>`);
+        log.warn(`No recording found for track ${role.track.position} "${role.track.title}" \u2014 skipped`);
         failed++;
         continue;
       }
@@ -3377,7 +3382,7 @@
       const trackRelKey = `${role.track.position}|${role.linkType}|${mbUrl}|${attrKey}`;
       if (seenTrackRels.has(trackRelKey)) continue;
       seenTrackRels.add(trackRelKey);
-      addLogLine(`Track ${role.track.position} "${role.track.title}": adding <strong>${role.linkType}</strong> \u2014 ${credit}`);
+      log.line(`Track ${role.track.position} "${role.track.title}": adding <strong>${role.linkType}</strong> \u2014 ${credit}`);
       await processOne(recEntity, "artist", "recording", role.linkType, mbUrl, role.attributes || [], credit, role.track.position);
       tickProgress();
     }
@@ -3391,7 +3396,7 @@
       re.dispatch({ type: "update-edit-note", editNote: note });
     } catch (e) {
     }
-    addLogLine(`<strong>Done: ${added} added, ${existedRels} already existed, ${skipped} skipped, ${failed} failed</strong>`);
+    log.line(`<strong>Done: ${added} added, ${existedRels} already existed, ${skipped} skipped, ${failed} failed</strong>`);
   }
 
   // src/ui-bar.js
@@ -3789,7 +3794,7 @@
       editNote.split("\n").forEach((line) => {
         if (!line.trim()) return;
         const html = line.replace(/(https?:\/\/[^\s]+)/g, '<a href="$1" target="_blank" rel="noopener noreferrer nofollow">$1</a>');
-        addLogLine(html);
+        log.line(html);
       });
       runImport(discogsUrl2, tracklistCb.checked, applyTracksCb.checked, createWorksCb.checked).finally(() => {
         importBtn.disabled = false;
@@ -3863,7 +3868,7 @@
         li.querySelector("details").appendChild(pre);
         _logs2.appendChild(li);
       }
-      addLogLine(`Found ${json.companies.length + artistRoles.length} release relationships`);
+      log.line(`Found ${json.companies.length + artistRoles.length} release relationships`);
       artistRoles = artistRoles.concat(convertPotentialDJMixers(json));
       let tracklistRels = [];
       if (processTracklist) {
@@ -3898,7 +3903,7 @@
             }, [])
           );
         }
-        addLogLine(`Found ${tracklistRels.length} tracklist relationships`);
+        log.line(`Found ${tracklistRels.length} tracklist relationships`);
       }
       const allArtistRoles = artistRoles.concat(tracklistRels);
       const uniqueArtists = [];

--- a/userscripts/discogs_credits/src/api-mb.js
+++ b/userscripts/discogs_credits/src/api-mb.js
@@ -183,7 +183,7 @@ export function resolveLinkTypeId(name, type0, type1) {
         contains.sort((a, b) => ((a.name || '').length || 999) - ((b.name || '').length || 999));
         const best = contains[0];
         if ((best.name || '').toLowerCase() !== needle) {
-            log.line(`Fuzzy match: "${name}" → "${best.name}" (${type0}→${type1})`);
+            log.info(`Fuzzy match: "${name}" → "${best.name}" (${type0}→${type1})`);
         }
         return best.id;
     }

--- a/userscripts/discogs_credits/src/api-mb.js
+++ b/userscripts/discogs_credits/src/api-mb.js
@@ -4,7 +4,7 @@
 // rate-limit handling lives in one place.
 
 import { pageWindow } from './constants.js';
-import { addLogLine } from './log.js';
+import { log }        from './log.js';
 
 /**
  * Fetch a full MB entity from the internal `/ws/js/entity/{mbid}` endpoint.
@@ -150,7 +150,7 @@ export function getDiscogsUrlForRelease(mbid) {
  */
 export function resolveLinkTypeId(name, type0, type1) {
     const lt = pageWindow.MB?.linkedEntities?.link_type;
-    if (!lt) { addLogLine('<span style="color:red">ERR MB.linkedEntities.link_type not available</span>'); return null; }
+    if (!lt) { log.error('MB.linkedEntities.link_type not available'); return null; }
     const needle = name.toLowerCase().trim();
     // Strip MB's curly-brace attribute placeholders, e.g. "{additional} orchestra"
     // → "orchestra" so a Discogs role "orchestra" matches.
@@ -183,7 +183,7 @@ export function resolveLinkTypeId(name, type0, type1) {
         contains.sort((a, b) => ((a.name || '').length || 999) - ((b.name || '').length || 999));
         const best = contains[0];
         if ((best.name || '').toLowerCase() !== needle) {
-            addLogLine(`Fuzzy match: "${name}" → "${best.name}" (${type0}→${type1})`);
+            log.line(`Fuzzy match: "${name}" → "${best.name}" (${type0}→${type1})`);
         }
         return best.id;
     }
@@ -204,12 +204,12 @@ export function resolveLinkTypeId(name, type0, type1) {
         // block the commit. Log as ERR (red) since this is a hard refusal,
         // not a warning the user might safely override.
         const altPairs = [...new Set(allByName.filter(v => !v.deprecated).map(v => `${v.type0}→${v.type1}`))].join(', ');
-        addLogLine(`<span style="color:red">ERR "${name}" (${type0}→${type1}) is deprecated by MB and would block the commit — skipping${altPairs ? `. Valid alternative(s): ${altPairs}` : ''}.</span>`);
+        log.error(`"${name}" (${type0}→${type1}) is deprecated by MB and would block the commit — skipping${altPairs ? `. Valid alternative(s): ${altPairs}` : ''}.`);
     } else if (wrongPairHits.length > 0) {
         const hitDesc = wrongPairHits.map(v => `${v.name}(${v.type0}→${v.type1})`).join(', ');
-        addLogLine(`<span style="color:orange">WARN No "${name}" link type for (${type0}→${type1}) — exists for other entity pairs: ${hitDesc} — skipping</span>`);
+        log.warn(`No "${name}" link type for (${type0}→${type1}) — exists for other entity pairs: ${hitDesc} — skipping`);
     } else {
-        addLogLine(`<span style="color:orange">WARN Unknown link type "${name}" (${type0}→${type1}). Available for this pair: ${availableNames || 'none'}</span>`);
+        log.warn(`Unknown link type "${name}" (${type0}→${type1}). Available for this pair: ${availableNames || 'none'}`);
     }
     return null;
 }

--- a/userscripts/discogs_credits/src/dispatch.js
+++ b/userscripts/discogs_credits/src/dispatch.js
@@ -4,7 +4,7 @@
 // track-level artist credits, and the work-level credits — with
 // deduplication against this session and against MB's existing rels.
 
-import { addLogLine }                  from './log.js';
+import { log }                  from './log.js';
 import { pageWindow }                   from './constants.js';
 import { db }                            from './storage.js';
 import { parseDiscogsUrl }               from './api-discogs.js';
@@ -61,7 +61,7 @@ export async function instantFillRelationships(companies, artistRoles, tracklist
         // NOT 'mastering' — MB deprecated artist→recording mastering (link type 136).
     ]);
 
-    addLogLine(`Starting instant fill: ${companies.length} companies, ${artistRoles.length} release artist roles, ${tracklistRels.length} tracklist roles`);
+    log.line(`Starting instant fill: ${companies.length} companies, ${artistRoles.length} release artist roles, ${tracklistRels.length} tracklist roles`);
 
     const bar = document.querySelector('.discogs-bar');
     function tickProgress() {
@@ -124,21 +124,21 @@ export async function instantFillRelationships(companies, artistRoles, tracklist
                 trackIndex++;
             }
         }
-        addLogLine(`Found ${trackCount} track(s) in editor state (${recordingByGid.size} with GID, ${recordingByPosition.size} position entries: ${[...recordingByPosition.keys()].join(',')}). relatedWorks: ${editorWorkByRecGid.size} pre-linked`)
+        log.line(`Found ${trackCount} track(s) in editor state (${recordingByGid.size} with GID, ${recordingByPosition.size} position entries: ${[...recordingByPosition.keys()].join(',')}). relatedWorks: ${editorWorkByRecGid.size} pre-linked`)
     } catch(e) {
-        addLogLine(`<span style="color:orange">WARN Iterating MB state: ${e.message}</span>`);
+        log.warn(`Iterating MB state: ${e.message}`);
     }
 
     // ── Fetch position→GID map from WS2 (authoritative, always correct) ──────
     const positionToGid = new Map(); // "1" / "A1" → recording GID
     try {
         const relMbid = releaseEntity.gid;
-        addLogLine(`WS2: fetching recordings for release ${relMbid}…`);
+        log.line(`WS2: fetching recordings for release ${relMbid}…`);
         const wsJson = await fetchWithRetry(`/ws/2/release/${relMbid}?inc=recordings&fmt=json`);
-        addLogLine(`WS2: response received`);
+        log.line(`WS2: response received`);
         if (wsJson) {
             const mediaCount = wsJson.media?.length ?? 0;
-            addLogLine(`WS2: ${mediaCount} medium/media in response`);
+            log.line(`WS2: ${mediaCount} medium/media in response`);
             const mediaArr = wsJson.media || [];
             const isMultiMedium = mediaArr.length > 1;
             for (const medium of mediaArr) {
@@ -160,10 +160,10 @@ export async function instantFillRelationships(companies, artistRoles, tracklist
                     }
                 }
             }
-            addLogLine(`WS2 position map: ${positionToGid.size} entries (${[...positionToGid.keys()].sort().join(', ')})`);
+            log.line(`WS2 position map: ${positionToGid.size} entries (${[...positionToGid.keys()].sort().join(', ')})`);
         }
     } catch(e) {
-        addLogLine(`<span style="color:orange">WARN WS2 recording fetch failed: ${e.message} — using editor state positions only</span>`);
+        log.warn(`WS2 recording fetch failed: ${e.message} — using editor state positions only`);
     }
 
     // ── Helper: get recording entity for a Discogs track ─────────────────────
@@ -231,7 +231,7 @@ export async function instantFillRelationships(companies, artistRoles, tracklist
             if (gid) {
                 const rec = recordingByGid.get(gid);
                 if (rec) return rec;
-                addLogLine(`<span style="color:orange">WARN Recording ${gid} for track ${track.position} not in editor state</span>`);
+                log.warn(`Recording ${gid} for track ${track.position} not in editor state`);
                 return null;
             }
         }
@@ -244,7 +244,7 @@ export async function instantFillRelationships(companies, artistRoles, tracklist
         if (trackCount > 0) {
             const ws2Keys   = positionToGid.size    ? [...positionToGid.keys()].join(', ')    : '(empty)';
             const stateKeys = recordingByPosition.size ? [...recordingByPosition.keys()].join(', ') : '(empty)';
-            addLogLine(`<span style="color:orange">WARN No recording for track ${track.position} "${track.title}". WS2 keys: ${ws2Keys} | State keys: ${stateKeys}</span>`);
+            log.warn(`No recording for track ${track.position} "${track.title}". WS2 keys: ${ws2Keys} | State keys: ${stateKeys}`);
         }
         return null;
     }
@@ -292,7 +292,7 @@ export async function instantFillRelationships(companies, artistRoles, tracklist
     // ── Helper: process one relationship ─────────────────────────────────────
     async function processOne(sourceEntity, entityType0, entityType1, linkTypeName, mbUrl, rawAttributes, credit, trackPos) {
         const mbid = mbUrl.replace(/.*\//, '').replace(/[^a-f0-9-]/gi, '').substring(0, 36);
-        if (!mbid) { addLogLine(`<span style="color:red">ERR Bad MBID URL: ${mbUrl}</span>`); failed++; return; }
+        if (!mbid) { log.error(`Bad MBID URL: ${mbUrl}`); failed++; return; }
 
         const linkTypeID = resolveLinkTypeId(linkTypeName, entityType0, entityType1);
         if (!linkTypeID) {
@@ -314,7 +314,7 @@ export async function instantFillRelationships(companies, artistRoles, tracklist
         try {
             targetEntity = await fetchMBEntity(mbid);
         } catch(e) {
-            addLogLine(`<span style="color:red">ERR Entity fetch failed for ${mbid}: ${e.message}</span>`);
+            log.error(`Entity fetch failed for ${mbid}: ${e.message}`);
             failed++; return;
         }
 
@@ -347,7 +347,7 @@ export async function instantFillRelationships(companies, artistRoles, tracklist
             if (reResolved) {
                 resolvedLinkTypeID = reResolved;
             } else {
-                addLogLine(`<span style="color:orange">WARN Entity "${targetEntity.name}" is a ${targetEntity.entityType} but expected ${entityType0}/${entityType1} — link type "${linkTypeName}" may not apply</span>`);
+                log.warn(`Entity "${targetEntity.name}" is a ${targetEntity.entityType} but expected ${entityType0}/${entityType1} — link type "${linkTypeName}" may not apply`);
             }
         }
 
@@ -375,7 +375,7 @@ export async function instantFillRelationships(companies, artistRoles, tracklist
             // MB only supports certain link types per entity type combination.
             // All place-mapped link types are place-only and cannot be used with labels.
             if (details.entityType === 'place' && resolvedEt === 'label') {
-                addLogLine(`<span style="color:orange">WARN Skipped ${company.name}: MB has no "${details.linkType}" relationship for labels (only places). Add manually if needed.</span>`);
+                log.warn(`Skipped ${company.name}: MB has no "${details.linkType}" relationship for labels (only places). Add manually if needed.`);
                 skipped++; tickProgress(); continue;
             }
         }
@@ -386,7 +386,7 @@ export async function instantFillRelationships(companies, artistRoles, tracklist
         let mbUrl;
         try { mbUrl = await getMbidForEntity(company, resolvedEt); }
         catch(e) {
-            addLogLine(`<span style="color:orange">WARN Skipped ${company.name} — not resolved in review</span>`);
+            log.warn(`Skipped ${company.name} — not resolved in review`);
             skipped++; tickProgress(); continue;
         }
         const et = resolvedEt;
@@ -414,14 +414,14 @@ export async function instantFillRelationships(companies, artistRoles, tracklist
         }
         if (!mbUrl && !role.artist.resource_url) {
             // No Discogs page, not in confirmedMap — skip with clear message
-            addLogLine(`<span style="color:orange">WARN Skipped ${role.artist.name} (${role.linkType}) — no Discogs page, not confirmed in review</span>`);
+            log.warn(`Skipped ${role.artist.name} (${role.linkType}) — no Discogs page, not confirmed in review`);
             skipped++; tickProgress(); continue;
         }
         if (!mbUrl) {
             // See bug #8 — no network fallback; unresolved = skip immediately.
             try { mbUrl = await getMbidForEntity(role.artist, 'artist'); }
             catch(e) {
-                addLogLine(`<span style="color:orange">WARN Skipped ${role.artist.name} — not resolved in review (${role.linkType})</span>`);
+                log.warn(`Skipped ${role.artist.name} — not resolved in review (${role.linkType})`);
                 skipped++; tickProgress(); continue;
             }
         }
@@ -435,13 +435,13 @@ export async function instantFillRelationships(companies, artistRoles, tracklist
         // Exclude work-only roles — those go to works via the works section below
         const applicable = artistRoles.filter(role => RECORDING_LINK_TYPES.has(role.linkType) && !WORK_ONLY_ARTIST_RELS.includes(role.linkType));
         if (applicable.length > 0) {
-            addLogLine(`Applying ${applicable.length} release credit(s) to ${recordingByGid.size} recording(s)…`);
+            log.line(`Applying ${applicable.length} release credit(s) to ${recordingByGid.size} recording(s)…`);
             for (const role of applicable) {
                 let mbUrl;
                 // See bug #8 — no network fallback.
                 try { mbUrl = await getMbidForEntity(role.artist, 'artist'); }
                 catch(e) {
-                    addLogLine(`<span style="color:orange">WARN Skipped ${role.artist.name} (${role.linkType}) in applyToTracks — not resolved in review</span>`);
+                    log.warn(`Skipped ${role.artist.name} (${role.linkType}) in applyToTracks — not resolved in review`);
                     continue;
                 }
                 const credit = role.artist.anv?.trim() || role.artist.name;
@@ -462,7 +462,7 @@ export async function instantFillRelationships(companies, artistRoles, tracklist
         if (!WORK_ONLY_ARTIST_RELS.includes(role.linkType)) continue;
         const recEntity = getRecordingEntity(role.track);
         if (!recEntity) {
-            addLogLine(`<span style="color:red">ERR Work-only rel for track ${role.track.position} "${role.track.title}" — no recording found, skipped</span>`);
+            log.error(`Work-only rel for track ${role.track.position} "${role.track.title}" — no recording found, skipped`);
             failed++;
             continue;
         }
@@ -494,13 +494,13 @@ export async function instantFillRelationships(companies, artistRoles, tracklist
 
     if (workOnlyByGid.size > 0) {
         if (!recordingOfLinkTypeId) {
-            addLogLine('<span style="color:red">ERR Could not resolve "performance" link type — work processing skipped</span>');
+            log.error('Could not resolve "performance" link type — work processing skipped');
         } else {
-            addLogLine(`Processing work relationships for ${workOnlyByGid.size} recording(s)…`);
+            log.line(`Processing work relationships for ${workOnlyByGid.size} recording(s)…`);
 
             // Use editor state relatedWorks (built during recording map phase above) — no extra fetch needed
             const existingWorkByRecGid = editorWorkByRecGid;
-            addLogLine(`Editor state: ${existingWorkByRecGid.size} recording(s) already have a linked work`);
+            log.line(`Editor state: ${existingWorkByRecGid.size} recording(s) already have a linked work`);
 
             // Check editor state only for relationships dispatched in THIS session
             function getWorkFromEditorState(recEntity) {
@@ -529,7 +529,7 @@ export async function instantFillRelationships(companies, artistRoles, tracklist
                 if (hasExistingWork) {
                     workEntity = editorWorkByRecGid.get(recGid);
                     const wid = workEntity.gid || workEntity.id;
-                    addLogLine(`Track ${trackPos} "${trackTitle}": work already linked (${workEntity.name || wid || 'existing'}) — skipping creation`);
+                    log.line(`Track ${trackPos} "${trackTitle}": work already linked (${workEntity.name || wid || 'existing'}) — skipping creation`);
                     if (!workEntity.gid && !workEntity.id) continue; // can't use this entity
                 }
 
@@ -541,7 +541,7 @@ export async function instantFillRelationships(companies, artistRoles, tracklist
                     if (!createWorks) {
                         // Log as error — work-only rels cannot be applied without a work
                         for (const { role } of entries) {
-                            addLogLine(`<span style="color:red">ERR Track ${trackPos} "${trackTitle}": no work exists for ${role.linkType} (${role.artist.name}) — enable "Create missing works" or add work manually</span>`);
+                            log.error(`Track ${trackPos} "${trackTitle}": no work exists for ${role.linkType} (${role.artist.name}) — enable "Create missing works" or add work manually`);
                             failed++;
                         }
                         continue;
@@ -597,7 +597,7 @@ export async function instantFillRelationships(companies, artistRoles, tracklist
                             linkTypeID: recordingOfLinkTypeId,
                         },
                     });
-                    addLogLine(`Track ${trackPos} "${trackTitle}": created new work "${trackTitle}"`);
+                    log.line(`Track ${trackPos} "${trackTitle}": created new work "${trackTitle}"`);
                     added++;
                     tickProgress();
                     // Re-read from editor state so subsequent artist→work dispatches see the live entity
@@ -610,7 +610,7 @@ export async function instantFillRelationships(companies, artistRoles, tracklist
                     // See bug #8 — no network fallback.
                     try { mbUrl = await getMbidForEntity(role.artist, 'artist'); }
                     catch(e) {
-                        addLogLine(`<span style="color:orange">WARN Skipped ${role.artist.name} — not resolved in review (${role.linkType})</span>`);
+                        log.warn(`Skipped ${role.artist.name} — not resolved in review (${role.linkType})`);
                         continue;
                     }
                     const credit = role.artist.anv?.trim() || role.artist.name;
@@ -626,7 +626,7 @@ export async function instantFillRelationships(companies, artistRoles, tracklist
                                 dispatchRelationship(re, workEntity, artistEntity, linkTypeID, credit, buildAttributes(role.attributes || []));
                                 added++;
                             } catch(e) {
-                                addLogLine(`<span style="color:red">ERR Failed to add ${role.linkType} for new work: ${e.message}</span>`);
+                                log.error(`Failed to add ${role.linkType} for new work: ${e.message}`);
                             }
                         }
                     }
@@ -649,21 +649,21 @@ export async function instantFillRelationships(companies, artistRoles, tracklist
             }
         }
         if (!mbUrl && !role.artist.resource_url) {
-            addLogLine(`<span style="color:orange">WARN Skipped ${role.artist.name} on track ${role.track.position} — no Discogs page, not confirmed</span>`);
+            log.warn(`Skipped ${role.artist.name} on track ${role.track.position} — no Discogs page, not confirmed`);
             continue;
         }
         if (!mbUrl) {
             // See bug #8 — no network fallback.
             try { mbUrl = await getMbidForEntity(role.artist, 'artist'); }
             catch(e) {
-                addLogLine(`<span style="color:orange">WARN Skipped ${role.artist.name} on track ${role.track.position} — not resolved in review</span>`);
+                log.warn(`Skipped ${role.artist.name} on track ${role.track.position} — not resolved in review`);
                 continue;
             }
         }
 
         const recEntity = getRecordingEntity(role.track);
         if (!recEntity) {
-            addLogLine(`<span style="color:orange">WARN No recording found for track ${role.track.position} "${role.track.title}" — skipped</span>`);
+            log.warn(`No recording found for track ${role.track.position} "${role.track.title}" — skipped`);
             failed++; continue;
         }
 
@@ -672,7 +672,7 @@ export async function instantFillRelationships(companies, artistRoles, tracklist
         const trackRelKey = `${role.track.position}|${role.linkType}|${mbUrl}|${attrKey}`;
         if (seenTrackRels.has(trackRelKey)) continue;
         seenTrackRels.add(trackRelKey);
-        addLogLine(`Track ${role.track.position} "${role.track.title}": adding <strong>${role.linkType}</strong> — ${credit}`);
+        log.line(`Track ${role.track.position} "${role.track.title}": adding <strong>${role.linkType}</strong> — ${credit}`);
         await processOne(recEntity, 'artist', 'recording', role.linkType, mbUrl, role.attributes || [], credit, role.track.position);
         tickProgress();
     }
@@ -688,5 +688,5 @@ export async function instantFillRelationships(companies, artistRoles, tracklist
         re.dispatch({ type: 'update-edit-note', editNote: note });
     } catch(e) { /* ignore */ }
 
-    addLogLine(`<strong>Done: ${added} added, ${existedRels} already existed, ${skipped} skipped, ${failed} failed</strong>`);
+    log.line(`<strong>Done: ${added} added, ${existedRels} already existed, ${skipped} skipped, ${failed} failed</strong>`);
 }

--- a/userscripts/discogs_credits/src/dispatch.js
+++ b/userscripts/discogs_credits/src/dispatch.js
@@ -61,7 +61,7 @@ export async function instantFillRelationships(companies, artistRoles, tracklist
         // NOT 'mastering' — MB deprecated artist→recording mastering (link type 136).
     ]);
 
-    log.line(`Starting instant fill: ${companies.length} companies, ${artistRoles.length} release artist roles, ${tracklistRels.length} tracklist roles`);
+    log.info(`Starting instant fill: ${companies.length} companies, ${artistRoles.length} release artist roles, ${tracklistRels.length} tracklist roles`);
 
     const bar = document.querySelector('.discogs-bar');
     function tickProgress() {
@@ -124,7 +124,7 @@ export async function instantFillRelationships(companies, artistRoles, tracklist
                 trackIndex++;
             }
         }
-        log.line(`Found ${trackCount} track(s) in editor state (${recordingByGid.size} with GID, ${recordingByPosition.size} position entries: ${[...recordingByPosition.keys()].join(',')}). relatedWorks: ${editorWorkByRecGid.size} pre-linked`)
+        log.info(`Found ${trackCount} track(s) in editor state (${recordingByGid.size} with GID, ${recordingByPosition.size} position entries: ${[...recordingByPosition.keys()].join(',')}). relatedWorks: ${editorWorkByRecGid.size} pre-linked`)
     } catch(e) {
         log.warn(`Iterating MB state: ${e.message}`);
     }
@@ -133,12 +133,12 @@ export async function instantFillRelationships(companies, artistRoles, tracklist
     const positionToGid = new Map(); // "1" / "A1" → recording GID
     try {
         const relMbid = releaseEntity.gid;
-        log.line(`WS2: fetching recordings for release ${relMbid}…`);
+        log.info(`WS2: fetching recordings for release ${relMbid}…`);
         const wsJson = await fetchWithRetry(`/ws/2/release/${relMbid}?inc=recordings&fmt=json`);
-        log.line(`WS2: response received`);
+        log.info(`WS2: response received`);
         if (wsJson) {
             const mediaCount = wsJson.media?.length ?? 0;
-            log.line(`WS2: ${mediaCount} medium/media in response`);
+            log.info(`WS2: ${mediaCount} medium/media in response`);
             const mediaArr = wsJson.media || [];
             const isMultiMedium = mediaArr.length > 1;
             for (const medium of mediaArr) {
@@ -160,7 +160,7 @@ export async function instantFillRelationships(companies, artistRoles, tracklist
                     }
                 }
             }
-            log.line(`WS2 position map: ${positionToGid.size} entries (${[...positionToGid.keys()].sort().join(', ')})`);
+            log.info(`WS2 position map: ${positionToGid.size} entries (${[...positionToGid.keys()].sort().join(', ')})`);
         }
     } catch(e) {
         log.warn(`WS2 recording fetch failed: ${e.message} — using editor state positions only`);
@@ -435,7 +435,7 @@ export async function instantFillRelationships(companies, artistRoles, tracklist
         // Exclude work-only roles — those go to works via the works section below
         const applicable = artistRoles.filter(role => RECORDING_LINK_TYPES.has(role.linkType) && !WORK_ONLY_ARTIST_RELS.includes(role.linkType));
         if (applicable.length > 0) {
-            log.line(`Applying ${applicable.length} release credit(s) to ${recordingByGid.size} recording(s)…`);
+            log.info(`Applying ${applicable.length} release credit(s) to ${recordingByGid.size} recording(s)…`);
             for (const role of applicable) {
                 let mbUrl;
                 // See bug #8 — no network fallback.
@@ -496,11 +496,11 @@ export async function instantFillRelationships(companies, artistRoles, tracklist
         if (!recordingOfLinkTypeId) {
             log.error('Could not resolve "performance" link type — work processing skipped');
         } else {
-            log.line(`Processing work relationships for ${workOnlyByGid.size} recording(s)…`);
+            log.info(`Processing work relationships for ${workOnlyByGid.size} recording(s)…`);
 
             // Use editor state relatedWorks (built during recording map phase above) — no extra fetch needed
             const existingWorkByRecGid = editorWorkByRecGid;
-            log.line(`Editor state: ${existingWorkByRecGid.size} recording(s) already have a linked work`);
+            log.info(`Editor state: ${existingWorkByRecGid.size} recording(s) already have a linked work`);
 
             // Check editor state only for relationships dispatched in THIS session
             function getWorkFromEditorState(recEntity) {
@@ -529,7 +529,7 @@ export async function instantFillRelationships(companies, artistRoles, tracklist
                 if (hasExistingWork) {
                     workEntity = editorWorkByRecGid.get(recGid);
                     const wid = workEntity.gid || workEntity.id;
-                    log.line(`Track ${trackPos} "${trackTitle}": work already linked (${workEntity.name || wid || 'existing'}) — skipping creation`);
+                    log.info(`Track ${trackPos} "${trackTitle}": work already linked (${workEntity.name || wid || 'existing'}) — skipping creation`);
                     if (!workEntity.gid && !workEntity.id) continue; // can't use this entity
                 }
 
@@ -597,7 +597,7 @@ export async function instantFillRelationships(companies, artistRoles, tracklist
                             linkTypeID: recordingOfLinkTypeId,
                         },
                     });
-                    log.line(`Track ${trackPos} "${trackTitle}": created new work "${trackTitle}"`);
+                    log.info(`Track ${trackPos} "${trackTitle}": created new work "${trackTitle}"`);
                     added++;
                     tickProgress();
                     // Re-read from editor state so subsequent artist→work dispatches see the live entity
@@ -672,7 +672,7 @@ export async function instantFillRelationships(companies, artistRoles, tracklist
         const trackRelKey = `${role.track.position}|${role.linkType}|${mbUrl}|${attrKey}`;
         if (seenTrackRels.has(trackRelKey)) continue;
         seenTrackRels.add(trackRelKey);
-        log.line(`Track ${role.track.position} "${role.track.title}": adding <strong>${role.linkType}</strong> — ${credit}`);
+        log.info(`Track ${role.track.position} "${role.track.title}": adding <strong>${role.linkType}</strong> — ${credit}`);
         await processOne(recEntity, 'artist', 'recording', role.linkType, mbUrl, role.attributes || [], credit, role.track.position);
         tickProgress();
     }
@@ -688,5 +688,5 @@ export async function instantFillRelationships(companies, artistRoles, tracklist
         re.dispatch({ type: 'update-edit-note', editNote: note });
     } catch(e) { /* ignore */ }
 
-    log.line(`<strong>Done: ${added} added, ${existedRels} already existed, ${skipped} skipped, ${failed} failed</strong>`);
+    log.info(`<strong>Done: ${added} added, ${existedRels} already existed, ${skipped} skipped, ${failed} failed</strong>`);
 }

--- a/userscripts/discogs_credits/src/editor-state.js
+++ b/userscripts/discogs_credits/src/editor-state.js
@@ -11,21 +11,21 @@ import { log }               from './log.js';
 
 /** Poll for MB.relationshipEditor.state.entity with verbose log feedback. */
 export async function waitForMBEditor(timeoutMs = 15000) {
-    log.line('Waiting for MB relationship editor…');
+    log.info('Waiting for MB relationship editor…');
     let waited = 0;
     while (waited < timeoutMs) {
         const MB = pageWindow.MB;
         const re = MB?.relationshipEditor;
         const st = re?.state;
         if (st?.entity) {
-            log.line(`Editor ready (${waited}ms). Release: "${st.entity.name}"`);
+            log.info(`Editor ready (${waited}ms). Release: "${st.entity.name}"`);
             return re;
         }
         if (waited % 2000 === 0 && waited > 0) {
             const mbKeys = MB ? Object.keys(MB).join(', ') : 'undefined';
             const reKeys = re ? Object.keys(re).join(', ') : 'undefined';
             const stKeys = st ? Object.keys(st).join(', ') : 'undefined';
-            log.line(`[${waited}ms] MB={${mbKeys}} re={${reKeys}} state={${stKeys}}`);
+            log.info(`[${waited}ms] MB={${mbKeys}} re={${reKeys}} state={${stKeys}}`);
         }
         await new Promise(r => setTimeout(r, 200));
         waited += 200;
@@ -65,7 +65,7 @@ export function dispatchRelationship(re, sourceEntity, targetEntity, linkTypeID,
         } catch(e) {}
     }
     const posLabel = (trackPos != null && trackPos !== '') ? ` <span style="color:#888;font-size:0.85em">#${trackPos}</span>` : '';
-    log.line(`→ <strong>${ltName}</strong>${attrDesc}${posLabel}: ${sourceEntity.name || sourceEntity.gid} ↔ ${targetEntity.name || targetEntity.gid}${credit && credit !== (targetEntity.name || targetEntity.gid) ? ` (credited: ${credit})` : ''}`);
+    log.info(`→ <strong>${ltName}</strong>${attrDesc}${posLabel}: ${sourceEntity.name || sourceEntity.gid} ↔ ${targetEntity.name || targetEntity.gid}${credit && credit !== (targetEntity.name || targetEntity.gid) ? ` (credited: ${credit})` : ''}`);
     re.dispatch({
         type: 'update-relationship-state',
         sourceEntity,

--- a/userscripts/discogs_credits/src/editor-state.js
+++ b/userscripts/discogs_credits/src/editor-state.js
@@ -7,30 +7,30 @@
 //     into MB's internal ImmutableTree shape via `MB.tree.fromDistinctAscArray`.
 
 import { pageWindow, REL_TEMPLATE } from './constants.js';
-import { addLogLine }               from './log.js';
+import { log }               from './log.js';
 
 /** Poll for MB.relationshipEditor.state.entity with verbose log feedback. */
 export async function waitForMBEditor(timeoutMs = 15000) {
-    addLogLine('Waiting for MB relationship editor…');
+    log.line('Waiting for MB relationship editor…');
     let waited = 0;
     while (waited < timeoutMs) {
         const MB = pageWindow.MB;
         const re = MB?.relationshipEditor;
         const st = re?.state;
         if (st?.entity) {
-            addLogLine(`Editor ready (${waited}ms). Release: "${st.entity.name}"`);
+            log.line(`Editor ready (${waited}ms). Release: "${st.entity.name}"`);
             return re;
         }
         if (waited % 2000 === 0 && waited > 0) {
             const mbKeys = MB ? Object.keys(MB).join(', ') : 'undefined';
             const reKeys = re ? Object.keys(re).join(', ') : 'undefined';
             const stKeys = st ? Object.keys(st).join(', ') : 'undefined';
-            addLogLine(`[${waited}ms] MB={${mbKeys}} re={${reKeys}} state={${stKeys}}`);
+            log.line(`[${waited}ms] MB={${mbKeys}} re={${reKeys}} state={${stKeys}}`);
         }
         await new Promise(r => setTimeout(r, 200));
         waited += 200;
     }
-    addLogLine('<span style="color:red">ERR MB editor not ready after 15s — aborting</span>');
+    log.error('MB editor not ready after 15s — aborting');
     return null;
 }
 
@@ -65,7 +65,7 @@ export function dispatchRelationship(re, sourceEntity, targetEntity, linkTypeID,
         } catch(e) {}
     }
     const posLabel = (trackPos != null && trackPos !== '') ? ` <span style="color:#888;font-size:0.85em">#${trackPos}</span>` : '';
-    addLogLine(`→ <strong>${ltName}</strong>${attrDesc}${posLabel}: ${sourceEntity.name || sourceEntity.gid} ↔ ${targetEntity.name || targetEntity.gid}${credit && credit !== (targetEntity.name || targetEntity.gid) ? ` (credited: ${credit})` : ''}`);
+    log.line(`→ <strong>${ltName}</strong>${attrDesc}${posLabel}: ${sourceEntity.name || sourceEntity.gid} ↔ ${targetEntity.name || targetEntity.gid}${credit && credit !== (targetEntity.name || targetEntity.gid) ? ` (credited: ${credit})` : ''}`);
     re.dispatch({
         type: 'update-relationship-state',
         sourceEntity,
@@ -126,7 +126,7 @@ export function buildAttributes(rawAttributes) {
                 if (vl.includes(lower) || lower.includes(vl)) return v;
             }
         }
-        addLogLine(`<span style="color:orange">WARN Attribute "${name}" not found in MB — dropping attribute but keeping the rel</span>`);
+        log.warn(`Attribute "${name}" not found in MB — dropping attribute but keeping the rel`);
         return null;
     }
 
@@ -170,7 +170,7 @@ export function buildAttributes(rawAttributes) {
     try {
         return tree.fromDistinctAscArray(attrObjs);
     } catch(e) {
-        addLogLine(`<span style="color:orange">WARN Attribute tree build failed (${e.message}) — importing without attributes</span>`);
+        log.warn(`Attribute tree build failed (${e.message}) — importing without attributes`);
         return null;
     }
 }

--- a/userscripts/discogs_credits/src/log.js
+++ b/userscripts/discogs_credits/src/log.js
@@ -1,11 +1,20 @@
 // Userscript-side logger. Renders one `<li>` per call into the `<ul>` the
 // UI bar creates, and pipes a plain-text summary into the progress ticker.
 //
-// The log container is set lazily via `setLogContainer(el)` because the
-// `<ul>` is constructed inside the UI bar's insertion routine. Until then,
-// `addLogLine` is a silent no-op rather than throwing (pre-UI-bar callers
-// would crash today; they shouldn't, but if any slip through they now fail
-// quietly rather than blowing up the whole import).
+// Public API:
+//
+//   log.line(msg)   plain line
+//   log.warn(msg)   orange "WARN <msg>"
+//   log.error(msg)  red "ERR <msg>"
+//
+// Callers pass plain text; the logger handles colouring and severity
+// prefixing. Severity is at the call site, not encoded into the message
+// string — `log.warn('Attribute "co" not found')` instead of
+// `addLogLine('<span style="color:orange">WARN Attribute "co" not found</span>')`.
+//
+// Module init order: the log container (a `<ul>`) is created inside the
+// UI bar's mount routine, so calls made before `setLogContainer(el)` is
+// invoked silently no-op (pre-UI-bar callers would otherwise crash here).
 
 let _logs = null;
 
@@ -19,16 +28,7 @@ export function getLogContainer() {
     return _logs;
 }
 
-/**
- * Append a log line. `message` is interpreted as HTML (legacy — many callers
- * embed `<span style="color:...">` for severity colouring). Prepended with
- * a muted-monospace `HH:MM:SS` timestamp.
- *
- * Also pipes a plain-text version of the message into the progress ticker
- * span (`.discogs-bar`'s `_setProgress`) so the UI bar status line shows
- * the most-recent log content.
- */
-export function addLogLine(message) {
+function _emit(html, plainText) {
     if (!_logs) return;
     const li = document.createElement('li');
     // HH:MM:SS prefix so per-step timings are visible. Styled muted/monospace so
@@ -39,11 +39,42 @@ export function addLogLine(message) {
     // Real space character after the timestamp span — `margin-right` on the span
     // renders fine in the browser but disappears when log content is copied as
     // text (CSS spacing isn't part of textContent).
-    li.innerHTML = `<span style="color:#999;font-family:ui-monospace,Menlo,Consolas,monospace;font-size:0.82em;">${stamp}</span> ${message}`;
+    li.innerHTML = `<span style="color:#999;font-family:ui-monospace,Menlo,Consolas,monospace;font-size:0.82em;">${stamp}</span> ${html}`;
     _logs.insertAdjacentElement('beforeend', li);
     // Feed progress ticker (strip HTML tags for plain-text display)
     const bar = document.querySelector('.discogs-bar');
     if (bar?._setProgress) {
-        bar._setProgress(null, message.replace(/<[^>]*>/g, '').trim().substring(0, 120));
+        bar._setProgress(null, plainText.replace(/<[^>]*>/g, '').trim().substring(0, 120));
     }
+}
+
+/**
+ * Severity-aware logger. Each method appends one styled `<li>` to the
+ * shared log container plus pipes a plain-text summary into the
+ * progress ticker.
+ *
+ *   - `log.line(msg)`   plain (no prefix, no colour).
+ *   - `log.warn(msg)`   orange `WARN ${msg}`.
+ *   - `log.error(msg)`  red `ERR ${msg}`.
+ *
+ * `msg` may contain inline HTML (callers sometimes embed `<a>` links or
+ * `<strong>`) — only the severity prefix and colour wrapper are added
+ * by the logger.
+ */
+export const log = {
+    line:  msg => _emit(msg, msg),
+    warn:  msg => _emit(`<span style="color:orange">WARN ${msg}</span>`, `WARN ${msg}`),
+    error: msg => _emit(`<span style="color:red">ERR ${msg}</span>`,     `ERR ${msg}`),
+};
+
+/**
+ * @deprecated  Use `log.line` / `log.warn` / `log.error` instead.
+ *
+ * Old API where severity was encoded into the message string as inline
+ * HTML (`<span style="color:orange">WARN ...</span>`). New callers
+ * should use the severity-aware methods; existing callers will be
+ * migrated incrementally and this re-export removed afterwards.
+ */
+export function addLogLine(message) {
+    _emit(message, message);
 }

--- a/userscripts/discogs_credits/src/log.js
+++ b/userscripts/discogs_credits/src/log.js
@@ -3,7 +3,7 @@
 //
 // Public API:
 //
-//   log.line(msg)   plain line
+//   log.info(msg)   plain line
 //   log.warn(msg)   orange "WARN <msg>"
 //   log.error(msg)  red "ERR <msg>"
 //
@@ -53,7 +53,7 @@ function _emit(html, plainText) {
  * shared log container plus pipes a plain-text summary into the
  * progress ticker.
  *
- *   - `log.line(msg)`   plain (no prefix, no colour).
+ *   - `log.info(msg)`   plain (no prefix, no colour).
  *   - `log.warn(msg)`   orange `WARN ${msg}`.
  *   - `log.error(msg)`  red `ERR ${msg}`.
  *
@@ -62,13 +62,13 @@ function _emit(html, plainText) {
  * by the logger.
  */
 export const log = {
-    line:  msg => _emit(msg, msg),
+    info:  msg => _emit(msg, msg),
     warn:  msg => _emit(`<span style="color:orange">WARN ${msg}</span>`, `WARN ${msg}`),
     error: msg => _emit(`<span style="color:red">ERR ${msg}</span>`,     `ERR ${msg}`),
 };
 
 /**
- * @deprecated  Use `log.line` / `log.warn` / `log.error` instead.
+ * @deprecated  Use `log.info` / `log.warn` / `log.error` instead.
  *
  * Old API where severity was encoded into the message string as inline
  * HTML (`<span style="color:orange">WARN ...</span>`). New callers

--- a/userscripts/discogs_credits/src/ui-bar.js
+++ b/userscripts/discogs_credits/src/ui-bar.js
@@ -17,7 +17,7 @@
 import { DISCOGS_LOGO_URL }              from './constants.js';
 import { db }                             from './storage.js';
 import {
-    addLogLine,
+    log,
     setLogContainer,
 }                                        from './log.js';
 import { _showBar, _hideBar }             from './progress-bar.js';
@@ -442,7 +442,7 @@ export function insertDiscogsBar(discogsUrl) {
             if (!line.trim()) return;
             // Make URLs clickable in the log
             const html = line.replace(/(https?:\/\/[^\s]+)/g, '<a href="$1" target="_blank" rel="noopener noreferrer nofollow">$1</a>');
-            addLogLine(html);
+            log.line(html);
         });
         runImport(discogsUrl, tracklistCb.checked, applyTracksCb.checked, createWorksCb.checked).finally(() => {
             importBtn.disabled = false;
@@ -520,7 +520,7 @@ function runImport(discogsUrl, processTracklist, applyToTracks, createWorks) {
                 li.querySelector('details').appendChild(pre);
                 _logs.appendChild(li);
             }
-            addLogLine(`Found ${json.companies.length + artistRoles.length} release relationships`);
+            log.line(`Found ${json.companies.length + artistRoles.length} release relationships`);
             // handle potential dj mixes - if the tracks are the full medium then assign it to the release/medium else leave it as individual tracks
             artistRoles = artistRoles.concat(convertPotentialDJMixers(json));
             let tracklistRels = [];
@@ -558,7 +558,7 @@ function runImport(discogsUrl, processTracklist, applyToTracks, createWorks) {
                         }, [])
                     );
                 }
-                addLogLine(`Found ${tracklistRels.length} tracklist relationships`);
+                log.line(`Found ${tracklistRels.length} tracklist relationships`);
             }
 
             // Collect all unique artist entities referenced across release-level and tracklist roles

--- a/userscripts/discogs_credits/src/ui-bar.js
+++ b/userscripts/discogs_credits/src/ui-bar.js
@@ -442,7 +442,7 @@ export function insertDiscogsBar(discogsUrl) {
             if (!line.trim()) return;
             // Make URLs clickable in the log
             const html = line.replace(/(https?:\/\/[^\s]+)/g, '<a href="$1" target="_blank" rel="noopener noreferrer nofollow">$1</a>');
-            log.line(html);
+            log.info(html);
         });
         runImport(discogsUrl, tracklistCb.checked, applyTracksCb.checked, createWorksCb.checked).finally(() => {
             importBtn.disabled = false;
@@ -520,7 +520,7 @@ function runImport(discogsUrl, processTracklist, applyToTracks, createWorks) {
                 li.querySelector('details').appendChild(pre);
                 _logs.appendChild(li);
             }
-            log.line(`Found ${json.companies.length + artistRoles.length} release relationships`);
+            log.info(`Found ${json.companies.length + artistRoles.length} release relationships`);
             // handle potential dj mixes - if the tracks are the full medium then assign it to the release/medium else leave it as individual tracks
             artistRoles = artistRoles.concat(convertPotentialDJMixers(json));
             let tracklistRels = [];
@@ -558,7 +558,7 @@ function runImport(discogsUrl, processTracklist, applyToTracks, createWorks) {
                         }, [])
                     );
                 }
-                log.line(`Found ${tracklistRels.length} tracklist relationships`);
+                log.info(`Found ${tracklistRels.length} tracklist relationships`);
             }
 
             // Collect all unique artist entities referenced across release-level and tracklist roles


### PR DESCRIPTION
Refs #32 — proposal F continued. Targets `refactor`, not `main`.

## What

Severity moves from the message string into the call site.

| Before | After |
|---|---|
| `addLogLine('<span style="color:red">ERR ...</span>')` | `log.error('...')` |
| `addLogLine('<span style="color:orange">WARN ...</span>')` | `log.warn('...')` |
| `addLogLine('...')` (plain) | `log.line('...')` |

`log.js` now exports a `log` object with three methods. The `<span>` colour wrapper and the `WARN ` / `ERR ` prefix move into the logger; callers pass plain text. The plain-text feed into the progress ticker (`.discogs-bar`'s `_setProgress`) now gets the prefix too, so the ticker shows `WARN Some thing` instead of the bare HTML-stripped tail.

## Migration

52 call sites migrated mechanically across:

- `api-mb.js` (6)
- `editor-state.js` (8)
- `ui-bar.js` (4)
- `dispatch.js` (34)

`addLogLine` is kept as a deprecated alias inside `log.js` for backward compat. Can drop once nothing depends on it externally; for now the alias means no breakage if someone has cached an older snippet.

## Test plan

- [x] `pnpm run verify` — green.
- [x] Smoke fixture (Spiritual Jazz: 95 staged rels) — green; per-fixture log shows `WARN Skipped …` lines correctly prefixed.
