### PR TITLE
Single resolveEntity + resolveAll replaces checkMissingArtists / checkMissingCompanies

### DIFF
--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -1705,344 +1705,156 @@
   }
 
   // src/preflight.js
-  async function checkMissingArtists(artists, progressLi, bypassIdb) {
+  var KIND_TABLE = {
+    artist: { searchLimit: 10, resultKey: "artists", incRels: "artist-rels" },
+    label: { searchLimit: 8, resultKey: "labels", incRels: "label-rels" },
+    // Places also accept label-rels because MB editors often file a
+    // facility as a label rather than a place (issue we've worked around
+    // since the original company resolver).
+    place: { searchLimit: 8, resultKey: "places", incRels: "place-rels+label-rels" }
+  };
+  async function resolveEntity(entity, kind, opts) {
+    const { bypassIdb } = opts;
+    const { searchLimit, resultKey, incRels } = KIND_TABLE[kind];
+    const parsed = parseDiscogsUrl(entity.resource_url);
+    const key = parsed?.key;
+    const searchName = entity.name;
+    const displayName = kind === "artist" ? entity.anv && entity.anv.trim() || entity.name : entity.name;
+    const discogsHref = entity.resource_url.replace(/https:\/\/api\.discogs\.com\/(\w+?)s\/(\d+)/, "https://www.discogs.com/$1/$2");
+    function buildResolved(mbUrl, mbName, mbDisambig, via, actualKind = kind) {
+      return {
+        type: "resolved",
+        entityType: actualKind,
+        entity,
+        displayName,
+        discogsHref,
+        mbUrl,
+        mbName,
+        mbDisambig,
+        logEntry: { displayName, discogsHref, mbUrl, mbName, mbDisambig, via }
+      };
+    }
+    async function fetchMbEntityInfo(mbUrl) {
+      const m = mbUrl.match(/\/(artist|label|place)\/([a-f0-9-]+)/);
+      if (!m) return { name: null, disambiguation: "" };
+      const json = await mbThrottle.fetchJson(`//musicbrainz.org/ws/2/${m[1]}/${m[2]}?fmt=json`);
+      return json ? { name: json.name || null, disambiguation: json.disambiguation || "" } : { name: null, disambiguation: "" };
+    }
+    if (!bypassIdb && key) {
+      const cachedRec = await readIdbRecord(key);
+      if (cachedRec?.mb_links?.[0]) {
+        const cached = cachedRec.mb_links[0];
+        if (cachedRec.mb_name) {
+          return buildResolved(cached, cachedRec.mb_name, cachedRec.mb_disambiguation || "", "cache");
+        }
+        const info = await fetchMbEntityInfo(cached);
+        if (info.name && db) {
+          try {
+            db.transaction(["mblinks"], "readwrite").objectStore("mblinks").put({ ...cachedRec, mb_name: info.name, mb_disambiguation: info.disambiguation });
+          } catch (e) {
+          }
+        }
+        return buildResolved(cached, info.name, info.disambiguation, "cache");
+      }
+    }
+    const nameJson = await mbThrottle.fetchJson(
+      `//musicbrainz.org/ws/2/${kind}?query=${encodeURIComponent(searchName)}&fmt=json&limit=${searchLimit}`
+    );
+    const nameSearchFailed = nameJson === null;
+    const normalized = searchName.toLowerCase().trim();
+    const nameMatches = !nameJson?.[resultKey] ? [] : nameJson[resultKey].filter((a) => a.name.toLowerCase().trim() === normalized || a.score != null && a.score >= 70).map((a) => ({
+      id: a.id,
+      name: a.name,
+      disambiguation: a.disambiguation || a["disambiguation-comment"] || "",
+      score: a.score || 0
+    }));
+    const exactMatches = nameMatches.filter((a) => a.name.toLowerCase().trim() === normalized);
+    if (exactMatches.length === 1) {
+      const a = exactMatches[0];
+      const mbUrl = `//musicbrainz.org/${kind}/${a.id}`;
+      if (key && db) {
+        try {
+          db.transaction(["mblinks"], "readwrite").objectStore("mblinks").put({ discogs_id: key, mb_links: [mbUrl], mb_name: a.name, mb_disambiguation: a.disambiguation || "" });
+        } catch (e) {
+        }
+      }
+      return buildResolved(mbUrl, a.name, a.disambiguation || "", "name");
+    }
+    const urlJson = parsed ? await mbThrottle.fetchJson(
+      `//musicbrainz.org/ws/2/url?resource=${encodeURIComponent(parsed.cleanUrl)}&inc=${incRels}&fmt=json`
+    ) : null;
+    if (urlJson?.relations?.length > 0) {
+      const rel = kind === "place" ? urlJson.relations.find((r) => r.place || r.label) : urlJson.relations.find((r) => r[kind]);
+      if (rel) {
+        const actualKind = rel[kind] ? kind : rel.label ? "label" : "place";
+        const a = rel[actualKind];
+        const mbUrl = `//musicbrainz.org/${actualKind}/${a.id}`;
+        const info = a.name ? a : await fetchMbEntityInfo(mbUrl);
+        const resolvedName = info.name || a.name;
+        const resolvedDisam = info.disambiguation || a.disambiguation || "";
+        if (key && resolvedName && db) {
+          try {
+            db.transaction(["mblinks"], "readwrite").objectStore("mblinks").put({ discogs_id: key, mb_links: [mbUrl], mb_name: resolvedName, mb_disambiguation: resolvedDisam });
+          } catch (e) {
+          }
+        }
+        return buildResolved(mbUrl, resolvedName, resolvedDisam, "url", actualKind);
+      }
+    }
+    return {
+      type: "attention",
+      entityType: kind,
+      entity,
+      displayName,
+      discogsHref,
+      nameMatches,
+      // Only artists track this — used by the review table to badge
+      // entries that failed because of a rate-limited name search vs
+      // entries that genuinely don't exist in MB.
+      rateLimited: kind === "artist" && nameSearchFailed && !nameMatches.length
+    };
+  }
+  async function resolveAll(entities, opts) {
+    const { kindOf, progressLi, bypassIdb, progressLabel } = opts;
     const CONCURRENCY = 5;
     const MIN_GAP_MS = 50;
     let done = 0;
-    let inFlight = 0;
     const inFlightNames = /* @__PURE__ */ new Set();
     function setProgress() {
       if (!progressLi) return;
-      const remaining = artists.length - done;
+      const remaining = entities.length - done;
       const checking = inFlightNames.size ? ` \u2014 checking <em>${[...inFlightNames].join(", ")}</em>` : "";
-      progressLi.innerHTML = `Checking artists against MusicBrainz\u2026 <strong>${done}/${artists.length}</strong> done${checking}` + (remaining === 0 ? " \u2714" : ` (${remaining} remaining)`);
+      progressLi.innerHTML = `${progressLabel}\u2026 <strong>${done}/${entities.length}</strong> done${checking}` + (remaining === 0 ? " \u2714" : ` (${remaining} remaining)`);
     }
     const delay = (ms) => new Promise((r) => setTimeout(r, ms));
-    async function mbFetch(url, retries = 4) {
-      return mbThrottle.fetchJson(url, retries);
-    }
-    function checkIdbCache(key) {
-      return new Promise((resolve) => {
-        if (!key || !db) return resolve(null);
-        try {
-          const tx = db.transaction(["mblinks"], "readonly");
-          const req = tx.objectStore("mblinks").get(key);
-          req.onsuccess = () => resolve(req.result || null);
-          req.onerror = () => resolve(null);
-        } catch (e) {
-          resolve(null);
-        }
-      });
-    }
-    async function checkOne(artist) {
-      const parsed = parseDiscogsUrl(artist.resource_url);
-      const key = parsed?.key;
-      const searchName = artist.name;
-      const displayName = artist.anv && artist.anv.trim() || artist.name;
-      const discogsHref = artist.resource_url.replace("https://api.discogs.com/artists/", "https://www.discogs.com/artist/");
-      function resolvedResult(mbUrl, mbName, mbDisambig, via) {
-        return {
-          type: "resolved",
-          entityType: "artist",
-          entity: artist,
-          displayName,
-          discogsHref,
-          mbUrl,
-          mbName,
-          mbDisambig,
-          logEntry: { displayName, discogsHref, mbUrl, mbName, mbDisambig, via }
-        };
-      }
-      async function fetchMbArtistInfo(mbUrl) {
-        const mbid = mbUrl.replace(/.*\/artist\//, "");
-        const json = await mbFetch(`//musicbrainz.org/ws/2/artist/${mbid}?fmt=json`);
-        return json ? { name: json.name || null, disambiguation: json.disambiguation || "" } : { name: null, disambiguation: "" };
-      }
-      if (!bypassIdb && key) {
-        const cachedRec = await checkIdbCache(key);
-        if (cachedRec?.mb_links?.[0]) {
-          const cached = cachedRec.mb_links[0];
-          if (cachedRec.mb_name) {
-            return resolvedResult(cached, cachedRec.mb_name, cachedRec.mb_disambiguation || "", "cache");
-          }
-          const info = await fetchMbArtistInfo(cached);
-          if (info.name) {
-            try {
-              const t = db.transaction(["mblinks"], "readwrite");
-              t.objectStore("mblinks").put({ ...cachedRec, mb_name: info.name, mb_disambiguation: info.disambiguation });
-            } catch (e) {
-            }
-          }
-          return resolvedResult(cached, info.name, info.disambiguation, "cache");
-        }
-      }
-      const nameJson = await mbFetch(
-        `//musicbrainz.org/ws/2/artist?query=${encodeURIComponent(searchName)}&fmt=json&limit=10`
-      );
-      const nameSearchFailed = nameJson === null;
-      const normalized = searchName.toLowerCase().trim();
-      const nameMatches = !nameJson?.artists ? [] : nameJson.artists.filter((a) => a.name.toLowerCase().trim() === normalized || a.score != null && a.score >= 70).map((a) => ({ id: a.id, name: a.name, disambiguation: a.disambiguation || "", score: a.score || 0 }));
-      const exactMatches = nameMatches.filter((a) => a.name.toLowerCase().trim() === normalized);
-      if (exactMatches.length === 1) {
-        const a = exactMatches[0];
-        const mbUrl = `//musicbrainz.org/artist/${a.id}`;
-        if (key) {
-          try {
-            const tx = db.transaction(["mblinks"], "readwrite");
-            tx.objectStore("mblinks").put({ discogs_id: key, mb_links: [mbUrl], mb_name: a.name, mb_disambiguation: a.disambiguation || "" });
-          } catch (e) {
-          }
-        }
-        return resolvedResult(mbUrl, a.name, a.disambiguation, "name");
-      }
-      const urlJson = parsed ? await mbFetch(
-        `//musicbrainz.org/ws/2/url?resource=${encodeURIComponent(parsed.cleanUrl)}&inc=artist-rels&fmt=json`
-      ) : null;
-      if (urlJson?.relations?.length > 0) {
-        const rel = urlJson.relations.find((r) => r.artist);
-        if (rel) {
-          const a = rel.artist;
-          const mbUrl = `//musicbrainz.org/artist/${a.id}`;
-          const info = a.name ? a : await fetchMbArtistInfo(mbUrl);
-          const resolvedName = info.name || a.name;
-          const resolvedDisam = info.disambiguation || a.disambiguation || "";
-          if (key && resolvedName) {
-            try {
-              const tx2 = db.transaction(["mblinks"], "readwrite");
-              tx2.objectStore("mblinks").put({ discogs_id: key, mb_links: [mbUrl], mb_name: resolvedName, mb_disambiguation: resolvedDisam });
-            } catch (e) {
-            }
-          }
-          return resolvedResult(mbUrl, resolvedName, resolvedDisam, "url");
-        }
-      }
-      return {
-        type: "attention",
-        entityType: "artist",
-        entity: artist,
-        displayName,
-        discogsHref,
-        nameMatches,
-        rateLimited: nameSearchFailed && !nameMatches.length
-      };
-    }
-    return (async () => {
-      const queue = artists.map((a, i) => ({ artist: a, index: i }));
-      const results = new Array(artists.length);
-      setProgress();
-      async function worker(slotIndex) {
-        await delay(slotIndex * MIN_GAP_MS);
-        while (queue.length > 0) {
-          const { artist, index } = queue.shift();
-          const displayName = artist.anv && artist.anv.trim() || artist.name;
-          inFlightNames.add(displayName);
-          setProgress();
-          const result = await checkOne(artist);
-          results[index] = result;
-          inFlightNames.delete(displayName);
+    const queue = entities.map((e, i) => ({ entity: e, index: i }));
+    const results = new Array(entities.length);
+    setProgress();
+    async function worker(slotIndex) {
+      await delay(slotIndex * MIN_GAP_MS);
+      while (queue.length > 0) {
+        const { entity, index } = queue.shift();
+        const kind = kindOf(entity);
+        if (!kind) {
           done++;
           setProgress();
+          continue;
         }
+        const displayName = kind === "artist" ? entity.anv && entity.anv.trim() || entity.name : entity.name;
+        inFlightNames.add(displayName);
+        setProgress();
+        results[index] = await resolveEntity(entity, kind, { bypassIdb });
+        inFlightNames.delete(displayName);
+        done++;
+        setProgress();
       }
-      const slots = Math.min(CONCURRENCY, artists.length);
-      await Promise.all(Array.from({ length: slots }, (_, i) => worker(i)));
-      return { allResults: results };
-    })();
+    }
+    const slots = Math.min(CONCURRENCY, entities.length);
+    if (slots > 0) await Promise.all(Array.from({ length: slots }, (_, i) => worker(i)));
+    return { allResults: results.filter(Boolean) };
   }
-  async function checkMissingCompanies(companies, progressLi, bypassIdb) {
-    const CONCURRENCY = 5;
-    const MIN_GAP_MS = 200;
-    let done = 0;
-    const inFlightNames = /* @__PURE__ */ new Set();
-    function setProgress() {
-      if (!progressLi) return;
-      const remaining = companies.length - done;
-      const checking = inFlightNames.size ? ` \u2014 checking <em>${[...inFlightNames].join(", ")}</em>` : "";
-      progressLi.innerHTML = `Checking labels/places against MusicBrainz\u2026 <strong>${done}/${companies.length}</strong> done${checking}` + (remaining === 0 ? " \u2714" : ` (${remaining} remaining)`);
-    }
-    const delay = (ms) => new Promise((r) => setTimeout(r, ms));
-    async function mbFetch(url, retries = 4) {
-      return mbThrottle.fetchJson(url, retries);
-    }
-    function checkIdbCache(key) {
-      return new Promise((resolve) => {
-        if (!key || !db) return resolve(null);
-        try {
-          const tx = db.transaction(["mblinks"], "readonly");
-          const req = tx.objectStore("mblinks").get(key);
-          req.onsuccess = () => resolve(req.result || null);
-          req.onerror = () => resolve(null);
-        } catch (e) {
-          resolve(null);
-        }
-      });
-    }
-    async function checkOne(company) {
-      const details = ENTITY_TYPE_MAP[company.entity_type_name];
-      if (!details) return null;
-      const entityType = details.entityType;
-      const parsed = parseDiscogsUrl(company.resource_url);
-      const key = parsed?.key;
-      const searchName = company.name;
-      const displayName = company.name;
-      const discogsHref = company.resource_url.replace(/https:\/\/api\.discogs\.com\/(\w+?)s\/(\d+)/, "https://www.discogs.com/$1/$2");
-      async function fetchMbEntityInfo(mbUrl) {
-        const mbid = mbUrl.replace(/.*\/(label|place)\//, "");
-        const json = await mbFetch(`//musicbrainz.org/ws/2/${entityType}/${mbid}?fmt=json`);
-        return json ? { name: json.name || null, disambiguation: json.disambiguation || "" } : { name: null, disambiguation: "" };
-      }
-      if (!bypassIdb) {
-        const cachedRec = await checkIdbCache(key);
-        if (cachedRec?.mb_links?.[0]) {
-          const cached = cachedRec.mb_links[0];
-          if (cachedRec.mb_name) {
-            return {
-              type: "resolved",
-              entityType,
-              entity: company,
-              displayName,
-              discogsHref,
-              mbUrl: cached,
-              mbName: cachedRec.mb_name,
-              mbDisambig: cachedRec.mb_disambiguation || "",
-              logEntry: {
-                displayName,
-                discogsHref,
-                mbUrl: cached,
-                mbName: cachedRec.mb_name,
-                mbDisambig: cachedRec.mb_disambiguation || "",
-                via: "cache"
-              }
-            };
-          }
-          const info = await fetchMbEntityInfo(cached);
-          if (info.name) {
-            try {
-              const t = db.transaction(["mblinks"], "readwrite");
-              t.objectStore("mblinks").put({ ...cachedRec, mb_name: info.name, mb_disambiguation: info.disambiguation });
-            } catch (e) {
-            }
-          }
-          return {
-            type: "resolved",
-            entityType,
-            entity: company,
-            displayName,
-            discogsHref,
-            mbUrl: cached,
-            mbName: info.name,
-            mbDisambig: info.disambiguation,
-            logEntry: {
-              displayName,
-              discogsHref,
-              mbUrl: cached,
-              mbName: info.name,
-              mbDisambig: info.disambiguation,
-              via: "cache"
-            }
-          };
-        }
-      }
-      const nameJson = await mbFetch(
-        `//musicbrainz.org/ws/2/${entityType}?query=${encodeURIComponent(searchName)}&fmt=json&limit=8`
-      );
-      const resultKey = entityType === "label" ? "labels" : "places";
-      const normalized = searchName.toLowerCase().trim();
-      const nameSearchFailed2 = nameJson === null;
-      const nameMatches = !nameJson?.[resultKey] ? [] : nameJson[resultKey].filter((a) => a.name.toLowerCase().trim() === normalized || a.score != null && a.score >= 70).map((a) => ({ id: a.id, name: a.name, disambiguation: a.disambiguation || a["disambiguation-comment"] || "", score: a.score || 0 }));
-      const exactMatches = nameMatches.filter((a) => a.name.toLowerCase().trim() === normalized);
-      if (exactMatches.length === 1) {
-        const a = exactMatches[0];
-        const mbUrl = `//musicbrainz.org/${entityType}/${a.id}`;
-        if (key) {
-          try {
-            const tx = db.transaction(["mblinks"], "readwrite");
-            tx.objectStore("mblinks").put({ discogs_id: key, mb_links: [mbUrl] });
-          } catch (e) {
-          }
-        }
-        if (key) try {
-          const t = db.transaction(["mblinks"], "readwrite");
-          t.objectStore("mblinks").put({ discogs_id: key, mb_links: [mbUrl], mb_name: a.name, mb_disambiguation: a.disambiguation || "" });
-        } catch (e) {
-        }
-        return {
-          type: "resolved",
-          entityType,
-          entity: company,
-          displayName,
-          discogsHref,
-          mbUrl,
-          mbName: a.name,
-          mbDisambig: a.disambiguation,
-          logEntry: {
-            displayName,
-            discogsHref,
-            mbUrl,
-            mbName: a.name,
-            mbDisambig: a.disambiguation,
-            via: "name"
-          }
-        };
-      }
-      const incRels = entityType === "place" ? "place-rels+label-rels" : `${entityType}-rels`;
-      const urlJson = parsed ? await mbFetch(
-        `//musicbrainz.org/ws/2/url?resource=${encodeURIComponent(parsed.cleanUrl)}&inc=${incRels}&fmt=json`
-      ) : null;
-      if (urlJson?.relations?.length > 0) {
-        const rel = urlJson.relations.find((r) => r[entityType] || r["label"] || r["place"]);
-        if (rel) {
-          const actualEt = rel[entityType] ? entityType : rel["label"] ? "label" : "place";
-          const a = rel[actualEt];
-          const mbUrl = `//musicbrainz.org/${actualEt}/${a.id}`;
-          const info = a.name ? a : await fetchMbEntityInfo(mbUrl);
-          return {
-            type: "resolved",
-            entityType: actualEt,
-            entity: company,
-            displayName,
-            discogsHref,
-            mbUrl,
-            mbName: info.name || a.name,
-            mbDisambig: info.disambiguation || "",
-            logEntry: {
-              displayName,
-              discogsHref,
-              mbUrl,
-              mbName: info.name || a.name,
-              mbDisambig: info.disambiguation || "",
-              via: "url"
-            }
-          };
-        }
-      }
-      return { type: "attention", entityType, entity: company, displayName, discogsHref, nameMatches };
-    }
-    return (async () => {
-      const queue = companies.map((c, i) => ({ company: c, index: i }));
-      const results = [];
-      const resultArr = new Array(companies.length);
-      setProgress();
-      async function worker(slotIndex) {
-        await delay(slotIndex * MIN_GAP_MS);
-        while (queue.length > 0) {
-          const _item = queue.shift();
-          const company = _item.company || _item;
-          const _cIdx = _item.index ?? -1;
-          inFlightNames.add(company.name);
-          setProgress();
-          const result = await checkOne(company);
-          if (result && _cIdx >= 0) resultArr[_cIdx] = result;
-          inFlightNames.delete(company.name);
-          done++;
-          setProgress();
-        }
-      }
-      const slots = Math.min(CONCURRENCY, companies.length);
-      if (slots > 0) await Promise.all(Array.from({ length: slots }, (_, i) => worker(i)));
-      return { allResults: resultArr.filter(Boolean) };
-    })();
-  }
+  var ARTIST_KIND = () => "artist";
+  var COMPANY_KIND = (c) => ENTITY_TYPE_MAP[c.entity_type_name]?.entityType ?? null;
 
   // src/review-table.js
   var _urlCheckSessionCache = /* @__PURE__ */ new Map();
@@ -3963,8 +3775,18 @@
         companyProgressLi.textContent = `Checking ${uniqueCompanies.length} label(s)/place(s) against MusicBrainz\u2026`;
         _logs2.appendChild(companyProgressLi);
         return Promise.all([
-          checkMissingArtists(uniqueArtists, artistProgressLi, bypassIdb),
-          checkMissingCompanies(uniqueCompanies, companyProgressLi, bypassIdb)
+          resolveAll(uniqueArtists, {
+            progressLi: artistProgressLi,
+            bypassIdb,
+            progressLabel: "Checking artists against MusicBrainz",
+            kindOf: ARTIST_KIND
+          }),
+          resolveAll(uniqueCompanies, {
+            progressLi: companyProgressLi,
+            bypassIdb,
+            progressLabel: "Checking labels/places against MusicBrainz",
+            kindOf: COMPANY_KIND
+          })
         ]).then(([artistResults, companyResults]) => {
           const allResults = [...artistResults.allResults, ...companyResults.allResults].filter(Boolean);
           if (!bypassIdb) try {

--- a/userscripts/discogs_credits/src/preflight.js
+++ b/userscripts/discogs_credits/src/preflight.js
@@ -1,352 +1,228 @@
 // Pre-flight: resolve every Discogs artist / company against MusicBrainz
 // BEFORE the actual import runs, so the review-table phase can show one
 // row per credit with the chosen MBID (or "needs attention") for the user
-// to confirm. Lookup strategy per entity:
-//   1. IDB cache (mblinks store)        — instant; populated by prior runs.
-//   2. Name search (`/ws/2/<type>?query=…`) — single exact match wins.
+// to confirm.
+//
+// Single resolver. The two earlier near-duplicates (`checkMissingArtists`
+// and `checkMissingCompanies`) collapse into one
+// `resolveEntity(entity, kind, opts)` + `resolveAll(entities, opts)`
+// where `opts.kindOf(entity)` decides 'artist' | 'label' | 'place' per
+// entity (null = skip).
+//
+// Lookup strategy per entity (unchanged from the old code):
+//   1. IDB cache (mblinks store)             — instant; populated by prior runs.
+//   2. Name search (`/ws/2/<type>?query=…`)   — single exact match wins.
 //   3. URL relation (`/ws/2/url?resource=…&inc=<entity>-rels`) — fallback
 //      when name search is ambiguous or empty.
 //
-// Each function returns `{ allResults: [...] }` where each result is one of:
+// Result shape per entity is one of:
 //   { type: 'resolved',  entity, mbUrl, mbName, mbDisambig, logEntry: {...} }
 //   { type: 'attention', entity, nameMatches: [...]                      }
 
 import { mbThrottle }                       from './api-mb.js';
-import { db }                                from './storage.js';
+import { db, readIdbRecord }                 from './storage.js';
 import { parseDiscogsUrl }                  from './api-discogs.js';
 import { ENTITY_TYPE_MAP }                  from './data/entity-map.js';
 
+// `kind`-specific tweaks. Tiny lookup table so the per-strategy code in
+// `resolveEntity` reads as one shared body.
+const KIND_TABLE = {
+    artist: { searchLimit: 10, resultKey: 'artists', incRels: 'artist-rels' },
+    label:  { searchLimit: 8,  resultKey: 'labels',  incRels: 'label-rels'  },
+    // Places also accept label-rels because MB editors often file a
+    // facility as a label rather than a place (issue we've worked around
+    // since the original company resolver).
+    place:  { searchLimit: 8,  resultKey: 'places',  incRels: 'place-rels+label-rels' },
+};
+
 /**
- * Checks each artist against MB using two strategies in sequence:
- *   1. URL-relationship lookup (fast, exact) — the same query the real import uses.
- *      If the Discogs URL is already linked in MB this resolves immediately.
- *   2. Name search fallback — if the URL lookup finds nothing, search by artist name.
- *      A name hit means the artist exists in MB but has no Discogs link yet; the
- *      import will still fail, but the user should link rather than create.
+ * Resolve a single Discogs entity against MB using the 3-strategy chain
+ * (IDB → name search → URL relation).
  *
- * Returns an array of objects: { artist, nameMatches }
- *   artist      – the Discogs artist object
- *   nameMatches – array of { id, name, disambiguation } from the MB name search
- *                 (empty array means truly not found → needs creation)
+ *   - `kind`: one of `'artist' | 'label' | 'place'`.
+ *   - `opts.bypassIdb`: skip step 1 (for forced refreshes).
+ *
+ * Returns one of the result shapes documented at the top of the file.
  */
-export async function checkMissingArtists(artists, progressLi, bypassIdb) {
-    const CONCURRENCY = 5;   // worker count (MB requests are serialized via mbThrottle)
-    const MIN_GAP_MS  = 50;  // stagger between worker starts (actual MB pacing is in mbThrottle)
+async function resolveEntity(entity, kind, opts) {
+    const { bypassIdb } = opts;
+    const { searchLimit, resultKey, incRels } = KIND_TABLE[kind];
 
-    let done = 0;
-    let inFlight = 0; // names of artists currently being fetched
-    const inFlightNames = new Set();
+    const parsed     = parseDiscogsUrl(entity.resource_url);
+    const key        = parsed?.key;
+    const searchName = entity.name;
+    const displayName = kind === 'artist'
+        ? (entity.anv && entity.anv.trim()) || entity.name
+        : entity.name;
+    // API URLs ("api.discogs.com/artists/123") → website form ("www.discogs.com/artist/123").
+    // Same `(\w+?)s/(\d+)` pattern works for artist/label/master.
+    const discogsHref = entity.resource_url
+        .replace(/https:\/\/api\.discogs\.com\/(\w+?)s\/(\d+)/, 'https://www.discogs.com/$1/$2');
 
-    function setProgress() {
-        if (!progressLi) return;
-        const remaining = artists.length - done;
-        const checking = inFlightNames.size
-            ? ` \u2014 checking <em>${[...inFlightNames].join(', ')}</em>` : '';
-        progressLi.innerHTML =
-            `Checking artists against MusicBrainz\u2026 ` +
-            `<strong>${done}/${artists.length}</strong> done${checking}` +
-            (remaining === 0 ? ' \u2714' : ` (${remaining} remaining)`);
+    function buildResolved(mbUrl, mbName, mbDisambig, via, actualKind = kind) {
+        return {
+            type: 'resolved', entityType: actualKind, entity,
+            displayName, discogsHref, mbUrl, mbName, mbDisambig,
+            logEntry: { displayName, discogsHref, mbUrl, mbName, mbDisambig, via },
+        };
     }
 
-    const delay = (ms) => new Promise(r => setTimeout(r, ms));
-
-    // Fetch with automatic retry on 503/429; backs off and retries up to 4 times.
-    // Returns parsed JSON or null on permanent failure.
-    async function mbFetch(url, retries = 4) {
-        return mbThrottle.fetchJson(url, retries);
+    /** Fetch MB entity name/disambiguation for a known MB URL (display only). */
+    async function fetchMbEntityInfo(mbUrl) {
+        const m = mbUrl.match(/\/(artist|label|place)\/([a-f0-9-]+)/);
+        if (!m) return { name: null, disambiguation: '' };
+        const json = await mbThrottle.fetchJson(`//musicbrainz.org/ws/2/${m[1]}/${m[2]}?fmt=json`);
+        return json
+            ? { name: json.name || null, disambiguation: json.disambiguation || '' }
+            : { name: null, disambiguation: '' };
     }
 
-    function checkIdbCache(key) {
-        return new Promise(resolve => {
-            if (!key || !db) return resolve(null);
-            try {
-                const tx = db.transaction(['mblinks'], 'readonly');
-                const req = tx.objectStore('mblinks').get(key);
-                req.onsuccess = () => resolve(req.result || null);
-                req.onerror  = () => resolve(null);
-            } catch(e) { resolve(null); }
-        });
-    }
-
-    async function checkOne(artist) {
-        const parsed      = parseDiscogsUrl(artist.resource_url);
-        const key         = parsed?.key;
-        const searchName  = artist.name;
-        const displayName = (artist.anv && artist.anv.trim()) || artist.name;
-        const discogsHref = artist.resource_url
-            .replace('https://api.discogs.com/artists/', 'https://www.discogs.com/artist/');
-
-        function resolvedResult(mbUrl, mbName, mbDisambig, via) {
-            return { type: 'resolved', entityType: 'artist', entity: artist,
-                     displayName, discogsHref, mbUrl, mbName, mbDisambig,
-                     logEntry: { displayName, discogsHref, mbUrl, mbName, mbDisambig, via } };
-        }
-
-        // Fetch MB artist name/disambiguation for a known MBID (for display purposes)
-        async function fetchMbArtistInfo(mbUrl) {
-            const mbid = mbUrl.replace(/.*\/artist\//, '');
-            const json = await mbFetch(`//musicbrainz.org/ws/2/artist/${mbid}?fmt=json`);
-            return json ? { name: json.name || null, disambiguation: json.disambiguation || '' } : { name: null, disambiguation: '' };
-        }
-
-        // 1. IDB cache — instant, no network (skip for artists with no real key)
-        if (!bypassIdb && key) {
-            const cachedRec = await checkIdbCache(key);
-            if (cachedRec?.mb_links?.[0]) {
-                const cached = cachedRec.mb_links[0];
-                if (cachedRec.mb_name) {
-                    return resolvedResult(cached, cachedRec.mb_name, cachedRec.mb_disambiguation || '', 'cache');
-                }
-                const info = await fetchMbArtistInfo(cached);
-                if (info.name) {
-                    try { const t=db.transaction(['mblinks'],'readwrite'); t.objectStore('mblinks').put({...cachedRec, mb_name:info.name, mb_disambiguation:info.disambiguation}); } catch(e){}
-                }
-                return resolvedResult(cached, info.name, info.disambiguation, 'cache');
+    // ── 1. IDB cache ─────────────────────────────────────────────────────────
+    if (!bypassIdb && key) {
+        const cachedRec = await readIdbRecord(key);
+        if (cachedRec?.mb_links?.[0]) {
+            const cached = cachedRec.mb_links[0];
+            if (cachedRec.mb_name) {
+                return buildResolved(cached, cachedRec.mb_name, cachedRec.mb_disambiguation || '', 'cache');
             }
-        }
-
-        // 2. Name search — resolves newly created artists without a Discogs link yet
-        const nameJson = await mbFetch(
-            `//musicbrainz.org/ws/2/artist?query=${encodeURIComponent(searchName)}&fmt=json&limit=10`
-        );
-        const nameSearchFailed = nameJson === null;
-        const normalized = searchName.toLowerCase().trim();
-        const nameMatches = !nameJson?.artists ? [] : nameJson.artists
-            .filter(a => a.name.toLowerCase().trim() === normalized || (a.score != null && a.score >= 70))
-            .map(a => ({ id: a.id, name: a.name, disambiguation: a.disambiguation || '', score: a.score || 0 }));
-
-        const exactMatches = nameMatches.filter(a => a.name.toLowerCase().trim() === normalized);
-        if (exactMatches.length === 1) {
-            const a = exactMatches[0];
-            const mbUrl = `//musicbrainz.org/artist/${a.id}`;
-            if (key) {
+            const info = await fetchMbEntityInfo(cached);
+            if (info.name && db) {
                 try {
-                    const tx = db.transaction(['mblinks'], 'readwrite');
-                    tx.objectStore('mblinks').put({ discogs_id: key, mb_links: [mbUrl], mb_name: a.name, mb_disambiguation: a.disambiguation || '' });
-                } catch(e) { /* ignore duplicate */ }
+                    db.transaction(['mblinks'], 'readwrite')
+                      .objectStore('mblinks')
+                      .put({ ...cachedRec, mb_name: info.name, mb_disambiguation: info.disambiguation });
+                } catch(e) { /* ignore — best-effort cache populate */ }
             }
-            return resolvedResult(mbUrl, a.name, a.disambiguation, 'name');
+            return buildResolved(cached, info.name, info.disambiguation, 'cache');
         }
-
-        // 3. URL lookup — needed when name search is ambiguous or empty
-        const urlJson = parsed ? await mbFetch(
-            `//musicbrainz.org/ws/2/url?resource=${encodeURIComponent(parsed.cleanUrl)}&inc=artist-rels&fmt=json`
-        ) : null;
-        if (urlJson?.relations?.length > 0) {
-            const rel = urlJson.relations.find(r => r.artist);
-            if (rel) {
-                const a = rel.artist;
-                const mbUrl = `//musicbrainz.org/artist/${a.id}`;
-                // rel.artist from the URL endpoint may not include full name details; fetch them
-                const info = (a.name) ? a : await fetchMbArtistInfo(mbUrl);
-                const resolvedName = info.name || a.name;
-                const resolvedDisam = info.disambiguation || a.disambiguation || '';
-                if (key && resolvedName) {
-                    try {
-                        const tx2 = db.transaction(['mblinks'], 'readwrite');
-                        tx2.objectStore('mblinks').put({ discogs_id: key, mb_links: [mbUrl], mb_name: resolvedName, mb_disambiguation: resolvedDisam });
-                    } catch(e) {}
-                }
-                return resolvedResult(mbUrl, resolvedName, resolvedDisam, 'url');
-            }
-        }
-
-        return { type: 'attention', entityType: 'artist', entity: artist,
-                 displayName, discogsHref, nameMatches,
-                 rateLimited: nameSearchFailed && !nameMatches.length };
     }
 
-    // Concurrency pool: launch up to CONCURRENCY workers simultaneously.
-    // Each worker pulls the next artist from the queue, processes it, then loops.
-    // A small per-slot stagger (MIN_GAP_MS) avoids thundering-herd on burst start.
-    return (async () => {
-        const queue   = artists.map((a, i) => ({ artist: a, index: i }));
-        const results = new Array(artists.length);
-
-        setProgress();
-
-        async function worker(slotIndex) {
-            await delay(slotIndex * MIN_GAP_MS); // stagger slot start
-            while (queue.length > 0) {
-                const { artist, index } = queue.shift();
-                const displayName = (artist.anv && artist.anv.trim()) || artist.name;
-                inFlightNames.add(displayName);
-                setProgress();
-
-                const result = await checkOne(artist);
-                results[index] = result;
-
-                inFlightNames.delete(displayName);
-                done++;
-                setProgress();
-            }
+    // ── 2. Name search ──────────────────────────────────────────────────────
+    const nameJson = await mbThrottle.fetchJson(
+        `//musicbrainz.org/ws/2/${kind}?query=${encodeURIComponent(searchName)}&fmt=json&limit=${searchLimit}`
+    );
+    const nameSearchFailed = nameJson === null;
+    const normalized = searchName.toLowerCase().trim();
+    const nameMatches = !(nameJson?.[resultKey]) ? [] : nameJson[resultKey]
+        .filter(a => a.name.toLowerCase().trim() === normalized || (a.score != null && a.score >= 70))
+        .map(a => ({
+            id: a.id,
+            name: a.name,
+            disambiguation: a.disambiguation || a['disambiguation-comment'] || '',
+            score: a.score || 0,
+        }));
+    const exactMatches = nameMatches.filter(a => a.name.toLowerCase().trim() === normalized);
+    if (exactMatches.length === 1) {
+        const a = exactMatches[0];
+        const mbUrl = `//musicbrainz.org/${kind}/${a.id}`;
+        if (key && db) {
+            try {
+                db.transaction(['mblinks'], 'readwrite')
+                  .objectStore('mblinks')
+                  .put({ discogs_id: key, mb_links: [mbUrl], mb_name: a.name, mb_disambiguation: a.disambiguation || '' });
+            } catch(e) { /* ignore duplicate */ }
         }
+        return buildResolved(mbUrl, a.name, a.disambiguation || '', 'name');
+    }
 
-        const slots = Math.min(CONCURRENCY, artists.length);
-        await Promise.all(Array.from({ length: slots }, (_, i) => worker(i)));
+    // ── 3. URL relation ─────────────────────────────────────────────────────
+    const urlJson = parsed ? await mbThrottle.fetchJson(
+        `//musicbrainz.org/ws/2/url?resource=${encodeURIComponent(parsed.cleanUrl)}&inc=${incRels}&fmt=json`
+    ) : null;
+    if (urlJson?.relations?.length > 0) {
+        // For places, accept either place or label rels (facility-as-label edge case).
+        const rel = kind === 'place'
+            ? urlJson.relations.find(r => r.place || r.label)
+            : urlJson.relations.find(r => r[kind]);
+        if (rel) {
+            const actualKind = rel[kind] ? kind : (rel.label ? 'label' : 'place');
+            const a = rel[actualKind];
+            const mbUrl = `//musicbrainz.org/${actualKind}/${a.id}`;
+            const info = a.name ? a : await fetchMbEntityInfo(mbUrl);
+            const resolvedName = info.name || a.name;
+            const resolvedDisam = info.disambiguation || a.disambiguation || '';
+            if (key && resolvedName && db) {
+                try {
+                    db.transaction(['mblinks'], 'readwrite')
+                      .objectStore('mblinks')
+                      .put({ discogs_id: key, mb_links: [mbUrl], mb_name: resolvedName, mb_disambiguation: resolvedDisam });
+                } catch(e) { /* ignore */ }
+            }
+            return buildResolved(mbUrl, resolvedName, resolvedDisam, 'url', actualKind);
+        }
+    }
 
-        // Return all results for the unified review table
-        // resolved: { type:'resolved', artist, mbUrl, logEntry:{displayName,discogsHref,mbUrl,mbName,mbDisambig,via} }
-        // attention: { type:'attention', artist, nameMatches }
-        return { allResults: results };
-    })();
+    return {
+        type: 'attention', entityType: kind, entity,
+        displayName, discogsHref, nameMatches,
+        // Only artists track this — used by the review table to badge
+        // entries that failed because of a rate-limited name search vs
+        // entries that genuinely don't exist in MB.
+        rateLimited: kind === 'artist' && nameSearchFailed && !nameMatches.length,
+    };
 }
 
 /**
- * Checks companies (labels/places) against MB — same approach as checkMissingArtists.
- * Returns { allResults } with the same unified result shape.
+ * Run the 3-strategy resolver over every entity in parallel (concurrency
+ * pool of 5). Updates a progress `<li>` as workers churn through the queue.
+ *
+ *   - `opts.kindOf(entity)`: returns `'artist'|'label'|'place'` or `null`.
+ *     `null` ⇒ skip this entity (e.g. an unmapped Discogs `entity_type_name`).
+ *   - `opts.progressLi`: DOM element to update with "M/N done — checking …".
+ *   - `opts.progressLabel`: leading text for the progress line.
+ *   - `opts.bypassIdb`: pass through to `resolveEntity`.
+ *
+ * Returns `{ allResults: [...] }` with skipped entities filtered out.
  */
-export async function checkMissingCompanies(companies, progressLi, bypassIdb) {
+export async function resolveAll(entities, opts) {
+    const { kindOf, progressLi, bypassIdb, progressLabel } = opts;
     const CONCURRENCY = 5;
-    const MIN_GAP_MS  = 200;
+    const MIN_GAP_MS  = 50;
     let done = 0;
     const inFlightNames = new Set();
 
     function setProgress() {
         if (!progressLi) return;
-        const remaining = companies.length - done;
+        const remaining = entities.length - done;
         const checking = inFlightNames.size
-            ? ` \u2014 checking <em>${[...inFlightNames].join(', ')}</em>` : '';
+            ? ` — checking <em>${[...inFlightNames].join(', ')}</em>` : '';
         progressLi.innerHTML =
-            `Checking labels/places against MusicBrainz\u2026 ` +
-            `<strong>${done}/${companies.length}</strong> done${checking}` +
-            (remaining === 0 ? ' \u2714' : ` (${remaining} remaining)`);
+            `${progressLabel}… ` +
+            `<strong>${done}/${entities.length}</strong> done${checking}` +
+            (remaining === 0 ? ' ✔' : ` (${remaining} remaining)`);
     }
 
-    const delay = (ms) => new Promise(r => setTimeout(r, ms));
+    const delay = ms => new Promise(r => setTimeout(r, ms));
+    const queue = entities.map((e, i) => ({ entity: e, index: i }));
+    const results = new Array(entities.length);
+    setProgress();
 
-    async function mbFetch(url, retries = 4) {
-        return mbThrottle.fetchJson(url, retries);
+    async function worker(slotIndex) {
+        await delay(slotIndex * MIN_GAP_MS);  // stagger slot starts
+        while (queue.length > 0) {
+            const { entity, index } = queue.shift();
+            const kind = kindOf(entity);
+            if (!kind) { done++; setProgress(); continue; }
+            const displayName = kind === 'artist'
+                ? (entity.anv && entity.anv.trim()) || entity.name
+                : entity.name;
+            inFlightNames.add(displayName);
+            setProgress();
+            results[index] = await resolveEntity(entity, kind, { bypassIdb });
+            inFlightNames.delete(displayName);
+            done++;
+            setProgress();
+        }
     }
 
-    function checkIdbCache(key) {
-        return new Promise(resolve => {
-            if (!key || !db) return resolve(null);
-            try {
-                const tx = db.transaction(['mblinks'], 'readonly');
-                const req = tx.objectStore('mblinks').get(key);
-                req.onsuccess = () => resolve(req.result || null);
-                req.onerror  = () => resolve(null);
-            } catch(e) { resolve(null); }
-        });
-    }
+    const slots = Math.min(CONCURRENCY, entities.length);
+    if (slots > 0) await Promise.all(Array.from({ length: slots }, (_, i) => worker(i)));
 
-    async function checkOne(company) {
-        const details = ENTITY_TYPE_MAP[company.entity_type_name];
-        if (!details) return null; // unmapped company type — skip
-        const entityType  = details.entityType; // 'label' or 'place'
-        const parsed      = parseDiscogsUrl(company.resource_url);
-        const key         = parsed?.key;
-        const searchName  = company.name;
-        const displayName = company.name;
-        // API uses plural paths (labels/, masters/) but website uses singular (label/, master/)
-        const discogsHref = company.resource_url
-            .replace(/https:\/\/api\.discogs\.com\/(\w+?)s\/(\d+)/, 'https://www.discogs.com/$1/$2');
-
-        async function fetchMbEntityInfo(mbUrl) {
-            const mbid = mbUrl.replace(/.*\/(label|place)\//, '');
-            const json = await mbFetch(`//musicbrainz.org/ws/2/${entityType}/${mbid}?fmt=json`);
-            return json ? { name: json.name || null, disambiguation: json.disambiguation || '' }
-                        : { name: null, disambiguation: '' };
-        }
-
-        // 1. IDB cache — use stored name if available (skip when bypassIdb)
-        if (!bypassIdb) {
-            const cachedRec = await checkIdbCache(key);
-            if (cachedRec?.mb_links?.[0]) {
-                const cached = cachedRec.mb_links[0];
-                if (cachedRec.mb_name) {
-                    return { type: 'resolved', entityType, entity: company, displayName, discogsHref,
-                             mbUrl: cached, mbName: cachedRec.mb_name, mbDisambig: cachedRec.mb_disambiguation || '',
-                             logEntry: { displayName, discogsHref, mbUrl: cached, mbName: cachedRec.mb_name,
-                                         mbDisambig: cachedRec.mb_disambiguation || '', via: 'cache' } };
-                }
-                const info = await fetchMbEntityInfo(cached);
-                if (info.name) {
-                    try { const t=db.transaction(['mblinks'],'readwrite'); t.objectStore('mblinks').put({...cachedRec, mb_name:info.name, mb_disambiguation:info.disambiguation}); } catch(e){}
-                }
-                return { type: 'resolved', entityType, entity: company, displayName, discogsHref,
-                         mbUrl: cached, mbName: info.name, mbDisambig: info.disambiguation,
-                         logEntry: { displayName, discogsHref, mbUrl: cached, mbName: info.name,
-                                     mbDisambig: info.disambiguation, via: 'cache' } };
-            }
-        }
-
-        // 2. Name search
-        const nameJson = await mbFetch(
-            `//musicbrainz.org/ws/2/${entityType}?query=${encodeURIComponent(searchName)}&fmt=json&limit=8`
-        );
-        const resultKey = entityType === 'label' ? 'labels' : 'places';
-        const normalized = searchName.toLowerCase().trim();
-        const nameSearchFailed2 = nameJson === null;
-        const nameMatches = !(nameJson?.[resultKey]) ? [] : nameJson[resultKey]
-            .filter(a => a.name.toLowerCase().trim() === normalized || (a.score != null && a.score >= 70))
-            .map(a => ({ id: a.id, name: a.name, disambiguation: a.disambiguation || a['disambiguation-comment'] || '', score: a.score || 0 }));
-
-        const exactMatches = nameMatches.filter(a => a.name.toLowerCase().trim() === normalized);
-        if (exactMatches.length === 1) {
-            const a = exactMatches[0];
-            const mbUrl = `//musicbrainz.org/${entityType}/${a.id}`;
-            if (key) {
-                try {
-                    const tx = db.transaction(['mblinks'], 'readwrite');
-                    tx.objectStore('mblinks').put({ discogs_id: key, mb_links: [mbUrl] });
-                } catch(e) {}
-            }
-            if (key) try { const t=db.transaction(['mblinks'],'readwrite'); t.objectStore('mblinks').put({discogs_id:key, mb_links:[mbUrl], mb_name:a.name, mb_disambiguation:a.disambiguation||''}); } catch(e){}
-            return { type: 'resolved', entityType, entity: company, displayName, discogsHref,
-                     mbUrl, mbName: a.name, mbDisambig: a.disambiguation,
-                     logEntry: { displayName, discogsHref, mbUrl, mbName: a.name,
-                                 mbDisambig: a.disambiguation, via: 'name' } };
-        }
-
-        // 3. URL lookup — for places also try label-rels (facilities are often stored as labels in MB)
-        const incRels = entityType === 'place' ? 'place-rels+label-rels' : `${entityType}-rels`;
-        const urlJson = parsed ? await mbFetch(
-            `//musicbrainz.org/ws/2/url?resource=${encodeURIComponent(parsed.cleanUrl)}&inc=${incRels}&fmt=json`
-        ) : null;
-        if (urlJson?.relations?.length > 0) {
-            const rel = urlJson.relations.find(r => r[entityType] || r['label'] || r['place']);
-            if (rel) {
-                const actualEt = rel[entityType] ? entityType : (rel['label'] ? 'label' : 'place');
-                const a = rel[actualEt];
-                const mbUrl = `//musicbrainz.org/${actualEt}/${a.id}`;
-                const info = a.name ? a : await fetchMbEntityInfo(mbUrl);
-                return { type: 'resolved', entityType: actualEt, entity: company, displayName, discogsHref,
-                         mbUrl, mbName: info.name || a.name, mbDisambig: info.disambiguation || '',
-                         logEntry: { displayName, discogsHref, mbUrl,
-                                     mbName: info.name || a.name, mbDisambig: info.disambiguation || '', via: 'url' } };
-            }
-        }
-
-        return { type: 'attention', entityType, entity: company, displayName, discogsHref, nameMatches };
-    }
-
-    return (async () => {
-        const queue   = companies.map((c, i) => ({ company: c, index: i }));
-        const results = [];
-        // Use index from queue item instead of resource_url Map (avoids collision for duplicate URLs)
-        const resultArr = new Array(companies.length);
-        setProgress();
-
-        async function worker(slotIndex) {
-            await delay(slotIndex * MIN_GAP_MS);
-            while (queue.length > 0) {
-                const _item = queue.shift();
-                const company = _item.company || _item;
-                const _cIdx = _item.index ?? -1;
-                inFlightNames.add(company.name);
-                setProgress();
-                const result = await checkOne(company);
-                if (result && _cIdx >= 0) resultArr[_cIdx] = result;
-                inFlightNames.delete(company.name);
-                done++;
-                setProgress();
-            }
-        }
-
-        const slots = Math.min(CONCURRENCY, companies.length);
-        if (slots > 0) await Promise.all(Array.from({ length: slots }, (_, i) => worker(i)));
-        return { allResults: resultArr.filter(Boolean) };
-    })();
+    return { allResults: results.filter(Boolean) };
 }
+
+/** `kindOf` helper for artists — always `'artist'`. */
+export const ARTIST_KIND = () => 'artist';
+
+/** `kindOf` helper for Discogs companies — maps via ENTITY_TYPE_MAP. */
+export const COMPANY_KIND = c => ENTITY_TYPE_MAP[c.entity_type_name]?.entityType ?? null;

--- a/userscripts/discogs_credits/src/ui-bar.js
+++ b/userscripts/discogs_credits/src/ui-bar.js
@@ -33,8 +33,9 @@ import {
     getArtistRoles,
 }                                        from './mappers.js';
 import {
-    checkMissingArtists,
-    checkMissingCompanies,
+    resolveAll,
+    ARTIST_KIND,
+    COMPANY_KIND,
 }                                        from './preflight.js';
 import { showReviewTable }               from './review-table.js';
 import { instantFillRelationships }      from './dispatch.js';
@@ -634,8 +635,18 @@ function runImport(discogsUrl, processTracklist, applyToTracks, createWorks) {
                 _logs.appendChild(companyProgressLi);
 
                 return Promise.all([
-                    checkMissingArtists(uniqueArtists, artistProgressLi, bypassIdb),
-                    checkMissingCompanies(uniqueCompanies, companyProgressLi, bypassIdb),
+                    resolveAll(uniqueArtists, {
+                        progressLi:    artistProgressLi,
+                        bypassIdb,
+                        progressLabel: 'Checking artists against MusicBrainz',
+                        kindOf:        ARTIST_KIND,
+                    }),
+                    resolveAll(uniqueCompanies, {
+                        progressLi:    companyProgressLi,
+                        bypassIdb,
+                        progressLabel: 'Checking labels/places against MusicBrainz',
+                        kindOf:        COMPANY_KIND,
+                    }),
                 ]).then(([artistResults, companyResults]) => {
                     const allResults = [...artistResults.allResults, ...companyResults.allResults].filter(Boolean);
                     // Save to cache (only if not bypassing)


### PR DESCRIPTION
Refs #32 — proposal A.5 (the structural collapse mentioned in `dev/ANALYSIS.md §2.3`).

**Stacked on #40** (`refactor-log-api`) — needs that one to merge first so the diff stays clean. Targeting `refactor-log-api` rather than `refactor` for that reason.

## What

The two near-duplicate resolvers (`checkMissingArtists`, `checkMissingCompanies`, ~350 lines combined, 90% identical body) fold into:

```js
resolveEntity(entity, kind, opts)   // 3-strategy resolve for ONE entity
resolveAll(entities, opts)           // concurrency-5 pool runner
```

`kind` is `'artist' | 'label' | 'place'`. `opts.kindOf(entity)` decides per-entity — artists return `'artist'`; companies map via `ENTITY_TYPE_MAP[entity.entity_type_name].entityType`, or `null` to skip an unmapped one.

Two thin `kindOf` helpers exported for callers:

```js
export const ARTIST_KIND  = () => 'artist';
export const COMPANY_KIND = c => ENTITY_TYPE_MAP[c.entity_type_name]?.entityType ?? null;
```

Per-kind tweaks live in a tiny `KIND_TABLE`:

| kind | search limit | result key | inc-rels |
|---|---:|---|---|
| `artist` | 10 | `artists` | `artist-rels` |
| `label`  | 8  | `labels`  | `label-rels` |
| `place`  | 8  | `places`  | `place-rels+label-rels` |

The "place may resolve to a label" edge case (MB editors sometimes file a facility as a label) is one branch in `resolveEntity` instead of duplicated logic.

## Behaviour preserved

- Same 3-strategy chain (IDB → name → URL).
- Same result shapes (`{type: 'resolved'|'attention', ...}`).
- Per-artist `rateLimited` field still set (companies never had it).
- Same IDB writeback on every successful resolve.

## Bundle size

- Before: ~154 KB.
- After:  ~147 KB.

About 7 KB shrinkage from the dedup. `preflight.js` source: 350 → 200 lines.

## Test plan

- [x] `pnpm run verify` — green.
- [x] Smoke fixture (Spiritual Jazz: 95 staged rels) — green. Top staged distribution identical to pre-collapse run.

## Out of scope

- The next-listed §2.3 item — splitting `instantFillRelationships` into four named children — is a separate chunk.
- `_releaseDataCache` + `_urlCheckSessionCache` unification into one `sessionCache` (§2.3) — also separate.
