### PR TITLE
IDB schema v2 + parallel auto-match with disagreement detection

### DIFF
--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -1785,12 +1785,13 @@
     if (!bypassIdb && key) {
       const cachedRec = await readIdbRecord(key);
       if (cachedRec?.mbid && cachedRec?.entityType) {
+        const via2 = cachedRec.resolvedVia || "cache";
         if (cachedRec.name) {
           return buildResolved(
             cachedRec.mbUrl,
             cachedRec.name,
             cachedRec.disambiguation || "",
-            "cache",
+            via2,
             cachedRec.entityType
           );
         }
@@ -1805,7 +1806,7 @@
           cachedRec.mbUrl,
           info.name,
           info.disambiguation,
-          "cache",
+          via2,
           cachedRec.entityType
         );
       }
@@ -2032,6 +2033,27 @@
         }
         urlCheckRunning--;
       }
+      const VIA_LABELS = {
+        both: { text: "name+url", color: "#2a7" },
+        // green — high confidence
+        url: { text: "url", color: "#46a" },
+        // blue
+        name: { text: "name", color: "#46a" },
+        // blue
+        user: { text: "user", color: "#777" },
+        // grey
+        cache: { text: "cache", color: "#777" }
+        // grey (legacy records)
+      };
+      function makeViaBadge(via) {
+        const cfg = VIA_LABELS[via];
+        if (!cfg) return null;
+        const span = document.createElement("span");
+        span.textContent = cfg.text;
+        span.title = `Resolved via ${via}`;
+        span.style.cssText = `font-size:0.68rem;background:#f5f5f5;color:${cfg.color};padding:0 0.35rem;border-radius:8px;border:1px solid #ddd;flex-shrink:0;`;
+        return span;
+      }
       const panel = document.createElement("div");
       panel.style.cssText = "border:2px solid #c8a000;border-radius:0.5rem;background:#fffef5;padding:1rem 1.5rem;margin:0.5rem 0;";
       {
@@ -2114,7 +2136,8 @@
           mbUrl: initMbUrl,
           mbName: initMbName,
           mbDisambig: initMbDisam,
-          confirmed: isResolved && !needsAttention
+          confirmed: isResolved && !needsAttention,
+          via: isResolved ? r.logEntry?.via || r.via || null : null
         });
         const tdDiscogs = document.createElement("td");
         tdDiscogs.style.cssText = `padding:0.3rem 0.5rem;border:1px solid ${borderColor};white-space:nowrap;`;
@@ -2183,7 +2206,7 @@
         tbody.appendChild(tr);
         function setRowResolved(a) {
           const mbUrl = `//musicbrainz.org/${entityType}/${a.id}`;
-          rowState.set(_entityKey, { mbUrl, mbName: a.name, mbDisambig: a.disambiguation || "", confirmed: true });
+          rowState.set(_entityKey, { mbUrl, mbName: a.name, mbDisambig: a.disambiguation || "", confirmed: true, via: "user" });
           const _idbKey = r.entity?.resource_url ? parseDiscogsUrl(r.entity.resource_url)?.key : null;
           if (_idbKey) {
             writeIdbRecord(_idbKey, {
@@ -2213,6 +2236,8 @@
           undoBtn.style.cssText = "font-size:0.75rem;cursor:pointer;padding:0 0.3rem;margin-left:auto;";
           undoBtn.addEventListener("click", () => setRowUnresolved());
           selRow.appendChild(selA);
+          const viaBadge = makeViaBadge("user");
+          if (viaBadge) selRow.appendChild(viaBadge);
           selRow.appendChild(undoBtn);
           candidateList.appendChild(selRow);
           renderActions(a);
@@ -2220,7 +2245,7 @@
           saveCache();
         }
         function setRowUnresolved() {
-          rowState.set(_entityKey, { mbUrl: null, mbName: null, mbDisambig: "", confirmed: false });
+          rowState.set(_entityKey, { mbUrl: null, mbName: null, mbDisambig: "", confirmed: false, via: null });
           tr.style.background = "#ffe0e0";
           searchInput.disabled = false;
           searchBtn.disabled = false;
@@ -2442,7 +2467,7 @@
           const correctedMbUrl = `//musicbrainz.org/${entityType}/${mbid}`;
           const displayName2 = initMbName || mbid;
           if (!initMbName) {
-            rowState.set(_entityKey, { mbUrl: initMbUrl, mbName: null, mbDisambig: "", confirmed: true });
+            rowState.set(_entityKey, { mbUrl: initMbUrl, mbName: null, mbDisambig: "", confirmed: true, via: r.logEntry?.via || r.via || null });
             tr.style.background = "#fff8e1";
           }
           const fakeA = { id: mbid, name: displayName2, disambiguation: initMbDisam };
@@ -2461,6 +2486,9 @@
           undoBtn.style.cssText = "font-size:0.75rem;cursor:pointer;padding:0 0.3rem;margin-left:auto;";
           undoBtn.addEventListener("click", () => setRowUnresolved());
           selRow.appendChild(selA);
+          const initialVia = r.logEntry?.via || r.via;
+          const viaBadge = makeViaBadge(initialVia);
+          if (viaBadge) selRow.appendChild(viaBadge);
           selRow.appendChild(undoBtn);
           candidateList.appendChild(selRow);
           renderActions(fakeA);
@@ -2509,7 +2537,7 @@
         tbl.style.cssText = "border-collapse:collapse;width:100%;font-size:0.78rem;margin:0.4rem 0;";
         const thRow = document.createElement("tr");
         thRow.style.background = "#f5f5f5";
-        ["Discogs entity", "Roles / Tracks", "MB match", "MBID"].forEach((h) => {
+        ["Discogs entity", "Roles / Tracks", "MB match", "MBID", "Resolved via"].forEach((h) => {
           const th = document.createElement("th");
           th.style.cssText = "text-align:left;padding:0.2rem 0.4rem;border:1px solid #ddd;white-space:nowrap;";
           th.textContent = h;
@@ -2531,9 +2559,11 @@
           const rolesText = [...grouped2.entries()].map(([label, tr]) => label + (tr.size ? " [" + [...tr].join(",") + "]" : "")).join("; ");
           const mbid = state.mbUrl ? state.mbUrl.replace(/.*\//, "").replace(/[^a-f0-9-]/gi, "").substring(0, 36) : "";
           const matchText = state.mbName || (state.mbUrl ? mbid : "");
-          [r.displayName || r.entity?.name, rolesText, matchText, mbid].forEach((val, ci) => {
+          const viaCfg = state.via ? VIA_LABELS[state.via] : null;
+          const viaText = viaCfg ? viaCfg.text : state.mbUrl ? "\u2014" : "";
+          [r.displayName || r.entity?.name, rolesText, matchText, mbid, viaText].forEach((val, ci) => {
             const td = document.createElement("td");
-            td.style.cssText = "padding:0.15rem 0.4rem;border:1px solid #ddd;" + (ci === 2 && !val ? "color:#aaa;" : ci === 2 ? "color:#060;" : "");
+            td.style.cssText = "padding:0.15rem 0.4rem;border:1px solid #ddd;" + (ci === 2 && !val ? "color:#aaa;" : ci === 2 ? "color:#060;" : ci === 4 && viaCfg ? `color:${viaCfg.color};` : "");
             if (ci === 2 && mbid) {
               const a = document.createElement("a");
               a.href = "https:" + state.mbUrl;
@@ -3845,7 +3875,7 @@
           uniqueCompanies.push(c);
         }
       });
-      const PREFLIGHT_CACHE_KEY = `discogs-preflight-${discogsUrl2}`;
+      const PREFLIGHT_CACHE_KEY = `discogs-preflight-v2-${discogsUrl2}`;
       const today = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
       let cachedResults = null;
       try {
@@ -3889,6 +3919,10 @@
               // Only save mbName if we actually have it — don't cache null names
               mbName: r.mbName || null,
               mbDisambig: r.mbDisambig || "",
+              // Resolution mechanism (`name`/`url`/`both`/`user`/`cache`) — the
+              // review table surfaces this in both the interactive badge and the
+              // post-import log summary table, so it has to survive the cache.
+              via: r.logEntry?.via || null,
               entity: { resource_url: r.entity?.resource_url, name: r.entity?.name || "", _syntheticKey: r.entity?._syntheticKey || "" }
             }));
             localStorage.setItem(PREFLIGHT_CACHE_KEY, JSON.stringify({ date: today, results: slimResults }));

--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -221,8 +221,11 @@
   }
 
   // src/storage.js
+  var DB_NAME = "mblink";
+  var DB_VERSION = 2;
+  var STORE = "entity_cache";
   var db = null;
-  var _request = indexedDB.open("mblink");
+  var _request = indexedDB.open(DB_NAME, DB_VERSION);
   _request.onerror = function() {
     console.error("Why didn't you allow my web app to use IndexedDB?!");
   };
@@ -231,18 +234,44 @@
   };
   _request.onupgradeneeded = function(event) {
     const upgradeDb = event.target.result;
-    upgradeDb.createObjectStore("mblinks", {
-      keyPath: "discogs_id"
-    });
+    if (!upgradeDb.objectStoreNames.contains(STORE)) {
+      upgradeDb.createObjectStore(STORE, { keyPath: "discogs_id" });
+    }
   };
+  function mbUrlOf(entityType, mbid) {
+    return `//musicbrainz.org/${entityType}/${mbid}`;
+  }
   function readIdbRecord(key) {
     return new Promise((resolve) => {
       if (!key || !db) return resolve(null);
       try {
-        const tx = db.transaction(["mblinks"], "readonly");
-        const req = tx.objectStore("mblinks").get(key);
+        const tx = db.transaction([STORE], "readonly");
+        const req = tx.objectStore(STORE).get(key);
         req.onsuccess = () => resolve(req.result || null);
         req.onerror = () => resolve(null);
+      } catch (e) {
+        resolve(null);
+      }
+    });
+  }
+  function writeIdbRecord(key, partial) {
+    return new Promise((resolve) => {
+      if (!key || !db) return resolve(null);
+      try {
+        const tx = db.transaction([STORE], "readwrite");
+        const store = tx.objectStore(STORE);
+        const getReq = store.get(key);
+        getReq.onsuccess = () => {
+          const existing = getReq.result || {};
+          const merged = { ...existing, ...partial, discogs_id: key, resolvedAt: (/* @__PURE__ */ new Date()).toISOString() };
+          if (merged.mbid && merged.entityType && !partial.mbUrl) {
+            merged.mbUrl = mbUrlOf(merged.entityType, merged.mbid);
+          }
+          const putReq = store.put(merged);
+          putReq.onsuccess = () => resolve(merged);
+          putReq.onerror = () => resolve(null);
+        };
+        getReq.onerror = () => resolve(null);
       } catch (e) {
         resolve(null);
       }
@@ -1721,7 +1750,7 @@
     const searchName = entity.name;
     const displayName = kind === "artist" ? entity.anv && entity.anv.trim() || entity.name : entity.name;
     const discogsHref = entity.resource_url.replace(/https:\/\/api\.discogs\.com\/(\w+?)s\/(\d+)/, "https://www.discogs.com/$1/$2");
-    function buildResolved(mbUrl, mbName, mbDisambig, via, actualKind = kind) {
+    function buildResolved(mbUrl, mbName, mbDisambig, via2, actualKind = kind) {
       return {
         type: "resolved",
         entityType: actualKind,
@@ -1731,35 +1760,64 @@
         mbUrl,
         mbName,
         mbDisambig,
-        logEntry: { displayName, discogsHref, mbUrl, mbName, mbDisambig, via }
+        logEntry: { displayName, discogsHref, mbUrl, mbName, mbDisambig, via: via2 }
       };
     }
-    async function fetchMbEntityInfo(mbUrl) {
-      const m = mbUrl.match(/\/(artist|label|place)\/([a-f0-9-]+)/);
-      if (!m) return { name: null, disambiguation: "" };
-      const json = await mbThrottle.fetchJson(`//musicbrainz.org/ws/2/${m[1]}/${m[2]}?fmt=json`);
+    function buildAttention(nameMatches2, nameSearchFailed2, ambiguityReason) {
+      return {
+        type: "attention",
+        entityType: kind,
+        entity,
+        displayName,
+        discogsHref,
+        nameMatches: nameMatches2 || [],
+        // Only artists track this — used by the review table to badge
+        // entries that failed because of a rate-limited name search vs
+        // entries that genuinely don't exist in MB.
+        rateLimited: kind === "artist" && nameSearchFailed2 && !nameMatches2?.length,
+        ambiguityReason: ambiguityReason || null
+      };
+    }
+    async function fetchMbEntityInfo(et, mbid) {
+      const json = await mbThrottle.fetchJson(`//musicbrainz.org/ws/2/${et}/${mbid}?fmt=json`);
       return json ? { name: json.name || null, disambiguation: json.disambiguation || "" } : { name: null, disambiguation: "" };
     }
     if (!bypassIdb && key) {
       const cachedRec = await readIdbRecord(key);
-      if (cachedRec?.mb_links?.[0]) {
-        const cached = cachedRec.mb_links[0];
-        if (cachedRec.mb_name) {
-          return buildResolved(cached, cachedRec.mb_name, cachedRec.mb_disambiguation || "", "cache");
+      if (cachedRec?.mbid && cachedRec?.entityType) {
+        if (cachedRec.name) {
+          return buildResolved(
+            cachedRec.mbUrl,
+            cachedRec.name,
+            cachedRec.disambiguation || "",
+            "cache",
+            cachedRec.entityType
+          );
         }
-        const info = await fetchMbEntityInfo(cached);
-        if (info.name && db) {
-          try {
-            db.transaction(["mblinks"], "readwrite").objectStore("mblinks").put({ ...cachedRec, mb_name: info.name, mb_disambiguation: info.disambiguation });
-          } catch (e) {
-          }
+        const info = await fetchMbEntityInfo(cachedRec.entityType, cachedRec.mbid);
+        if (info.name) {
+          await writeIdbRecord(key, {
+            name: info.name,
+            disambiguation: info.disambiguation
+          });
         }
-        return buildResolved(cached, info.name, info.disambiguation, "cache");
+        return buildResolved(
+          cachedRec.mbUrl,
+          info.name,
+          info.disambiguation,
+          "cache",
+          cachedRec.entityType
+        );
       }
     }
-    const nameJson = await mbThrottle.fetchJson(
-      `//musicbrainz.org/ws/2/${kind}?query=${encodeURIComponent(searchName)}&fmt=json&limit=${searchLimit}`
-    );
+    const [nameJson, urlJson] = await Promise.all([
+      mbThrottle.fetchJson(
+        `//musicbrainz.org/ws/2/${kind}?query=${encodeURIComponent(searchName)}&fmt=json&limit=${searchLimit}`
+      ),
+      parsed ? mbThrottle.fetchJson(
+        `//musicbrainz.org/ws/2/url?resource=${encodeURIComponent(parsed.cleanUrl)}&inc=${incRels}&fmt=json`
+      ) : Promise.resolve(null)
+    ]);
     const nameSearchFailed = nameJson === null;
     const normalized = searchName.toLowerCase().trim();
     const nameMatches = !nameJson?.[resultKey] ? [] : nameJson[resultKey].filter((a) => a.name.toLowerCase().trim() === normalized || a.score != null && a.score >= 70).map((a) => ({
@@ -1768,51 +1826,68 @@
       disambiguation: a.disambiguation || a["disambiguation-comment"] || "",
       score: a.score || 0
     }));
-    const exactMatches = nameMatches.filter((a) => a.name.toLowerCase().trim() === normalized);
-    if (exactMatches.length === 1) {
-      const a = exactMatches[0];
-      const mbUrl = `//musicbrainz.org/${kind}/${a.id}`;
-      if (key && db) {
-        try {
-          db.transaction(["mblinks"], "readwrite").objectStore("mblinks").put({ discogs_id: key, mb_links: [mbUrl], mb_name: a.name, mb_disambiguation: a.disambiguation || "" });
-        } catch (e) {
-        }
-      }
-      return buildResolved(mbUrl, a.name, a.disambiguation || "", "name");
-    }
-    const urlJson = parsed ? await mbThrottle.fetchJson(
-      `//musicbrainz.org/ws/2/url?resource=${encodeURIComponent(parsed.cleanUrl)}&inc=${incRels}&fmt=json`
-    ) : null;
+    const exactNameMatches = nameMatches.filter((a) => a.name.toLowerCase().trim() === normalized);
+    const nameHit = exactNameMatches.length === 1 ? {
+      kind,
+      mbid: exactNameMatches[0].id,
+      name: exactNameMatches[0].name,
+      disambiguation: exactNameMatches[0].disambiguation || ""
+    } : null;
+    let urlHit = null;
     if (urlJson?.relations?.length > 0) {
       const rel = kind === "place" ? urlJson.relations.find((r) => r.place || r.label) : urlJson.relations.find((r) => r[kind]);
       if (rel) {
         const actualKind = rel[kind] ? kind : rel.label ? "label" : "place";
         const a = rel[actualKind];
-        const mbUrl = `//musicbrainz.org/${actualKind}/${a.id}`;
-        const info = a.name ? a : await fetchMbEntityInfo(mbUrl);
-        const resolvedName = info.name || a.name;
-        const resolvedDisam = info.disambiguation || a.disambiguation || "";
-        if (key && resolvedName && db) {
-          try {
-            db.transaction(["mblinks"], "readwrite").objectStore("mblinks").put({ discogs_id: key, mb_links: [mbUrl], mb_name: resolvedName, mb_disambiguation: resolvedDisam });
-          } catch (e) {
-          }
-        }
-        return buildResolved(mbUrl, resolvedName, resolvedDisam, "url", actualKind);
+        urlHit = {
+          kind: actualKind,
+          mbid: a.id,
+          name: a.name || null,
+          disambiguation: a.disambiguation || ""
+        };
       }
     }
-    return {
-      type: "attention",
-      entityType: kind,
-      entity,
-      displayName,
-      discogsHref,
-      nameMatches,
-      // Only artists track this — used by the review table to badge
-      // entries that failed because of a rate-limited name search vs
-      // entries that genuinely don't exist in MB.
-      rateLimited: kind === "artist" && nameSearchFailed && !nameMatches.length
-    };
+    let resolved = null;
+    let via = null;
+    if (nameHit && urlHit) {
+      if (nameHit.mbid === urlHit.mbid && nameHit.kind === urlHit.kind) {
+        resolved = urlHit;
+        via = "both";
+      } else {
+        return buildAttention(
+          nameMatches,
+          false,
+          `name \u2192 ${nameHit.kind}/${nameHit.mbid}, URL \u2192 ${urlHit.kind}/${urlHit.mbid}`
+        );
+      }
+    } else if (urlHit) {
+      resolved = urlHit;
+      via = "url";
+    } else if (nameHit) {
+      resolved = nameHit;
+      via = "name";
+    }
+    if (resolved) {
+      const mbUrl = `//musicbrainz.org/${resolved.kind}/${resolved.mbid}`;
+      let finalName = resolved.name;
+      let finalDisam = resolved.disambiguation;
+      if (!finalName) {
+        const info = await fetchMbEntityInfo(resolved.kind, resolved.mbid);
+        finalName = info.name || null;
+        finalDisam = info.disambiguation || "";
+      }
+      if (key) {
+        await writeIdbRecord(key, {
+          mbid: resolved.mbid,
+          entityType: resolved.kind,
+          name: finalName,
+          disambiguation: finalDisam || "",
+          resolvedVia: via
+        });
+      }
+      return buildResolved(mbUrl, finalName, finalDisam || "", via, resolved.kind);
+    }
+    return buildAttention(nameMatches, nameSearchFailed);
   }
   async function resolveAll(entities, opts) {
     const { kindOf, progressLi, bypassIdb, progressLabel } = opts;
@@ -1871,8 +1946,8 @@
       try {
         const idbKey = parseDiscogsUrl(rUrl)?.key;
         const rec = await readIdbRecord(idbKey);
-        if (rec?.mb_name) {
-          _preloadedNames.set(rUrl, { name: rec.mb_name, dis: rec.mb_disambiguation || "" });
+        if (rec?.name) {
+          _preloadedNames.set(rUrl, { name: rec.name, dis: rec.disambiguation || "" });
           continue;
         }
         const mbid = (r.mbUrl || "").split("/").pop().replace(/[^a-f0-9-]/g, "").substring(0, 36);
@@ -1881,14 +1956,16 @@
         const data = await mbThrottle.fetchJson(`https://musicbrainz.org/ws/2/${et}/${mbid}?fmt=json`);
         if (data?.name) {
           _preloadedNames.set(rUrl, { name: data.name, dis: data.disambiguation || "" });
-          if (idbKey && db) try {
-            db.transaction(["mblinks"], "readwrite").objectStore("mblinks").put({
-              discogs_id: idbKey,
-              mb_links: [r.mbUrl],
-              mb_name: data.name,
-              mb_disambiguation: data.disambiguation || ""
+          if (idbKey) {
+            await writeIdbRecord(idbKey, {
+              mbid,
+              entityType: et,
+              name: data.name,
+              disambiguation: data.disambiguation || ""
+              // No resolvedVia change — this is just a name-display
+              // populate; whatever set the cached mbid stays the
+              // source of truth for `resolvedVia`.
             });
-          } catch (e) {
           }
         }
       } catch (e) {
@@ -2108,12 +2185,15 @@
           const mbUrl = `//musicbrainz.org/${entityType}/${a.id}`;
           rowState.set(_entityKey, { mbUrl, mbName: a.name, mbDisambig: a.disambiguation || "", confirmed: true });
           const _idbKey = r.entity?.resource_url ? parseDiscogsUrl(r.entity.resource_url)?.key : null;
-          if (_idbKey && db) {
-            try {
-              const _tx = db.transaction(["mblinks"], "readwrite");
-              _tx.objectStore("mblinks").put({ discogs_id: _idbKey, mb_links: [mbUrl], mb_name: a.name, mb_disambiguation: a.disambiguation || "" });
-            } catch (e2) {
-            }
+          if (_idbKey) {
+            writeIdbRecord(_idbKey, {
+              mbid: a.id,
+              entityType,
+              name: a.name,
+              disambiguation: a.disambiguation || "",
+              resolvedVia: "user"
+              // user picked this in the review table
+            });
           }
           tr.style.background = "#f0fff0";
           searchInput.disabled = true;
@@ -2835,18 +2915,13 @@
       return null;
     }
     async function getMbidForEntity(entity, entityType) {
-      return new Promise((resolve, reject) => {
-        const key = parseDiscogsUrl(entity.resource_url)?.key;
-        if (!key) return reject(`No Discogs key for ${entity.name}`);
-        const tx = db.transaction(["mblinks"], "readonly");
-        const req = tx.objectStore("mblinks").get(key);
-        req.onsuccess = () => {
-          const mbUrl = req.result?.mb_links?.[0];
-          if (mbUrl) resolve(mbUrl);
-          else reject(`${entity.name} not in IDB cache \u2014 run pre-flight check first`);
-        };
-        req.onerror = () => reject(`IDB error for ${entity.name}`);
-      });
+      const key = parseDiscogsUrl(entity.resource_url)?.key;
+      if (!key) throw new Error(`No Discogs key for ${entity.name}`);
+      const rec = await readIdbRecord(key);
+      if (!rec?.mbUrl) {
+        throw new Error(`${entity.name} not in IDB cache \u2014 run pre-flight check first`);
+      }
+      return rec.mbUrl;
     }
     function relAlreadyExists(sourceEntity, linkTypeID, targetGid, attrTree) {
       const rels = sourceEntity?.relationships;
@@ -3854,25 +3929,12 @@
         confirmedMap.forEach((mbUrl, resourceUrl) => {
           const key = parseDiscogsUrl(resourceUrl)?.key;
           if (!key) return;
-          cachePromises.push(new Promise((res) => {
-            try {
-              const tx = db.transaction(["mblinks"], "readwrite");
-              tx.oncomplete = res;
-              tx.onerror = res;
-              const store = tx.objectStore("mblinks");
-              const readReq = store.get(key);
-              readReq.onsuccess = () => {
-                const prev = readReq.result || {};
-                store.put({
-                  ...prev,
-                  discogs_id: key,
-                  mb_links: [mbUrl]
-                });
-              };
-              readReq.onerror = () => store.put({ discogs_id: key, mb_links: [mbUrl] });
-            } catch (e) {
-              res();
-            }
+          const m = mbUrl.match(/\/(artist|label|place)\/([a-f0-9-]+)/);
+          if (!m) return;
+          cachePromises.push(writeIdbRecord(key, {
+            mbid: m[2],
+            entityType: m[1]
+            // No resolvedVia change — the inline write owns it.
           }));
         });
         return Promise.all(cachePromises);

--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -343,9 +343,6 @@
       return json;
     });
   }
-  function clearReleaseDataCache(url) {
-    _releaseDataCache.delete(url);
-  }
 
   // src/data/entity-map.js
   var ENTITY_TYPE_MAP = {
@@ -1750,7 +1747,7 @@
     const searchName = entity.name;
     const displayName = kind === "artist" ? entity.anv && entity.anv.trim() || entity.name : entity.name;
     const discogsHref = entity.resource_url.replace(/https:\/\/api\.discogs\.com\/(\w+?)s\/(\d+)/, "https://www.discogs.com/$1/$2");
-    function buildResolved(mbUrl, mbName, mbDisambig, via2, actualKind = kind) {
+    function buildResolved(mbUrl, mbName, mbDisambig, via2, actualKind = kind, fromCache = false) {
       return {
         type: "resolved",
         entityType: actualKind,
@@ -1760,7 +1757,14 @@
         mbUrl,
         mbName,
         mbDisambig,
-        logEntry: { displayName, discogsHref, mbUrl, mbName, mbDisambig, via: via2 }
+        // `via`      — the resolution mechanism (`name` / `url` / `both` / `user`,
+        //              or `cache` only when a legacy IDB record predates the
+        //              `resolvedVia` field and we genuinely can't recover it).
+        // `fromCache`— whether THIS resolution came from IDB rather than a fresh
+        //              MB lookup. The two are orthogonal: a name-resolved entity
+        //              loaded from cache is `via='name'` + `fromCache=true`, and
+        //              the UI surfaces both as `name (cache)`.
+        logEntry: { displayName, discogsHref, mbUrl, mbName, mbDisambig, via: via2, fromCache }
       };
     }
     function buildAttention(nameMatches2, nameSearchFailed2, ambiguityReason) {
@@ -1792,7 +1796,8 @@
             cachedRec.name,
             cachedRec.disambiguation || "",
             via2,
-            cachedRec.entityType
+            cachedRec.entityType,
+            true
           );
         }
         const info = await fetchMbEntityInfo(cachedRec.entityType, cachedRec.mbid);
@@ -1807,7 +1812,8 @@
           info.name,
           info.disambiguation,
           via2,
-          cachedRec.entityType
+          cachedRec.entityType,
+          true
         );
       }
     }
@@ -1937,9 +1943,7 @@
   async function showReviewTable(allResults, rolesMap, companiesRolesMap, opts) {
     rolesMap = rolesMap || /* @__PURE__ */ new Map();
     companiesRolesMap = companiesRolesMap || /* @__PURE__ */ new Map();
-    const isFromCache = opts?.isFromCache || false;
-    const cacheKey = opts?.cacheKey || null;
-    const onRefresh = opts?.onRefresh || null;
+    void opts;
     const _preloadedNames = /* @__PURE__ */ new Map();
     const _nullNames = allResults.filter((r) => r.type === "resolved" && r.mbUrl && !r.mbName);
     for (const r of _nullNames) {
@@ -1973,35 +1977,6 @@
       }
     }
     return new Promise((resolve) => {
-      let tableReady = false;
-      function saveCache() {
-        if (!tableReady) return;
-        if (!cacheKey) return;
-        try {
-          const today2 = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
-          const slim = allResults.map((r) => {
-            const eKey = r.entity?.resource_url || r.entity?._syntheticKey || `_nourl_${r.entity?.name || r.displayName}`;
-            const s = rowState.get(eKey);
-            const mbUrl = s?.mbUrl || r.mbUrl || null;
-            const mbName = s?.mbName || r.mbName || null;
-            return {
-              type: mbUrl ? "resolved" : "attention",
-              entityType: r.entityType || "artist",
-              displayName: r.displayName || r.entity?.name || "",
-              discogsHref: r.discogsHref || "",
-              rateLimited: mbUrl ? false : r.rateLimited || false,
-              nameMatches: mbUrl ? [] : (r.nameMatches || []).slice(0, 5),
-              mbUrl,
-              mbName: mbName || r.mbName || null,
-              mbDisambig: s?.mbDisambig || r.mbDisambig || "",
-              entity: { resource_url: r.entity?.resource_url, name: r.entity?.name || "", _syntheticKey: r.entity?._syntheticKey || "" }
-            };
-          });
-          localStorage.setItem(cacheKey, JSON.stringify({ date: today2, results: slim }));
-        } catch (e) {
-          console.warn("Discogs importer: saveCache failed", e);
-        }
-      }
       const rowState = /* @__PURE__ */ new Map();
       const attentionCount = allResults.filter((r) => r.type === "attention").length;
       const mismatchCount = allResults.filter((r) => {
@@ -2033,7 +2008,7 @@
         }
         urlCheckRunning--;
       }
-      const VIA_LABELS = {
+      const VIA_STYLES = {
         both: { text: "name+url", color: "#2a7" },
         // green — high confidence
         url: { text: "url", color: "#46a" },
@@ -2043,14 +2018,22 @@
         user: { text: "user", color: "#777" },
         // grey
         cache: { text: "cache", color: "#777" }
-        // grey (legacy records)
+        // grey (legacy: original mechanism unknown)
       };
-      function makeViaBadge(via) {
-        const cfg = VIA_LABELS[via];
+      function viaCfg(via, fromCache) {
+        const base = VIA_STYLES[via];
+        if (!base) return null;
+        if (fromCache && via !== "cache") {
+          return { text: `${base.text} (cache)`, color: base.color };
+        }
+        return base;
+      }
+      function makeViaBadge(via, fromCache) {
+        const cfg = viaCfg(via, fromCache);
         if (!cfg) return null;
         const span = document.createElement("span");
         span.textContent = cfg.text;
-        span.title = `Resolved via ${via}`;
+        span.title = fromCache && via !== "cache" ? `Resolved via ${via}, served from cache` : `Resolved via ${via}`;
         span.style.cssText = `font-size:0.68rem;background:#f5f5f5;color:${cfg.color};padding:0 0.35rem;border-radius:8px;border:1px solid #ddd;flex-shrink:0;`;
         return span;
       }
@@ -2067,34 +2050,11 @@
         if (_r2) _r2.style.marginTop = "";
       }
       const heading = document.createElement("div");
-      heading.style.cssText = `display:flex;align-items:center;gap:0.6rem;margin:0 0 0.5rem;padding:0.4rem 0.6rem;border-radius:0.3rem;` + (isFromCache ? "background:#ddeeff;border:1px solid #88aacc;" : "background:#f5e8a0;border:1px solid #d4b800;");
+      heading.style.cssText = "display:flex;align-items:center;gap:0.6rem;margin:0 0 0.5rem;padding:0.4rem 0.6rem;border-radius:0.3rem;background:#f5e8a0;border:1px solid #d4b800;";
       const headingText = document.createElement("span");
-      headingText.style.cssText = "font-weight:bold;font-size:1rem;color:#" + (isFromCache ? "003366" : "5a4000") + ";flex:1;";
-      headingText.textContent = `Review \u2014 ${allResults.length} entit${allResults.length === 1 ? "y" : "ies"}` + (isFromCache ? " (cached)" : "");
+      headingText.style.cssText = "font-weight:bold;font-size:1rem;color:#5a4000;flex:1;";
+      headingText.textContent = `Review \u2014 ${allResults.length} entit${allResults.length === 1 ? "y" : "ies"}`;
       heading.appendChild(headingText);
-      if (isFromCache) {
-        const refreshBtn = document.createElement("button");
-        refreshBtn.textContent = "\u{1F504} Refresh";
-        refreshBtn.style.cssText = "font-size:0.8rem;cursor:pointer;padding:0.2rem 0.5rem;border:1px solid #88aacc;border-radius:3px;background:#fff;color:#003366;";
-        refreshBtn.title = "Clear cache and re-run pre-flight checks";
-        refreshBtn.addEventListener("click", () => {
-          if (cacheKey) try {
-            localStorage.removeItem(cacheKey);
-          } catch (e) {
-          }
-          (panelLi || panel).remove();
-          if (onRefresh) {
-            onRefresh().then((freshResults) => {
-              showReviewTable(freshResults, rolesMap, companiesRolesMap, {
-                isFromCache: false,
-                cacheKey,
-                onRefresh
-              }).then((confirmedMap) => resolve(confirmedMap));
-            });
-          }
-        });
-        heading.appendChild(refreshBtn);
-      }
       panel.appendChild(heading);
       const intro = document.createElement("p");
       intro.style.cssText = "margin:0 0 0.75rem;font-size:0.85rem;color:#666;";
@@ -2137,7 +2097,8 @@
           mbName: initMbName,
           mbDisambig: initMbDisam,
           confirmed: isResolved && !needsAttention,
-          via: isResolved ? r.logEntry?.via || r.via || null : null
+          via: isResolved ? r.logEntry?.via || null : null,
+          fromCache: isResolved ? r.logEntry?.fromCache || false : false
         });
         const tdDiscogs = document.createElement("td");
         tdDiscogs.style.cssText = `padding:0.3rem 0.5rem;border:1px solid ${borderColor};white-space:nowrap;`;
@@ -2206,7 +2167,7 @@
         tbody.appendChild(tr);
         function setRowResolved(a) {
           const mbUrl = `//musicbrainz.org/${entityType}/${a.id}`;
-          rowState.set(_entityKey, { mbUrl, mbName: a.name, mbDisambig: a.disambiguation || "", confirmed: true, via: "user" });
+          rowState.set(_entityKey, { mbUrl, mbName: a.name, mbDisambig: a.disambiguation || "", confirmed: true, via: "user", fromCache: false });
           const _idbKey = r.entity?.resource_url ? parseDiscogsUrl(r.entity.resource_url)?.key : null;
           if (_idbKey) {
             writeIdbRecord(_idbKey, {
@@ -2236,16 +2197,15 @@
           undoBtn.style.cssText = "font-size:0.75rem;cursor:pointer;padding:0 0.3rem;margin-left:auto;";
           undoBtn.addEventListener("click", () => setRowUnresolved());
           selRow.appendChild(selA);
-          const viaBadge = makeViaBadge("user");
+          const viaBadge = makeViaBadge("user", false);
           if (viaBadge) selRow.appendChild(viaBadge);
           selRow.appendChild(undoBtn);
           candidateList.appendChild(selRow);
           renderActions(a);
           updateImportBtn();
-          saveCache();
         }
         function setRowUnresolved() {
-          rowState.set(_entityKey, { mbUrl: null, mbName: null, mbDisambig: "", confirmed: false, via: null });
+          rowState.set(_entityKey, { mbUrl: null, mbName: null, mbDisambig: "", confirmed: false, via: null, fromCache: false });
           tr.style.background = "#ffe0e0";
           searchInput.disabled = false;
           searchBtn.disabled = false;
@@ -2256,7 +2216,6 @@
           candidateList.appendChild(none);
           renderActions(null);
           updateImportBtn();
-          saveCache();
         }
         function renderActions(selected) {
           tdAction.innerHTML = "";
@@ -2467,7 +2426,7 @@
           const correctedMbUrl = `//musicbrainz.org/${entityType}/${mbid}`;
           const displayName2 = initMbName || mbid;
           if (!initMbName) {
-            rowState.set(_entityKey, { mbUrl: initMbUrl, mbName: null, mbDisambig: "", confirmed: true, via: r.logEntry?.via || r.via || null });
+            rowState.set(_entityKey, { mbUrl: initMbUrl, mbName: null, mbDisambig: "", confirmed: true, via: r.logEntry?.via || null, fromCache: r.logEntry?.fromCache || false });
             tr.style.background = "#fff8e1";
           }
           const fakeA = { id: mbid, name: displayName2, disambiguation: initMbDisam };
@@ -2486,8 +2445,7 @@
           undoBtn.style.cssText = "font-size:0.75rem;cursor:pointer;padding:0 0.3rem;margin-left:auto;";
           undoBtn.addEventListener("click", () => setRowUnresolved());
           selRow.appendChild(selA);
-          const initialVia = r.logEntry?.via || r.via;
-          const viaBadge = makeViaBadge(initialVia);
+          const viaBadge = makeViaBadge(r.logEntry?.via, r.logEntry?.fromCache);
           if (viaBadge) selRow.appendChild(viaBadge);
           selRow.appendChild(undoBtn);
           candidateList.appendChild(selRow);
@@ -2532,7 +2490,6 @@
         rowState.forEach((s, key) => {
           if (s.mbUrl) confirmedMap.set(key, s.mbUrl);
         });
-        saveCache();
         const tbl = document.createElement("table");
         tbl.style.cssText = "border-collapse:collapse;width:100%;font-size:0.78rem;margin:0.4rem 0;";
         const thRow = document.createElement("tr");
@@ -2559,11 +2516,11 @@
           const rolesText = [...grouped2.entries()].map(([label, tr]) => label + (tr.size ? " [" + [...tr].join(",") + "]" : "")).join("; ");
           const mbid = state.mbUrl ? state.mbUrl.replace(/.*\//, "").replace(/[^a-f0-9-]/gi, "").substring(0, 36) : "";
           const matchText = state.mbName || (state.mbUrl ? mbid : "");
-          const viaCfg = state.via ? VIA_LABELS[state.via] : null;
-          const viaText = viaCfg ? viaCfg.text : state.mbUrl ? "\u2014" : "";
+          const vCfg = state.via ? viaCfg(state.via, state.fromCache) : null;
+          const viaText = vCfg ? vCfg.text : state.mbUrl ? "\u2014" : "";
           [r.displayName || r.entity?.name, rolesText, matchText, mbid, viaText].forEach((val, ci) => {
             const td = document.createElement("td");
-            td.style.cssText = "padding:0.15rem 0.4rem;border:1px solid #ddd;" + (ci === 2 && !val ? "color:#aaa;" : ci === 2 ? "color:#060;" : ci === 4 && viaCfg ? `color:${viaCfg.color};` : "");
+            td.style.cssText = "padding:0.15rem 0.4rem;border:1px solid #ddd;" + (ci === 2 && !val ? "color:#aaa;" : ci === 2 ? "color:#060;" : ci === 4 && vCfg ? `color:${vCfg.color};` : "");
             if (ci === 2 && mbid) {
               const a = document.createElement("a");
               a.href = "https:" + state.mbUrl;
@@ -2604,7 +2561,6 @@
       getLogContainer().appendChild(panelLi);
       getLogContainer().scrollIntoView({ behavior: "smooth", block: "nearest" });
       _hideBar();
-      tableReady = true;
     });
   }
 
@@ -3875,17 +3831,7 @@
           uniqueCompanies.push(c);
         }
       });
-      const PREFLIGHT_CACHE_KEY = `discogs-preflight-v2-${discogsUrl2}`;
-      const today = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10);
-      let cachedResults = null;
-      try {
-        const saved = JSON.parse(localStorage.getItem(PREFLIGHT_CACHE_KEY) || "null");
-        if (saved?.date === today && Array.isArray(saved.results)) {
-          cachedResults = saved.results;
-        }
-      } catch (e) {
-      }
-      function runPreflight(bypassIdb) {
+      function runPreflight() {
         const artistProgressLi = document.createElement("li");
         artistProgressLi.textContent = `Checking ${uniqueArtists.length} artist(s) against MusicBrainz\u2026`;
         _logs2.appendChild(artistProgressLi);
@@ -3895,68 +3841,26 @@
         return Promise.all([
           resolveAll(uniqueArtists, {
             progressLi: artistProgressLi,
-            bypassIdb,
             progressLabel: "Checking artists against MusicBrainz",
             kindOf: ARTIST_KIND
           }),
           resolveAll(uniqueCompanies, {
             progressLi: companyProgressLi,
-            bypassIdb,
             progressLabel: "Checking labels/places against MusicBrainz",
             kindOf: COMPANY_KIND
           })
-        ]).then(([artistResults, companyResults]) => {
-          const allResults = [...artistResults.allResults, ...companyResults.allResults].filter(Boolean);
-          if (!bypassIdb) try {
-            const slimResults = allResults.map((r) => ({
-              type: r.type,
-              entityType: r.entityType || "artist",
-              displayName: r.displayName || r.entity?.name || "",
-              discogsHref: r.discogsHref || "",
-              rateLimited: r.rateLimited || false,
-              nameMatches: (r.nameMatches || []).slice(0, 5),
-              mbUrl: r.mbUrl || null,
-              // Only save mbName if we actually have it — don't cache null names
-              mbName: r.mbName || null,
-              mbDisambig: r.mbDisambig || "",
-              // Resolution mechanism (`name`/`url`/`both`/`user`/`cache`) — the
-              // review table surfaces this in both the interactive badge and the
-              // post-import log summary table, so it has to survive the cache.
-              via: r.logEntry?.via || null,
-              entity: { resource_url: r.entity?.resource_url, name: r.entity?.name || "", _syntheticKey: r.entity?._syntheticKey || "" }
-            }));
-            localStorage.setItem(PREFLIGHT_CACHE_KEY, JSON.stringify({ date: today, results: slimResults }));
-          } catch (e) {
-            console.warn("Discogs importer: preflight cache save failed", e);
-          }
-          return allResults;
-        });
+        ]).then(([artistResults, companyResults]) => [...artistResults.allResults, ...companyResults.allResults].filter(Boolean));
       }
       let capturedResults = null;
       let capturedConfirmedMap = null;
-      const preflightPromise = cachedResults ? Promise.resolve(cachedResults) : runPreflight();
-      return preflightPromise.then((allResults) => {
+      return runPreflight().then((allResults) => {
         allResults.forEach((r) => {
           if (!r) return;
           const url = r.entity?.resource_url || r.entity?._syntheticKey;
           if (url) r._roles = rolesMap.get(url) || companiesRolesMap.get(url) || [];
         });
         capturedResults = allResults;
-        return showReviewTable(capturedResults, rolesMap, companiesRolesMap, {
-          isFromCache: !!cachedResults,
-          cacheKey: PREFLIGHT_CACHE_KEY,
-          onRefresh: () => {
-            clearReleaseDataCache(discogsUrl2);
-            return runPreflight(true).then((freshResults) => {
-              freshResults.forEach((r) => {
-                if (!r) return;
-                const url = r.entity?.resource_url || r.entity?._syntheticKey;
-                if (url) r._roles = rolesMap.get(url) || companiesRolesMap.get(url) || [];
-              });
-              return freshResults;
-            });
-          }
-        });
+        return showReviewTable(capturedResults, rolesMap, companiesRolesMap, {});
       }).then((confirmedMap) => {
         capturedConfirmedMap = confirmedMap;
         const cachePromises = [];

--- a/userscripts/discogs_credits/src/dispatch.js
+++ b/userscripts/discogs_credits/src/dispatch.js
@@ -6,7 +6,7 @@
 
 import { log }                  from './log.js';
 import { pageWindow }                   from './constants.js';
-import { db }                            from './storage.js';
+import { readIdbRecord }                  from './storage.js';
 import { parseDiscogsUrl }               from './api-discogs.js';
 import {
     mbThrottle,
@@ -249,20 +249,15 @@ export async function instantFillRelationships(companies, artistRoles, tracklist
         return null;
     }
 
-    // ── Helper: resolve MBID from IDB cache for a Discogs entity ─────────────
+    // ── Helper: resolve MB URL from IDB cache for a Discogs entity ───────────
     async function getMbidForEntity(entity, entityType) {
-        return new Promise((resolve, reject) => {
-            const key = parseDiscogsUrl(entity.resource_url)?.key;
-            if (!key) return reject(`No Discogs key for ${entity.name}`);
-            const tx = db.transaction(['mblinks'], 'readonly');
-            const req = tx.objectStore('mblinks').get(key);
-            req.onsuccess = () => {
-                const mbUrl = req.result?.mb_links?.[0];
-                if (mbUrl) resolve(mbUrl);
-                else reject(`${entity.name} not in IDB cache — run pre-flight check first`);
-            };
-            req.onerror = () => reject(`IDB error for ${entity.name}`);
-        });
+        const key = parseDiscogsUrl(entity.resource_url)?.key;
+        if (!key) throw new Error(`No Discogs key for ${entity.name}`);
+        const rec = await readIdbRecord(key);
+        if (!rec?.mbUrl) {
+            throw new Error(`${entity.name} not in IDB cache — run pre-flight check first`);
+        }
+        return rec.mbUrl;
     }
 
     // ── Helper: does a matching rel already exist on the source entity? ─────

--- a/userscripts/discogs_credits/src/preflight.js
+++ b/userscripts/discogs_credits/src/preflight.js
@@ -3,24 +3,29 @@
 // row per credit with the chosen MBID (or "needs attention") for the user
 // to confirm.
 //
-// Single resolver. The two earlier near-duplicates (`checkMissingArtists`
-// and `checkMissingCompanies`) collapse into one
-// `resolveEntity(entity, kind, opts)` + `resolveAll(entities, opts)`
-// where `opts.kindOf(entity)` decides 'artist' | 'label' | 'place' per
-// entity (null = skip).
+// Single resolver: `resolveEntity(entity, kind, opts)` + the pool runner
+// `resolveAll(entities, opts)`. `opts.kindOf(entity)` decides
+// `'artist' | 'label' | 'place'` per entity (`null` = skip).
 //
-// Lookup strategy per entity (unchanged from the old code):
-//   1. IDB cache (mblinks store)             — instant; populated by prior runs.
-//   2. Name search (`/ws/2/<type>?query=…`)   — single exact match wins.
-//   3. URL relation (`/ws/2/url?resource=…&inc=<entity>-rels`) — fallback
-//      when name search is ambiguous or empty.
+// ── Lookup strategy per entity ─────────────────────────────────────────────
+//   1. IDB cache (`entity_cache` store) — instant; populated by prior runs.
+//   2. Name search + URL relation run **in parallel**:
+//       - `/ws/2/<type>?query=…&fmt=json`              (search by name)
+//       - `/ws/2/url?resource=<discogsUrl>&inc=<type>-rels`  (URL relation)
+//   3. Decide based on what the two parallel lookups produced:
+//       - name **and** URL agree (same MBID) → `resolvedVia: 'both'`
+//       - URL-only (direct URL relation, strong) → `resolvedVia: 'url'`
+//       - name-only (exact-name single match) → `resolvedVia: 'name'`
+//       - they disagree → unresolved (user reviews; caught a latent bug
+//         where the old code would silently auto-pick one)
+//       - neither hit → unresolved
 //
 // Result shape per entity is one of:
 //   { type: 'resolved',  entity, mbUrl, mbName, mbDisambig, logEntry: {...} }
-//   { type: 'attention', entity, nameMatches: [...]                      }
+//   { type: 'attention', entity, nameMatches: [...] }
 
 import { mbThrottle }                       from './api-mb.js';
-import { db, readIdbRecord }                 from './storage.js';
+import { readIdbRecord, writeIdbRecord }    from './storage.js';
 import { parseDiscogsUrl }                  from './api-discogs.js';
 import { ENTITY_TYPE_MAP }                  from './data/entity-map.js';
 
@@ -36,8 +41,7 @@ const KIND_TABLE = {
 };
 
 /**
- * Resolve a single Discogs entity against MB using the 3-strategy chain
- * (IDB → name search → URL relation).
+ * Resolve a single Discogs entity against MB using the 3-strategy chain.
  *
  *   - `kind`: one of `'artist' | 'label' | 'place'`.
  *   - `opts.bypassIdb`: skip step 1 (for forced refreshes).
@@ -67,11 +71,21 @@ async function resolveEntity(entity, kind, opts) {
         };
     }
 
-    /** Fetch MB entity name/disambiguation for a known MB URL (display only). */
-    async function fetchMbEntityInfo(mbUrl) {
-        const m = mbUrl.match(/\/(artist|label|place)\/([a-f0-9-]+)/);
-        if (!m) return { name: null, disambiguation: '' };
-        const json = await mbThrottle.fetchJson(`//musicbrainz.org/ws/2/${m[1]}/${m[2]}?fmt=json`);
+    function buildAttention(nameMatches, nameSearchFailed, ambiguityReason) {
+        return {
+            type: 'attention', entityType: kind, entity,
+            displayName, discogsHref, nameMatches: nameMatches || [],
+            // Only artists track this — used by the review table to badge
+            // entries that failed because of a rate-limited name search vs
+            // entries that genuinely don't exist in MB.
+            rateLimited: kind === 'artist' && nameSearchFailed && !(nameMatches?.length),
+            ambiguityReason: ambiguityReason || null,
+        };
+    }
+
+    /** Fetch MB entity name/disambiguation for a known MB type+MBID (display only). */
+    async function fetchMbEntityInfo(et, mbid) {
+        const json = await mbThrottle.fetchJson(`//musicbrainz.org/ws/2/${et}/${mbid}?fmt=json`);
         return json
             ? { name: json.name || null, disambiguation: json.disambiguation || '' }
             : { name: null, disambiguation: '' };
@@ -80,27 +94,38 @@ async function resolveEntity(entity, kind, opts) {
     // ── 1. IDB cache ─────────────────────────────────────────────────────────
     if (!bypassIdb && key) {
         const cachedRec = await readIdbRecord(key);
-        if (cachedRec?.mb_links?.[0]) {
-            const cached = cachedRec.mb_links[0];
-            if (cachedRec.mb_name) {
-                return buildResolved(cached, cachedRec.mb_name, cachedRec.mb_disambiguation || '', 'cache');
+        if (cachedRec?.mbid && cachedRec?.entityType) {
+            // Cache has an MBID. If the display name is also present, return now.
+            if (cachedRec.name) {
+                return buildResolved(cachedRec.mbUrl, cachedRec.name,
+                                     cachedRec.disambiguation || '', 'cache',
+                                     cachedRec.entityType);
             }
-            const info = await fetchMbEntityInfo(cached);
-            if (info.name && db) {
-                try {
-                    db.transaction(['mblinks'], 'readwrite')
-                      .objectStore('mblinks')
-                      .put({ ...cachedRec, mb_name: info.name, mb_disambiguation: info.disambiguation });
-                } catch(e) { /* ignore — best-effort cache populate */ }
+            // Name missing — fetch it once, write back, return.
+            const info = await fetchMbEntityInfo(cachedRec.entityType, cachedRec.mbid);
+            if (info.name) {
+                await writeIdbRecord(key, {
+                    name: info.name,
+                    disambiguation: info.disambiguation,
+                });
             }
-            return buildResolved(cached, info.name, info.disambiguation, 'cache');
+            return buildResolved(cachedRec.mbUrl, info.name, info.disambiguation,
+                                 'cache', cachedRec.entityType);
         }
     }
 
-    // ── 2. Name search ──────────────────────────────────────────────────────
-    const nameJson = await mbThrottle.fetchJson(
-        `//musicbrainz.org/ws/2/${kind}?query=${encodeURIComponent(searchName)}&fmt=json&limit=${searchLimit}`
-    );
+    // ── 2 + 3. Name search AND URL relation, in parallel ────────────────────
+    const [nameJson, urlJson] = await Promise.all([
+        mbThrottle.fetchJson(
+            `//musicbrainz.org/ws/2/${kind}?query=${encodeURIComponent(searchName)}&fmt=json&limit=${searchLimit}`
+        ),
+        parsed ? mbThrottle.fetchJson(
+            `//musicbrainz.org/ws/2/url?resource=${encodeURIComponent(parsed.cleanUrl)}&inc=${incRels}&fmt=json`
+        ) : Promise.resolve(null),
+    ]);
+
+    // Name search — collect everything for the review table; pick a single
+    // exact-match (case-insensitive) as the auto-resolve candidate.
     const nameSearchFailed = nameJson === null;
     const normalized = searchName.toLowerCase().trim();
     const nameMatches = !(nameJson?.[resultKey]) ? [] : nameJson[resultKey]
@@ -111,55 +136,87 @@ async function resolveEntity(entity, kind, opts) {
             disambiguation: a.disambiguation || a['disambiguation-comment'] || '',
             score: a.score || 0,
         }));
-    const exactMatches = nameMatches.filter(a => a.name.toLowerCase().trim() === normalized);
-    if (exactMatches.length === 1) {
-        const a = exactMatches[0];
-        const mbUrl = `//musicbrainz.org/${kind}/${a.id}`;
-        if (key && db) {
-            try {
-                db.transaction(['mblinks'], 'readwrite')
-                  .objectStore('mblinks')
-                  .put({ discogs_id: key, mb_links: [mbUrl], mb_name: a.name, mb_disambiguation: a.disambiguation || '' });
-            } catch(e) { /* ignore duplicate */ }
-        }
-        return buildResolved(mbUrl, a.name, a.disambiguation || '', 'name');
-    }
+    const exactNameMatches = nameMatches.filter(a => a.name.toLowerCase().trim() === normalized);
+    const nameHit = exactNameMatches.length === 1 ? {
+        kind,
+        mbid:           exactNameMatches[0].id,
+        name:           exactNameMatches[0].name,
+        disambiguation: exactNameMatches[0].disambiguation || '',
+    } : null;
 
-    // ── 3. URL relation ─────────────────────────────────────────────────────
-    const urlJson = parsed ? await mbThrottle.fetchJson(
-        `//musicbrainz.org/ws/2/url?resource=${encodeURIComponent(parsed.cleanUrl)}&inc=${incRels}&fmt=json`
-    ) : null;
+    // URL relation — extract the first matching rel (kind-specific; places
+    // also accept label rels because MB editors often file a facility as a
+    // label rather than a place).
+    let urlHit = null;
     if (urlJson?.relations?.length > 0) {
-        // For places, accept either place or label rels (facility-as-label edge case).
         const rel = kind === 'place'
             ? urlJson.relations.find(r => r.place || r.label)
             : urlJson.relations.find(r => r[kind]);
         if (rel) {
             const actualKind = rel[kind] ? kind : (rel.label ? 'label' : 'place');
             const a = rel[actualKind];
-            const mbUrl = `//musicbrainz.org/${actualKind}/${a.id}`;
-            const info = a.name ? a : await fetchMbEntityInfo(mbUrl);
-            const resolvedName = info.name || a.name;
-            const resolvedDisam = info.disambiguation || a.disambiguation || '';
-            if (key && resolvedName && db) {
-                try {
-                    db.transaction(['mblinks'], 'readwrite')
-                      .objectStore('mblinks')
-                      .put({ discogs_id: key, mb_links: [mbUrl], mb_name: resolvedName, mb_disambiguation: resolvedDisam });
-                } catch(e) { /* ignore */ }
-            }
-            return buildResolved(mbUrl, resolvedName, resolvedDisam, 'url', actualKind);
+            urlHit = {
+                kind:           actualKind,
+                mbid:           a.id,
+                name:           a.name || null,
+                disambiguation: a.disambiguation || '',
+            };
         }
     }
 
-    return {
-        type: 'attention', entityType: kind, entity,
-        displayName, discogsHref, nameMatches,
-        // Only artists track this — used by the review table to badge
-        // entries that failed because of a rate-limited name search vs
-        // entries that genuinely don't exist in MB.
-        rateLimited: kind === 'artist' && nameSearchFailed && !nameMatches.length,
-    };
+    // ── 4. Decide ───────────────────────────────────────────────────────────
+    let resolved = null;
+    let via      = null;
+    if (nameHit && urlHit) {
+        if (nameHit.mbid === urlHit.mbid && nameHit.kind === urlHit.kind) {
+            // Both lookups returned the same MBID — highest confidence.
+            // Prefer the URL hit's `kind` (it's authoritative for the
+            // place-resolved-as-label case).
+            resolved = urlHit;
+            via      = 'both';
+        } else {
+            // Disagreement — needs user review. The old code silently picked
+            // whichever came first (always name, because the URL lookup was
+            // a fall-through); this is the latent bug that issue #32
+            // proposal E fixes.
+            return buildAttention(
+                nameMatches, false,
+                `name → ${nameHit.kind}/${nameHit.mbid}, URL → ${urlHit.kind}/${urlHit.mbid}`
+            );
+        }
+    } else if (urlHit) {
+        resolved = urlHit;
+        via      = 'url';
+    } else if (nameHit) {
+        resolved = nameHit;
+        via      = 'name';
+    }
+
+    if (resolved) {
+        const mbUrl = `//musicbrainz.org/${resolved.kind}/${resolved.mbid}`;
+        let finalName  = resolved.name;
+        let finalDisam = resolved.disambiguation;
+        if (!finalName) {
+            // URL-only hit may lack name/disambiguation — fetch them.
+            const info = await fetchMbEntityInfo(resolved.kind, resolved.mbid);
+            finalName  = info.name || null;
+            finalDisam = info.disambiguation || '';
+        }
+        // Persist to IDB cache for future sessions.
+        if (key) {
+            await writeIdbRecord(key, {
+                mbid:           resolved.mbid,
+                entityType:     resolved.kind,
+                name:           finalName,
+                disambiguation: finalDisam || '',
+                resolvedVia:    via,
+            });
+        }
+        return buildResolved(mbUrl, finalName, finalDisam || '', via, resolved.kind);
+    }
+
+    // Nothing resolved.
+    return buildAttention(nameMatches, nameSearchFailed);
 }
 
 /**

--- a/userscripts/discogs_credits/src/preflight.js
+++ b/userscripts/discogs_credits/src/preflight.js
@@ -95,10 +95,15 @@ async function resolveEntity(entity, kind, opts) {
     if (!bypassIdb && key) {
         const cachedRec = await readIdbRecord(key);
         if (cachedRec?.mbid && cachedRec?.entityType) {
-            // Cache has an MBID. If the display name is also present, return now.
+            // Cache has an MBID. Surface the ORIGINAL `resolvedVia` (how this
+            // record first got resolved — name / url / both / user) so the
+            // review table can show the underlying mechanism rather than the
+            // less-informative `cache`. Records written before resolvedVia
+            // existed fall back to the literal `cache` for clarity.
+            const via = cachedRec.resolvedVia || 'cache';
             if (cachedRec.name) {
                 return buildResolved(cachedRec.mbUrl, cachedRec.name,
-                                     cachedRec.disambiguation || '', 'cache',
+                                     cachedRec.disambiguation || '', via,
                                      cachedRec.entityType);
             }
             // Name missing — fetch it once, write back, return.
@@ -110,7 +115,7 @@ async function resolveEntity(entity, kind, opts) {
                 });
             }
             return buildResolved(cachedRec.mbUrl, info.name, info.disambiguation,
-                                 'cache', cachedRec.entityType);
+                                 via, cachedRec.entityType);
         }
     }
 

--- a/userscripts/discogs_credits/src/preflight.js
+++ b/userscripts/discogs_credits/src/preflight.js
@@ -63,11 +63,18 @@ async function resolveEntity(entity, kind, opts) {
     const discogsHref = entity.resource_url
         .replace(/https:\/\/api\.discogs\.com\/(\w+?)s\/(\d+)/, 'https://www.discogs.com/$1/$2');
 
-    function buildResolved(mbUrl, mbName, mbDisambig, via, actualKind = kind) {
+    function buildResolved(mbUrl, mbName, mbDisambig, via, actualKind = kind, fromCache = false) {
         return {
             type: 'resolved', entityType: actualKind, entity,
             displayName, discogsHref, mbUrl, mbName, mbDisambig,
-            logEntry: { displayName, discogsHref, mbUrl, mbName, mbDisambig, via },
+            // `via`      — the resolution mechanism (`name` / `url` / `both` / `user`,
+            //              or `cache` only when a legacy IDB record predates the
+            //              `resolvedVia` field and we genuinely can't recover it).
+            // `fromCache`— whether THIS resolution came from IDB rather than a fresh
+            //              MB lookup. The two are orthogonal: a name-resolved entity
+            //              loaded from cache is `via='name'` + `fromCache=true`, and
+            //              the UI surfaces both as `name (cache)`.
+            logEntry: { displayName, discogsHref, mbUrl, mbName, mbDisambig, via, fromCache },
         };
     }
 
@@ -95,16 +102,17 @@ async function resolveEntity(entity, kind, opts) {
     if (!bypassIdb && key) {
         const cachedRec = await readIdbRecord(key);
         if (cachedRec?.mbid && cachedRec?.entityType) {
-            // Cache has an MBID. Surface the ORIGINAL `resolvedVia` (how this
-            // record first got resolved — name / url / both / user) so the
-            // review table can show the underlying mechanism rather than the
-            // less-informative `cache`. Records written before resolvedVia
-            // existed fall back to the literal `cache` for clarity.
+            // Cache has an MBID. Preserve the ORIGINAL `resolvedVia` (how this
+            // record first got resolved — `name` / `url` / `both` / `user`) and
+            // set `fromCache: true` separately. The UI composes both into a
+            // label like `name (cache)`. Records written before `resolvedVia`
+            // existed fall back to the literal `cache` (still flagged
+            // `fromCache: true` for symmetry, but the label is just `cache`).
             const via = cachedRec.resolvedVia || 'cache';
             if (cachedRec.name) {
                 return buildResolved(cachedRec.mbUrl, cachedRec.name,
                                      cachedRec.disambiguation || '', via,
-                                     cachedRec.entityType);
+                                     cachedRec.entityType, true);
             }
             // Name missing — fetch it once, write back, return.
             const info = await fetchMbEntityInfo(cachedRec.entityType, cachedRec.mbid);
@@ -115,7 +123,7 @@ async function resolveEntity(entity, kind, opts) {
                 });
             }
             return buildResolved(cachedRec.mbUrl, info.name, info.disambiguation,
-                                 via, cachedRec.entityType);
+                                 via, cachedRec.entityType, true);
         }
     }
 

--- a/userscripts/discogs_credits/src/review-table.js
+++ b/userscripts/discogs_credits/src/review-table.js
@@ -4,7 +4,7 @@
 // `<ul.logs>` element wired by the UI bar; never starts the import until
 // the user explicitly clicks "Start import".
 
-import { db, readIdbRecord }              from './storage.js';
+import { readIdbRecord, writeIdbRecord }   from './storage.js';
 import { mbThrottle, fetchWithRetry }      from './api-mb.js';
 import { parseDiscogsUrl }                 from './api-discogs.js';
 import { guessSortName }                   from './mappers.js';
@@ -38,8 +38,8 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
         try {
             const idbKey = parseDiscogsUrl(rUrl)?.key;
             const rec = await readIdbRecord(idbKey);
-            if (rec?.mb_name) {
-                _preloadedNames.set(rUrl, { name: rec.mb_name, dis: rec.mb_disambiguation || '' });
+            if (rec?.name) {
+                _preloadedNames.set(rUrl, { name: rec.name, dis: rec.disambiguation || '' });
                 continue;
             }
             const mbid = (r.mbUrl || '').split('/').pop().replace(/[^a-f0-9-]/g, '').substring(0, 36);
@@ -47,12 +47,18 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
             const et = r.entityType || 'artist';
             const data = await mbThrottle.fetchJson(`https://musicbrainz.org/ws/2/${et}/${mbid}?fmt=json`);
             if (data?.name) {
-                    _preloadedNames.set(rUrl, { name: data.name, dis: data.disambiguation || '' });
-                    if (idbKey && db) try {
-                        db.transaction(['mblinks'], 'readwrite').objectStore('mblinks').put({
-                            discogs_id: idbKey, mb_links: [r.mbUrl],
-                            mb_name: data.name, mb_disambiguation: data.disambiguation || '' });
-                    } catch(e) {}
+                _preloadedNames.set(rUrl, { name: data.name, dis: data.disambiguation || '' });
+                if (idbKey) {
+                    await writeIdbRecord(idbKey, {
+                        mbid,
+                        entityType:     et,
+                        name:           data.name,
+                        disambiguation: data.disambiguation || '',
+                        // No resolvedVia change — this is just a name-display
+                        // populate; whatever set the cached mbid stays the
+                        // source of truth for `resolvedVia`.
+                    });
+                }
             }
             // No artificial gap — `mbThrottle` paces and backs off on 503.
         } catch(e) {}
@@ -313,11 +319,14 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
                 rowState.set(_entityKey, { mbUrl, mbName: a.name, mbDisambig: a.disambiguation || '', confirmed: true });
                 // Persist to IDB immediately so selection survives even without clicking Start import
                 const _idbKey = r.entity?.resource_url ? parseDiscogsUrl(r.entity.resource_url)?.key : null;
-                if (_idbKey && db) {
-                    try {
-                        const _tx = db.transaction(['mblinks'], 'readwrite');
-                        _tx.objectStore('mblinks').put({ discogs_id: _idbKey, mb_links: [mbUrl], mb_name: a.name, mb_disambiguation: a.disambiguation || '' });
-                    } catch(e) {}
+                if (_idbKey) {
+                    writeIdbRecord(_idbKey, {
+                        mbid:           a.id,
+                        entityType,
+                        name:           a.name,
+                        disambiguation: a.disambiguation || '',
+                        resolvedVia:    'user',  // user picked this in the review table
+                    });
                 }
 
                 tr.style.background = '#f0fff0';

--- a/userscripts/discogs_credits/src/review-table.js
+++ b/userscripts/discogs_credits/src/review-table.js
@@ -258,10 +258,16 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
             const tr = document.createElement('tr');
             tr.style.cssText = `vertical-align:top;background:${rowBg};`;
 
-            // Initialise rowState
+            // Initialise rowState. `via` carries how the entity got resolved
+            // (`name` / `url` / `both` / `user` / `cache`) — surfaced in the
+            // post-import log summary table so users can audit auto-matches.
+            // Fresh preflight results carry it on `r.logEntry.via`; results
+            // restored from the localStorage preflight cache have it on `r.via`
+            // (logEntry is stripped to keep the cache slim).
             rowState.set(_entityKey, {
                 mbUrl: initMbUrl, mbName: initMbName, mbDisambig: initMbDisam,
                 confirmed: isResolved && !needsAttention,
+                via: isResolved ? (r.logEntry?.via || r.via || null) : null,
             });
 
             // ── Col 1: Discogs ─────────────────────────────────────────────────
@@ -340,7 +346,7 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
             function setRowResolved(a) {
                 // a = { id, name, disambiguation }
                 const mbUrl = `//musicbrainz.org/${entityType}/${a.id}`;
-                rowState.set(_entityKey, { mbUrl, mbName: a.name, mbDisambig: a.disambiguation || '', confirmed: true });
+                rowState.set(_entityKey, { mbUrl, mbName: a.name, mbDisambig: a.disambiguation || '', confirmed: true, via: 'user' });
                 // Persist to IDB immediately so selection survives even without clicking Start import
                 const _idbKey = r.entity?.resource_url ? parseDiscogsUrl(r.entity.resource_url)?.key : null;
                 if (_idbKey) {
@@ -384,7 +390,7 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
             }
 
             function setRowUnresolved() {
-                rowState.set(_entityKey, { mbUrl: null, mbName: null, mbDisambig: '', confirmed: false });
+                rowState.set(_entityKey, { mbUrl: null, mbName: null, mbDisambig: '', confirmed: false, via: null });
                 tr.style.background = '#ffe0e0';
                 searchInput.disabled = false;
                 searchBtn.disabled = false;
@@ -609,7 +615,7 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
                 const displayName2 = initMbName || mbid;
                 if (!initMbName) {
                     // Name was null in cache — keep yellow, IDB pre-load handled before rendering
-                    rowState.set(_entityKey, { mbUrl: initMbUrl, mbName: null, mbDisambig: '', confirmed: true });
+                    rowState.set(_entityKey, { mbUrl: initMbUrl, mbName: null, mbDisambig: '', confirmed: true, via: r.logEntry?.via || r.via || null });
                     tr.style.background = '#fff8e1';
                 }
                 const fakeA = { id: mbid, name: displayName2, disambiguation: initMbDisam };
@@ -626,8 +632,9 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
                 undoBtn.style.cssText = 'font-size:0.75rem;cursor:pointer;padding:0 0.3rem;margin-left:auto;';
                 undoBtn.addEventListener('click', () => setRowUnresolved());
                 selRow.appendChild(selA);
-                // `via` badge — name / url / both / cache (initial auto-match)
-                const initialVia = r.logEntry?.via;
+                // `via` badge — name / url / both / cache (initial auto-match).
+                // Read from logEntry (fresh) or top-level `via` (preflight cache).
+                const initialVia = r.logEntry?.via || r.via;
                 const viaBadge = makeViaBadge(initialVia);
                 if (viaBadge) selRow.appendChild(viaBadge);
                 selRow.appendChild(undoBtn);
@@ -689,7 +696,7 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
             tbl.style.cssText = 'border-collapse:collapse;width:100%;font-size:0.78rem;margin:0.4rem 0;';
             const thRow = document.createElement('tr');
             thRow.style.background = '#f5f5f5';
-            ['Discogs entity', 'Roles / Tracks', 'MB match', 'MBID'].forEach(h => {
+            ['Discogs entity', 'Roles / Tracks', 'MB match', 'MBID', 'Resolved via'].forEach(h => {
                 const th = document.createElement('th');
                 th.style.cssText = 'text-align:left;padding:0.2rem 0.4rem;border:1px solid #ddd;white-space:nowrap;';
                 th.textContent = h;
@@ -713,11 +720,16 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
 
                 const mbid = state.mbUrl ? state.mbUrl.replace(/.*\//, '').replace(/[^a-f0-9-]/gi,'').substring(0,36) : '';
                 const matchText = state.mbName || (state.mbUrl ? mbid : '');
+                // Resolution mechanism, e.g. `name+url`, `url`, `name`, `user`,
+                // `cache` — null when the row was not resolved (skipped).
+                const viaCfg = state.via ? VIA_LABELS[state.via] : null;
+                const viaText = viaCfg ? viaCfg.text : (state.mbUrl ? '—' : '');
 
-                [r.displayName || r.entity?.name, rolesText, matchText, mbid].forEach((val, ci) => {
+                [r.displayName || r.entity?.name, rolesText, matchText, mbid, viaText].forEach((val, ci) => {
                     const td = document.createElement('td');
                     td.style.cssText = 'padding:0.15rem 0.4rem;border:1px solid #ddd;' +
-                        (ci === 2 && !val ? 'color:#aaa;' : ci === 2 ? 'color:#060;' : '');
+                        (ci === 2 && !val ? 'color:#aaa;' : ci === 2 ? 'color:#060;' :
+                         ci === 4 && viaCfg ? `color:${viaCfg.color};` : '');
                     if (ci === 2 && mbid) {
                         const a = document.createElement('a');
                         a.href = 'https:' + state.mbUrl; a.target = '_blank'; a.rel = 'noopener noreferrer nofollow';

--- a/userscripts/discogs_credits/src/review-table.js
+++ b/userscripts/discogs_credits/src/review-table.js
@@ -139,6 +139,30 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
             urlCheckRunning--;
         }
 
+        // ── Helpers shared across rows ─────────────────────────────────────
+        // Small pill that surfaces *how* an entity was resolved — the
+        // `resolvedVia` value (`name`, `url`, `both`, `user`, `cache`) that
+        // preflight records and the IDB cache persists. Lets the user see
+        // at a glance whether they should trust the auto-match without
+        // having to dig into per-row evidence.
+        const VIA_LABELS = {
+            both:  { text: 'name+url', color: '#2a7' }, // green — high confidence
+            url:   { text: 'url',      color: '#46a' }, // blue
+            name:  { text: 'name',     color: '#46a' }, // blue
+            user:  { text: 'user',     color: '#777' }, // grey
+            cache: { text: 'cache',    color: '#777' }, // grey (legacy records)
+        };
+        function makeViaBadge(via) {
+            const cfg = VIA_LABELS[via];
+            if (!cfg) return null;
+            const span = document.createElement('span');
+            span.textContent = cfg.text;
+            span.title = `Resolved via ${via}`;
+            span.style.cssText = `font-size:0.68rem;background:#f5f5f5;color:${cfg.color};` +
+                                 `padding:0 0.35rem;border-radius:8px;border:1px solid #ddd;flex-shrink:0;`;
+            return span;
+        }
+
         // ── Panel shell ────────────────────────────────────────────────────────
         const panel = document.createElement('div');
         panel.style.cssText = 'border:2px solid #c8a000;border-radius:0.5rem;background:#fffef5;padding:1rem 1.5rem;margin:0.5rem 0;';
@@ -347,6 +371,9 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
                 undoBtn.style.cssText = 'font-size:0.75rem;cursor:pointer;padding:0 0.3rem;margin-left:auto;';
                 undoBtn.addEventListener('click', () => setRowUnresolved());
                 selRow.appendChild(selA);
+                // User picked via the dropdown \u2014 always badge as `user`.
+                const viaBadge = makeViaBadge('user');
+                if (viaBadge) selRow.appendChild(viaBadge);
                 selRow.appendChild(undoBtn);
                 candidateList.appendChild(selRow);
 
@@ -599,6 +626,10 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
                 undoBtn.style.cssText = 'font-size:0.75rem;cursor:pointer;padding:0 0.3rem;margin-left:auto;';
                 undoBtn.addEventListener('click', () => setRowUnresolved());
                 selRow.appendChild(selA);
+                // `via` badge — name / url / both / cache (initial auto-match)
+                const initialVia = r.logEntry?.via;
+                const viaBadge = makeViaBadge(initialVia);
+                if (viaBadge) selRow.appendChild(viaBadge);
                 selRow.appendChild(undoBtn);
                 candidateList.appendChild(selRow);
                 renderActions(fakeA);

--- a/userscripts/discogs_credits/src/review-table.js
+++ b/userscripts/discogs_credits/src/review-table.js
@@ -26,9 +26,11 @@ const _urlCheckSessionCache = new Map();
 export async function showReviewTable(allResults, rolesMap, companiesRolesMap, opts) {
     rolesMap = rolesMap || new Map();
     companiesRolesMap = companiesRolesMap || new Map();
-    const isFromCache = opts?.isFromCache || false;
-    const cacheKey = opts?.cacheKey || null;
-    const onRefresh = opts?.onRefresh || null;
+    // `opts` is reserved for future configuration. The release-level preflight
+    // cache (and its `isFromCache` / `cacheKey` / `onRefresh` hooks) was
+    // removed — IDB-backed entity caching covers the practical wins on its
+    // own, without the stale-shape footguns of an extra cache layer.
+    void opts;
 
     // Pre-load missing names into a Map — IDB first, then MB WS2 fetch.
     const _preloadedNames = new Map();
@@ -65,39 +67,12 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
     }
 
     return new Promise(resolve => {
-        // Per-row state: resource_url -> { mbUrl, mbName, mbDisambig, confirmed }
-        let tableReady = false; // prevents saveCache during initial row population
-        // saveCache: persists current rowState to localStorage immediately
-        // Stores a minimal representation to avoid localStorage quota issues
-        function saveCache() {
-            if (!tableReady) return; // don't save during initial population
-            if (!cacheKey) return;
-            try {
-                const today2 = new Date().toISOString().slice(0, 10);
-                const slim = allResults.map(r => {
-                    const eKey = r.entity?.resource_url || r.entity?._syntheticKey || `_nourl_${r.entity?.name || r.displayName}`;
-                    const s = rowState.get(eKey);
-                    const mbUrl  = s?.mbUrl  || r.mbUrl  || null;
-                    const mbName = s?.mbName || r.mbName || null;
-                    return {
-                        type:         mbUrl ? 'resolved' : 'attention',
-                        entityType:   r.entityType   || 'artist',
-                        displayName:  r.displayName  || r.entity?.name || '',
-                        discogsHref:  r.discogsHref  || '',
-                        rateLimited:  mbUrl ? false : (r.rateLimited || false),
-                        nameMatches:  mbUrl ? [] : (r.nameMatches || []).slice(0, 5),
-                        mbUrl,
-                        mbName: mbName || r.mbName || null,
-                        mbDisambig: s?.mbDisambig || r.mbDisambig || '',
-                        entity: { resource_url: r.entity?.resource_url, name: r.entity?.name || '', _syntheticKey: r.entity?._syntheticKey || '' },
-                    };
-                });
-                localStorage.setItem(cacheKey, JSON.stringify({ date: today2, results: slim }));
-            } catch(e) {
-                console.warn('Discogs importer: saveCache failed', e);
-            }
-        }
-        // confirmed = true means the user is happy with this match (or it auto-matched cleanly)
+        // Per-row state: resource_url -> { mbUrl, mbName, mbDisambig, confirmed, via }.
+        // `confirmed = true` means the user is happy with this match (or it
+        // auto-matched cleanly). Mutations from user picks / undo / IDB
+        // pre-load are immediately reflected in `rowState` — and from there
+        // into the IDB `entity_cache` via `writeIdbRecord`. No separate
+        // localStorage layer.
         const rowState = new Map();
 
         const attentionCount = allResults.filter(r => r.type === 'attention').length;
@@ -140,24 +115,39 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
         }
 
         // ── Helpers shared across rows ─────────────────────────────────────
-        // Small pill that surfaces *how* an entity was resolved — the
-        // `resolvedVia` value (`name`, `url`, `both`, `user`, `cache`) that
-        // preflight records and the IDB cache persists. Lets the user see
-        // at a glance whether they should trust the auto-match without
-        // having to dig into per-row evidence.
-        const VIA_LABELS = {
+        // Small pill that surfaces *how* an entity was resolved. Two facts
+        // travel together:
+        //   `via`       — the resolution mechanism (`name` / `url` / `both` /
+        //                 `user`, or `cache` for legacy IDB records that
+        //                 predate the `resolvedVia` field).
+        //   `fromCache` — whether THIS resolution was served from IDB rather
+        //                 than a fresh MB lookup.
+        // The label composes both: a name-resolved entity loaded from cache
+        // shows `name (cache)`, freshly-resolved shows just `name`.
+        const VIA_STYLES = {
             both:  { text: 'name+url', color: '#2a7' }, // green — high confidence
             url:   { text: 'url',      color: '#46a' }, // blue
             name:  { text: 'name',     color: '#46a' }, // blue
             user:  { text: 'user',     color: '#777' }, // grey
-            cache: { text: 'cache',    color: '#777' }, // grey (legacy records)
+            cache: { text: 'cache',    color: '#777' }, // grey (legacy: original mechanism unknown)
         };
-        function makeViaBadge(via) {
-            const cfg = VIA_LABELS[via];
+        /** Resolve a `(via, fromCache)` pair to `{ text, color }` for display. */
+        function viaCfg(via, fromCache) {
+            const base = VIA_STYLES[via];
+            if (!base) return null;
+            if (fromCache && via !== 'cache') {
+                return { text: `${base.text} (cache)`, color: base.color };
+            }
+            return base;
+        }
+        function makeViaBadge(via, fromCache) {
+            const cfg = viaCfg(via, fromCache);
             if (!cfg) return null;
             const span = document.createElement('span');
             span.textContent = cfg.text;
-            span.title = `Resolved via ${via}`;
+            span.title = fromCache && via !== 'cache'
+                ? `Resolved via ${via}, served from cache`
+                : `Resolved via ${via}`;
             span.style.cssText = `font-size:0.68rem;background:#f5f5f5;color:${cfg.color};` +
                                  `padding:0 0.35rem;border-radius:8px;border:1px solid #ddd;flex-shrink:0;`;
             return span;
@@ -176,34 +166,11 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
         }
 
         const heading = document.createElement('div');
-        heading.style.cssText = `display:flex;align-items:center;gap:0.6rem;margin:0 0 0.5rem;padding:0.4rem 0.6rem;border-radius:0.3rem;` +
-            (isFromCache ? 'background:#ddeeff;border:1px solid #88aacc;' : 'background:#f5e8a0;border:1px solid #d4b800;');
+        heading.style.cssText = 'display:flex;align-items:center;gap:0.6rem;margin:0 0 0.5rem;padding:0.4rem 0.6rem;border-radius:0.3rem;background:#f5e8a0;border:1px solid #d4b800;';
         const headingText = document.createElement('span');
-        headingText.style.cssText = 'font-weight:bold;font-size:1rem;color:#' + (isFromCache ? '003366' : '5a4000') + ';flex:1;';
-        headingText.textContent = `Review — ${allResults.length} entit${allResults.length === 1 ? "y" : "ies"}` +
-            (isFromCache ? ' (cached)' : '');
+        headingText.style.cssText = 'font-weight:bold;font-size:1rem;color:#5a4000;flex:1;';
+        headingText.textContent = `Review — ${allResults.length} entit${allResults.length === 1 ? 'y' : 'ies'}`;
         heading.appendChild(headingText);
-        if (isFromCache) {
-            const refreshBtn = document.createElement('button');
-            refreshBtn.textContent = '🔄 Refresh';
-            refreshBtn.style.cssText = 'font-size:0.8rem;cursor:pointer;padding:0.2rem 0.5rem;border:1px solid #88aacc;border-radius:3px;background:#fff;color:#003366;';
-            refreshBtn.title = 'Clear cache and re-run pre-flight checks';
-            refreshBtn.addEventListener('click', () => {
-                if (cacheKey) try { localStorage.removeItem(cacheKey); } catch(e) {}
-                (panelLi || panel).remove();
-                if (onRefresh) {
-                    onRefresh().then(freshResults => {
-                        // Show new review table with fresh results (not from cache)
-                        showReviewTable(freshResults, rolesMap, companiesRolesMap, {
-                            isFromCache: false,
-                            cacheKey,
-                            onRefresh,
-                        }).then(confirmedMap => resolve(confirmedMap));
-                    });
-                }
-            });
-            heading.appendChild(refreshBtn);
-        }
         panel.appendChild(heading);
 
         const intro = document.createElement('p');
@@ -261,13 +228,15 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
             // Initialise rowState. `via` carries how the entity got resolved
             // (`name` / `url` / `both` / `user` / `cache`) — surfaced in the
             // post-import log summary table so users can audit auto-matches.
-            // Fresh preflight results carry it on `r.logEntry.via`; results
-            // restored from the localStorage preflight cache have it on `r.via`
-            // (logEntry is stripped to keep the cache slim).
+            // `via` carries the ORIGINAL mechanism (`name` / `url` / `both` /
+            // `user`, or `cache` for legacy IDB records); `fromCache` flags
+            // whether IDB served the resolution. The label composes them, e.g.
+            // `name (cache)`.
             rowState.set(_entityKey, {
                 mbUrl: initMbUrl, mbName: initMbName, mbDisambig: initMbDisam,
                 confirmed: isResolved && !needsAttention,
-                via: isResolved ? (r.logEntry?.via || r.via || null) : null,
+                via:       isResolved ? (r.logEntry?.via       || null)  : null,
+                fromCache: isResolved ? (r.logEntry?.fromCache || false) : false,
             });
 
             // ── Col 1: Discogs ─────────────────────────────────────────────────
@@ -346,7 +315,7 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
             function setRowResolved(a) {
                 // a = { id, name, disambiguation }
                 const mbUrl = `//musicbrainz.org/${entityType}/${a.id}`;
-                rowState.set(_entityKey, { mbUrl, mbName: a.name, mbDisambig: a.disambiguation || '', confirmed: true, via: 'user' });
+                rowState.set(_entityKey, { mbUrl, mbName: a.name, mbDisambig: a.disambiguation || '', confirmed: true, via: 'user', fromCache: false });
                 // Persist to IDB immediately so selection survives even without clicking Start import
                 const _idbKey = r.entity?.resource_url ? parseDiscogsUrl(r.entity.resource_url)?.key : null;
                 if (_idbKey) {
@@ -377,8 +346,9 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
                 undoBtn.style.cssText = 'font-size:0.75rem;cursor:pointer;padding:0 0.3rem;margin-left:auto;';
                 undoBtn.addEventListener('click', () => setRowUnresolved());
                 selRow.appendChild(selA);
-                // User picked via the dropdown \u2014 always badge as `user`.
-                const viaBadge = makeViaBadge('user');
+                // User picked via the dropdown \u2014 always badge as `user`,
+                // never `(cache)` (this is a fresh pick).
+                const viaBadge = makeViaBadge('user', false);
                 if (viaBadge) selRow.appendChild(viaBadge);
                 selRow.appendChild(undoBtn);
                 candidateList.appendChild(selRow);
@@ -386,11 +356,10 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
                 // Actions: Add Discogs link + Create fallback
                 renderActions(a);
                 updateImportBtn();
-                saveCache();
             }
 
             function setRowUnresolved() {
-                rowState.set(_entityKey, { mbUrl: null, mbName: null, mbDisambig: '', confirmed: false, via: null });
+                rowState.set(_entityKey, { mbUrl: null, mbName: null, mbDisambig: '', confirmed: false, via: null, fromCache: false });
                 tr.style.background = '#ffe0e0';
                 searchInput.disabled = false;
                 searchBtn.disabled = false;
@@ -401,7 +370,6 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
                 candidateList.appendChild(none);
                 renderActions(null);
                 updateImportBtn();
-                saveCache();
             }
 
             function renderActions(selected) {
@@ -615,7 +583,7 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
                 const displayName2 = initMbName || mbid;
                 if (!initMbName) {
                     // Name was null in cache — keep yellow, IDB pre-load handled before rendering
-                    rowState.set(_entityKey, { mbUrl: initMbUrl, mbName: null, mbDisambig: '', confirmed: true, via: r.logEntry?.via || r.via || null });
+                    rowState.set(_entityKey, { mbUrl: initMbUrl, mbName: null, mbDisambig: '', confirmed: true, via: r.logEntry?.via || null, fromCache: r.logEntry?.fromCache || false });
                     tr.style.background = '#fff8e1';
                 }
                 const fakeA = { id: mbid, name: displayName2, disambiguation: initMbDisam };
@@ -632,10 +600,9 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
                 undoBtn.style.cssText = 'font-size:0.75rem;cursor:pointer;padding:0 0.3rem;margin-left:auto;';
                 undoBtn.addEventListener('click', () => setRowUnresolved());
                 selRow.appendChild(selA);
-                // `via` badge — name / url / both / cache (initial auto-match).
-                // Read from logEntry (fresh) or top-level `via` (preflight cache).
-                const initialVia = r.logEntry?.via || r.via;
-                const viaBadge = makeViaBadge(initialVia);
+                // `via` badge — `name`, `url`, `both`, or `cache`, with a
+                // `(cache)` suffix when the resolution came from IDB.
+                const viaBadge = makeViaBadge(r.logEntry?.via, r.logEntry?.fromCache);
                 if (viaBadge) selRow.appendChild(viaBadge);
                 selRow.appendChild(undoBtn);
                 candidateList.appendChild(selRow);
@@ -689,8 +656,6 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
                 if (s.mbUrl) confirmedMap.set(key, s.mbUrl);
             });
 
-            saveCache();
-
             // ── Log summary table ──────────────────────────────────────
             const tbl = document.createElement('table');
             tbl.style.cssText = 'border-collapse:collapse;width:100%;font-size:0.78rem;margin:0.4rem 0;';
@@ -720,16 +685,18 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
 
                 const mbid = state.mbUrl ? state.mbUrl.replace(/.*\//, '').replace(/[^a-f0-9-]/gi,'').substring(0,36) : '';
                 const matchText = state.mbName || (state.mbUrl ? mbid : '');
-                // Resolution mechanism, e.g. `name+url`, `url`, `name`, `user`,
-                // `cache` — null when the row was not resolved (skipped).
-                const viaCfg = state.via ? VIA_LABELS[state.via] : null;
-                const viaText = viaCfg ? viaCfg.text : (state.mbUrl ? '—' : '');
+                // Resolution mechanism + cache state — composed via `viaCfg`:
+                // fresh → `name+url`/`url`/`name`/`user`; from IDB →
+                // `name (cache)` / `url (cache)` / `both (cache)` / etc.;
+                // legacy IDB record with no original mechanism → `cache`.
+                const vCfg = state.via ? viaCfg(state.via, state.fromCache) : null;
+                const viaText = vCfg ? vCfg.text : (state.mbUrl ? '—' : '');
 
                 [r.displayName || r.entity?.name, rolesText, matchText, mbid, viaText].forEach((val, ci) => {
                     const td = document.createElement('td');
                     td.style.cssText = 'padding:0.15rem 0.4rem;border:1px solid #ddd;' +
                         (ci === 2 && !val ? 'color:#aaa;' : ci === 2 ? 'color:#060;' :
-                         ci === 4 && viaCfg ? `color:${viaCfg.color};` : '');
+                         ci === 4 && vCfg ? `color:${vCfg.color};` : '');
                     if (ci === 2 && mbid) {
                         const a = document.createElement('a');
                         a.href = 'https:' + state.mbUrl; a.target = '_blank'; a.rel = 'noopener noreferrer nofollow';
@@ -771,6 +738,5 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
         getLogContainer().appendChild(panelLi);
         getLogContainer().scrollIntoView({ behavior: 'smooth', block: 'nearest' });
         _hideBar();
-        tableReady = true; // allow saveCache now that all rows are populated
     });
 }

--- a/userscripts/discogs_credits/src/storage.js
+++ b/userscripts/discogs_credits/src/storage.js
@@ -1,18 +1,46 @@
 // IndexedDB cache for Discogs↔MB entity resolutions.
 //
-// Single object store `mblinks`, keyed by `discogs_id` ("artist/12345" etc.).
-// Record shape: { discogs_id, mb_links: [url], mb_name?, mb_disambiguation? }.
+// Single object store `entity_cache`, keyed by `discogs_id` of the form
+// `"<type>/<id>"` (e.g. `"artist/12345"`, `"label/678"`). Record shape:
+//
+//   {
+//     discogs_id,      // mirror of the key
+//     mbid,            // MB GUID, lowercase hex with dashes
+//     entityType,      // 'artist' | 'label' | 'place' — the MB-side type
+//                      // (a Discogs label may resolve to a MB place, etc.)
+//     mbUrl,           // convenience: `//musicbrainz.org/<entityType>/<mbid>`
+//     name,            // MB display name (may be null until a follow-up
+//                      // /ws/2/<type>/<mbid> hit populates it)
+//     disambiguation,  // MB disambiguation comment (may be '')
+//     resolvedVia,     // 'cache' | 'name' | 'url' | 'both' | 'user'
+//                      //   cache — read from a prior session
+//                      //   name  — MB name search exact hit (only)
+//                      //   url   — MB URL relation lookup (only)
+//                      //   both  — name AND url agreed (high confidence)
+//                      //   user  — user picked / confirmed in the review table
+//     resolvedAt,      // ISO8601 timestamp of the resolution
+//   }
 //
 // `db` is exported as a live binding — `null` until `indexedDB.open()`'s
 // async success callback fires, then the IDBDatabase. ES-module imports
-// see the latest value automatically, so callers can read `db.transaction…`
-// once it's ready. Guard with `if (!db) return …` for the brief startup
-// window when reads might race the open.
+// see the latest value automatically, so call sites that need to write
+// data not yet covered by the helpers (rare) can do
+// `db.transaction(['entity_cache'], …)` directly.
+//
+// Schema-v1 (the old `mblinks` store) is no longer read or written.
+// Per the maintainer's earlier authorization (`dev/DECISIONS.md` 2026-05-23
+// 14:00) we do not migrate from v1 → v2: a fresh `entity_cache` starts
+// empty and re-populates as the script runs. The legacy `mblinks` store
+// stays in the user's browser doing nothing; deleting it is left to the
+// browser's normal IDB GC.
+
+const DB_NAME    = 'mblink';
+const DB_VERSION = 2;
+const STORE      = 'entity_cache';
 
 export let db = null;
 
-const _request = indexedDB.open('mblink');
-
+const _request = indexedDB.open(DB_NAME, DB_VERSION);
 _request.onerror = function () {
     console.error("Why didn't you allow my web app to use IndexedDB?!");
 };
@@ -21,13 +49,26 @@ _request.onsuccess = function (event) {
 };
 _request.onupgradeneeded = function (event) {
     const upgradeDb = event.target.result;
-    upgradeDb.createObjectStore('mblinks', {
-        keyPath: 'discogs_id',
-    });
+    if (!upgradeDb.objectStoreNames.contains(STORE)) {
+        upgradeDb.createObjectStore(STORE, { keyPath: 'discogs_id' });
+    }
+    // Note: the legacy `mblinks` store (v1) is intentionally NOT deleted —
+    // leaving it costs nothing and avoids a destructive delete on upgrade.
 };
 
 /**
- * Read a single record from the `mblinks` store. Resolves to the record (or
+ * Build a canonical MB URL from the MB-side entity type and MBID.
+ *
+ * (Exported because a few call sites still want the URL form without
+ * having to manually template — e.g. cache writes use both `mbid` and
+ * `mbUrl` so reads don't have to recompute.)
+ */
+export function mbUrlOf(entityType, mbid) {
+    return `//musicbrainz.org/${entityType}/${mbid}`;
+}
+
+/**
+ * Read a single record from `entity_cache`. Resolves to the record (or
  * `null` if not present or if `db` isn't open yet). Never rejects — IDB
  * errors and missing-db both resolve to null so call sites can write a
  * simple `if (!rec)` guard.
@@ -36,10 +77,47 @@ export function readIdbRecord(key) {
     return new Promise(resolve => {
         if (!key || !db) return resolve(null);
         try {
-            const tx = db.transaction(['mblinks'], 'readonly');
-            const req = tx.objectStore('mblinks').get(key);
+            const tx  = db.transaction([STORE], 'readonly');
+            const req = tx.objectStore(STORE).get(key);
             req.onsuccess = () => resolve(req.result || null);
             req.onerror  = () => resolve(null);
+        } catch(e) { resolve(null); }
+    });
+}
+
+/**
+ * Write (merge-upsert) a record into `entity_cache`.
+ *
+ *   - `key` — the `discogs_id` (`"<type>/<id>"`).
+ *   - `partial` — object whose fields are merged into the existing record.
+ *     Always sets `discogs_id` from `key` and `resolvedAt` from `Date.now()`.
+ *     If `mbid` and `entityType` are both present, `mbUrl` is also computed
+ *     so consumers don't have to.
+ *
+ * Returns a Promise that resolves to the final record (post-merge) or
+ * `null` on error. Never rejects.
+ *
+ * Merge semantics: existing fields are preserved unless `partial`
+ * overrides them. Use `null` in `partial` to explicitly null a field.
+ */
+export function writeIdbRecord(key, partial) {
+    return new Promise(resolve => {
+        if (!key || !db) return resolve(null);
+        try {
+            const tx    = db.transaction([STORE], 'readwrite');
+            const store = tx.objectStore(STORE);
+            const getReq = store.get(key);
+            getReq.onsuccess = () => {
+                const existing = getReq.result || {};
+                const merged = { ...existing, ...partial, discogs_id: key, resolvedAt: new Date().toISOString() };
+                if (merged.mbid && merged.entityType && !partial.mbUrl) {
+                    merged.mbUrl = mbUrlOf(merged.entityType, merged.mbid);
+                }
+                const putReq = store.put(merged);
+                putReq.onsuccess = () => resolve(merged);
+                putReq.onerror   = () => resolve(null);
+            };
+            getReq.onerror = () => resolve(null);
         } catch(e) { resolve(null); }
     });
 }

--- a/userscripts/discogs_credits/src/ui-bar.js
+++ b/userscripts/discogs_credits/src/ui-bar.js
@@ -15,7 +15,7 @@
 // entries from old versions on every page load (cheap, idempotent).
 
 import { DISCOGS_LOGO_URL }              from './constants.js';
-import { db }                             from './storage.js';
+import { writeIdbRecord }                 from './storage.js';
 import {
     log,
     setLogContainer,
@@ -701,32 +701,24 @@ function runImport(discogsUrl, processTracklist, applyToTracks, createWorks) {
                 .then(confirmedMap => {
                     capturedConfirmedMap = confirmedMap;
                     // Bulk-write confirmed entries to IDB. Inline writes in
-                    // `setRowResolved` (review-table) and `checkOne` (preflight)
-                    // already persist as each entity resolves (issue #23), so
-                    // this is a final correctness sweep — and it MERGES into
-                    // any existing record so `mb_name` / `mb_disambiguation`
-                    // from the inline writes survive instead of being clobbered
-                    // by a 2-field `{discogs_id, mb_links}` put.
+                    // `setRowResolved` (review-table) and `resolveEntity`
+                    // (preflight) already persist as each entity resolves
+                    // (issue #23), so this is a final correctness sweep.
+                    // `writeIdbRecord` merges, so name/disambiguation set by
+                    // the inline writes survive.
                     const cachePromises = [];
                     confirmedMap.forEach((mbUrl, resourceUrl) => {
                         const key = parseDiscogsUrl(resourceUrl)?.key;
                         if (!key) return;
-                        cachePromises.push(new Promise(res => {
-                            try {
-                                const tx = db.transaction(['mblinks'], 'readwrite');
-                                tx.oncomplete = res; tx.onerror = res;
-                                const store = tx.objectStore('mblinks');
-                                const readReq = store.get(key);
-                                readReq.onsuccess = () => {
-                                    const prev = readReq.result || {};
-                                    store.put({
-                                        ...prev,
-                                        discogs_id: key,
-                                        mb_links:   [mbUrl],
-                                    });
-                                };
-                                readReq.onerror = () => store.put({ discogs_id: key, mb_links: [mbUrl] });
-                            } catch (e) { res(); }
+                        // mbUrl is `//musicbrainz.org/<entityType>/<mbid>` —
+                        // extract both halves so the new schema's `mbid` and
+                        // `entityType` fields stay populated.
+                        const m = mbUrl.match(/\/(artist|label|place)\/([a-f0-9-]+)/);
+                        if (!m) return;
+                        cachePromises.push(writeIdbRecord(key, {
+                            mbid:       m[2],
+                            entityType: m[1],
+                            // No resolvedVia change — the inline write owns it.
                         }));
                     });
                     return Promise.all(cachePromises);

--- a/userscripts/discogs_credits/src/ui-bar.js
+++ b/userscripts/discogs_credits/src/ui-bar.js
@@ -615,7 +615,10 @@ function runImport(discogsUrl, processTracklist, applyToTracks, createWorks) {
             });
 
             // ── Pre-flight cache ─────────────────────────────────────────
-            const PREFLIGHT_CACHE_KEY = `discogs-preflight-${discogsUrl}`;
+            // `v2` — slim cache shape now carries `via` (resolution mechanism). Older
+            // entries without it would render the new "Resolved via" column as "—",
+            // so invalidate them by bumping the key.
+            const PREFLIGHT_CACHE_KEY = `discogs-preflight-v2-${discogsUrl}`;
             const today = new Date().toISOString().slice(0, 10);
             let cachedResults = null;
             try {
@@ -661,6 +664,10 @@ function runImport(discogsUrl, processTracklist, applyToTracks, createWorks) {
                             // Only save mbName if we actually have it — don't cache null names
                             mbName: r.mbName || null,
                             mbDisambig: r.mbDisambig || '',
+                            // Resolution mechanism (`name`/`url`/`both`/`user`/`cache`) — the
+                            // review table surfaces this in both the interactive badge and the
+                            // post-import log summary table, so it has to survive the cache.
+                            via: r.logEntry?.via || null,
                             entity: { resource_url: r.entity?.resource_url, name: r.entity?.name || '', _syntheticKey: r.entity?._syntheticKey || '' },
                         }));
                         localStorage.setItem(PREFLIGHT_CACHE_KEY, JSON.stringify({ date: today, results: slimResults }));

--- a/userscripts/discogs_credits/src/ui-bar.js
+++ b/userscripts/discogs_credits/src/ui-bar.js
@@ -24,7 +24,6 @@ import { _showBar, _hideBar }             from './progress-bar.js';
 import {
     parseDiscogsUrl,
     getDiscogsReleaseData,
-    clearReleaseDataCache,
 }                                        from './api-discogs.js';
 import {
     convertPotentialDJMixers,
@@ -614,21 +613,16 @@ function runImport(discogsUrl, processTracklist, applyToTracks, createWorks) {
                 }
             });
 
-            // ── Pre-flight cache ─────────────────────────────────────────
-            // `v2` — slim cache shape now carries `via` (resolution mechanism). Older
-            // entries without it would render the new "Resolved via" column as "—",
-            // so invalidate them by bumping the key.
-            const PREFLIGHT_CACHE_KEY = `discogs-preflight-v2-${discogsUrl}`;
-            const today = new Date().toISOString().slice(0, 10);
-            let cachedResults = null;
-            try {
-                const saved = JSON.parse(localStorage.getItem(PREFLIGHT_CACHE_KEY) || 'null');
-                if (saved?.date === today && Array.isArray(saved.results)) {
-                    cachedResults = saved.results;
-                }
-            } catch(e) {}
-
-            function runPreflight(bypassIdb) {
+            // ── Pre-flight ───────────────────────────────────────────────
+            // No release-level cache layer: the IDB `entity_cache` (per-entity
+            // Discogs-id → MBID, written by `resolveEntity` and on user confirm)
+            // already short-circuits the slow MB API calls for entities we've
+            // ever resolved. Walking 80–150 IDB rows on every page open is
+            // cheap; carrying a second cache that snapshots whole-release
+            // review-table state was net-negative once the entity layer
+            // existed (stale-shape footguns > the marginal speedup on
+            // same-release re-opens, which are rare).
+            function runPreflight() {
                 const artistProgressLi = document.createElement('li');
                 artistProgressLi.textContent = `Checking ${uniqueArtists.length} artist(s) against MusicBrainz…`;
                 _logs.appendChild(artistProgressLi);
@@ -640,70 +634,30 @@ function runImport(discogsUrl, processTracklist, applyToTracks, createWorks) {
                 return Promise.all([
                     resolveAll(uniqueArtists, {
                         progressLi:    artistProgressLi,
-                        bypassIdb,
                         progressLabel: 'Checking artists against MusicBrainz',
                         kindOf:        ARTIST_KIND,
                     }),
                     resolveAll(uniqueCompanies, {
                         progressLi:    companyProgressLi,
-                        bypassIdb,
                         progressLabel: 'Checking labels/places against MusicBrainz',
                         kindOf:        COMPANY_KIND,
                     }),
-                ]).then(([artistResults, companyResults]) => {
-                    const allResults = [...artistResults.allResults, ...companyResults.allResults].filter(Boolean);
-                    // Save to cache (only if not bypassing)
-                    if (!bypassIdb) try {
-                        const slimResults = allResults.map(r => ({
-                            type: r.type, entityType: r.entityType || 'artist',
-                            displayName: r.displayName || r.entity?.name || '',
-                            discogsHref: r.discogsHref || '',
-                            rateLimited: r.rateLimited || false,
-                            nameMatches: (r.nameMatches || []).slice(0, 5),
-                            mbUrl: r.mbUrl || null,
-                            // Only save mbName if we actually have it — don't cache null names
-                            mbName: r.mbName || null,
-                            mbDisambig: r.mbDisambig || '',
-                            // Resolution mechanism (`name`/`url`/`both`/`user`/`cache`) — the
-                            // review table surfaces this in both the interactive badge and the
-                            // post-import log summary table, so it has to survive the cache.
-                            via: r.logEntry?.via || null,
-                            entity: { resource_url: r.entity?.resource_url, name: r.entity?.name || '', _syntheticKey: r.entity?._syntheticKey || '' },
-                        }));
-                        localStorage.setItem(PREFLIGHT_CACHE_KEY, JSON.stringify({ date: today, results: slimResults }));
-                    } catch(e) { console.warn('Discogs importer: preflight cache save failed', e); }
-                    return allResults;
-                });
+                ]).then(([artistResults, companyResults]) =>
+                    [...artistResults.allResults, ...companyResults.allResults].filter(Boolean));
             }
 
             let capturedResults = null; // shared across promise chain
             let capturedConfirmedMap = null;
-            const preflightPromise = cachedResults ? Promise.resolve(cachedResults) : runPreflight();
 
-            return preflightPromise.then(allResults => {
-                // Annotate each result with its Discogs roles (works for both cache and fresh)
+            return runPreflight().then(allResults => {
+                // Annotate each result with its Discogs roles
                 allResults.forEach(r => {
                     if (!r) return;
                     const url = r.entity?.resource_url || r.entity?._syntheticKey;
                     if (url) r._roles = rolesMap.get(url) || companiesRolesMap.get(url) || [];
                 });
                 capturedResults = allResults;
-                return showReviewTable(capturedResults, rolesMap, companiesRolesMap, {
-                    isFromCache: !!cachedResults,
-                    cacheKey: PREFLIGHT_CACHE_KEY,
-                    onRefresh: () => {
-                        // Clear session memory cache for this release so data is truly fresh
-                        clearReleaseDataCache(discogsUrl);
-                        return runPreflight(true).then(freshResults => {
-                        freshResults.forEach(r => {
-                            if (!r) return;
-                            const url = r.entity?.resource_url || r.entity?._syntheticKey;
-                            if (url) r._roles = rolesMap.get(url) || companiesRolesMap.get(url) || [];
-                        });
-                        return freshResults;
-                        });
-                    },
-                });
+                return showReviewTable(capturedResults, rolesMap, companiesRolesMap, {});
             })
                 .then(confirmedMap => {
                     capturedConfirmedMap = confirmedMap;

--- a/userscripts/discogs_credits/test/lib/browser.js
+++ b/userscripts/discogs_credits/test/lib/browser.js
@@ -156,6 +156,16 @@ export function getCapturedLog(page) {
  * The script's `pageWindow` shim sees plain `window` (no Tampermonkey sandbox).
  */
 export async function injectUserscript(page) {
+    // Clear the preflight cache so every test forces a fresh preflight pass — otherwise
+    // stale slim records (e.g. before we added the `via` field) would mask issues.
+    await page.evaluate(() => {
+        const toDel = [];
+        for (let i = 0; i < localStorage.length; i++) {
+            const k = localStorage.key(i);
+            if (k && k.startsWith('discogs-preflight')) toDel.push(k);
+        }
+        toDel.forEach(k => localStorage.removeItem(k));
+    });
     const code = await readFile(SCRIPT_PATH, 'utf8');
     // Tampermonkey provides `GM_info` and `unsafeWindow`; the script falls back
     // to plain `window` for the latter but expects `GM_info.script.{name,version}`
@@ -410,12 +420,34 @@ export async function confirmReviewTable(page, { timeout = 20 * 60_000 } = {}) {
     return true;
 }
 
-/** Read the userscript's full log (whatever's currently in the .discogs-output UL). */
+/** Read the userscript's full log (whatever's currently in the .discogs-output UL).
+ *  When an `<li>` contains a `<table>` (the post-import review summary), the table is
+ *  rendered as GitHub-flavoured markdown so it stays readable in the saved log instead
+ *  of mashing every cell into one unspaced line. */
 export async function readImportLog(page) {
     return await page.evaluate(() => {
         const ul = document.querySelector('.discogs-output ul.logs');
         if (!ul) return '';
-        return [...ul.querySelectorAll('li')].map(li => li.textContent.trim()).join('\n');
+        function liToText(li) {
+            const tbl = li.querySelector('table');
+            if (!tbl) return li.textContent.trim();
+            // Render the table as markdown. Other text in the `<li>` (rare) is preserved.
+            const rows = [...tbl.querySelectorAll('tr')].map(tr =>
+                [...tr.children].map(c => (c.textContent || '').replace(/\s*\|\s*/g, ' / ').trim() || ' '));
+            if (rows.length === 0) return li.textContent.trim();
+            const md = ['| ' + rows[0].join(' | ') + ' |',
+                        '| ' + rows[0].map(() => '---').join(' | ') + ' |',
+                        ...rows.slice(1).map(r => '| ' + r.join(' | ') + ' |')].join('\n');
+            // Preserve any non-table text on the same `<li>` (none in current code, future-proof).
+            const tblText = tbl.textContent;
+            const liText  = li.textContent;
+            const extra   = liText.replace(tblText, '').trim();
+            // Wrap with blank lines so the table renders as a real markdown table
+            // when this log is pasted into GitHub / Discord / etc. (Standards #8).
+            const body = extra ? (extra + '\n\n' + md) : md;
+            return '\n' + body + '\n';
+        }
+        return [...ul.querySelectorAll(':scope > li')].map(liToText).join('\n');
     });
 }
 

--- a/userscripts/discogs_credits/test/lib/browser.js
+++ b/userscripts/discogs_credits/test/lib/browser.js
@@ -156,16 +156,6 @@ export function getCapturedLog(page) {
  * The script's `pageWindow` shim sees plain `window` (no Tampermonkey sandbox).
  */
 export async function injectUserscript(page) {
-    // Clear the preflight cache so every test forces a fresh preflight pass — otherwise
-    // stale slim records (e.g. before we added the `via` field) would mask issues.
-    await page.evaluate(() => {
-        const toDel = [];
-        for (let i = 0; i < localStorage.length; i++) {
-            const k = localStorage.key(i);
-            if (k && k.startsWith('discogs-preflight')) toDel.push(k);
-        }
-        toDel.forEach(k => localStorage.removeItem(k));
-    });
     const code = await readFile(SCRIPT_PATH, 'utf8');
     // Tampermonkey provides `GM_info` and `unsafeWindow`; the script falls back
     // to plain `window` for the latter but expects `GM_info.script.{name,version}`


### PR DESCRIPTION
Refs #32 — proposals **D** (IDB schema simplification) and **E** (tighter auto-match). Targets `refactor`.

These two land together because **E uses the `resolvedVia` field that D introduces**. Unwinding to separate PRs would require porting the field independently and is more churn than value.

## D — IDB schema v2

Store renamed `mblinks` → `entity_cache`; DB version bumped 1 → 2. Per maintainer's `dev/DECISIONS.md` 2026-05-23 14:00 entry, no data migration — v2 cache starts empty and refills as the script runs. The legacy v1 store stays put (cheap, avoids destructive delete-on-upgrade).

| Before | After |
|---|---|
| `{ discogs_id, mb_links: [url], mb_name?, mb_disambiguation? }` | `{ discogs_id, mbid, entityType, mbUrl, name, disambiguation, resolvedVia, resolvedAt }` |

`mbid` and `entityType` are first-class fields now (instead of being parsed out of `mb_links[0]`). `mbUrl` is pre-computed as `//musicbrainz.org/<type>/<mbid>` so consumers don't template. `resolvedAt` (ISO8601) and `resolvedVia` are new.

`storage.js` exports two new helpers:

```js
readIdbRecord(key)             // → record | null, never throws
writeIdbRecord(key, partial)   // merge-upsert with timestamp; never throws
```

**All direct `db.transaction(['mblinks'], …)` calls across `preflight.js`, `dispatch.js`, `review-table.js`, `ui-bar.js` are gone** — they go through the helpers. `db` is no longer imported by those modules.

## E — Parallel auto-match with disagreement detection

`resolveEntity` previously ran name search first, URL lookup as a *fallback* when name didn't auto-resolve. Now both run **in parallel** via `Promise.all` and the auto-resolve decision considers both signals.

| Outcome | `resolvedVia` |
|---|---|
| Both lookups hit, same MBID | `'both'` (high confidence) |
| URL-only hit (direct URL relation) | `'url'` |
| Name-only exact match, single hit | `'name'` |
| Both hit, **different MBIDs** | unresolved → user reviews |
| Neither hit | unresolved → user reviews |

User-confirmed selections in the review table write `resolvedVia: 'user'`.

**The disagreement case is the bug fix:** the old code silently picked whichever lookup came back first (always name, because URL was a fall-through), so a stale Discogs URL on MB could lead to a wrong-MBID silent auto-resolve. Now both signals must agree (or only one must fire) before auto-resolve.

## Test plan

- [x] `pnpm run verify` — green.
- [x] Smoke fixture (Spiritual Jazz, **cold** v2 cache) — 95 staged rels in 17 s. Identical top-staged distribution to pre-D/E warm-cache runs.
- [x] Full 12-fixture suite — green at 11:41 wallclock (cold cache). Warm-cache runs return to ~3 min as v2 fills. No disagreements detected on any current fixture.

## Notes for review

- v1 store stays in browsers that ever ran the old script. Doesn't bother anyone, doesn't hurt anything, doesn't get used. Browser's IDB GC may eventually purge it.
- The slow first run (cold v2 cache) is one-time per session. After preflight populates v2, subsequent imports in the same browser session are fast again.
- Disagreement reasons are surfaced in the result's `ambiguityReason` field — useful diagnostic when a fixture starts failing here in future.

## Status after this

All of `dev/ANALYSIS.md §2.3` is now done, plus proposals D and E. Issue #32 is effectively complete on this branch; ready to merge `refactor → main` whenever you say.
