### PR TITLE
Standard #9: link every referenced entity to the closest anchor

### DIFF
--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -1,25 +1,16 @@
 # Standards
 
-Reusable conventions for this repository (and similar future work). Each
-entry has a short title and a 1–3 sentence description with an example
-when useful.
+Reusable conventions for this repository (and similar future work). Each entry has a short title and a 1–3 sentence description with an example when useful.
 
-New standards arrive when the maintainer prefixes a chat message with
-`standard: ...`. Add them here at that moment, numbered consecutively;
-existing numbers never get reused.
+New standards arrive when the maintainer prefixes a chat message with `standard: ...`. Add them here at that moment, numbered consecutively; existing numbers never get reused.
 
-For project-specific decisions (e.g. "MB's `[no artist]` MBID is
-`eec63d3c-…`"), use the per-project `dev/DECISIONS.md` log, not this file.
+For project-specific decisions (e.g. "MB's `[no artist]` MBID is `eec63d3c-…`"), use the per-project `dev/DECISIONS.md` log, not this file.
 
 ---
 
 ## 1. Issue titles read as changelog entries
 
-Issue titles describe the user-visible symptom (for bugs) or the
-feature name (for enhancements). They become **changelog lines
-verbatim** — when cutting a release, copy the issue title across as the
-bullet text, untouched. The `bug` / `enhancement` label decides which
-section the bullet lands under (Fixes / Features respectively).
+Issue titles describe the user-visible symptom (for bugs) or the feature name (for enhancements). They become **changelog lines verbatim** — when cutting a release, copy the issue title across as the bullet text, untouched. The `bug` / `enhancement` label decides which section the bullet lands under (Fixes / Features respectively).
 
 Format per bullet:
 
@@ -28,86 +19,58 @@ Format per bullet:
 ```
 
 Rules for the title itself (so the verbatim copy reads well):
+
 - No leading verb (`Fix`, `Add`, `Persist`, `Refactor`, …).
-- No internal implementation details — no line numbers, exact counts,
-  internal variable names, file paths.
-- Describe what the user observes (for bugs) or what the feature is
-  (for enhancements), not how it's implemented.
+- No internal implementation details — no line numbers, exact counts, internal variable names, file paths.
+- Describe what the user observes (for bugs) or what the feature is (for enhancements), not how it's implemented.
 
 | Bad                                                                       | Good                                                       |
 | ------------------------------------------------------------------------- | ---------------------------------------------------------- |
 | Fix 51 instruments silently dropped due to duplicate keys in INSTRUMENTS  | Some instruments silently dropped due to duplicate keys in the map |
 | Persist entity-resolution cache incrementally instead of only on confirm  | Incremental cache persistence                              |
 
-If the title doesn't read well in the changelog, **fix the title first**
-(then update the changelog from the new title) — don't paraphrase in the
-changelog. The single source of truth is the issue tracker.
+If the title doesn't read well in the changelog, **fix the title first** (then update the changelog from the new title) — don't paraphrase in the changelog. The single source of truth is the issue tracker.
 
 ## 2. `bug` vs `enhancement` labels are meaningful
 
 - `bug` — something is broken; the user sees incorrect behaviour.
-- `enhancement` — a new feature, refactor, or improvement that wasn't
-  broken before.
+- `enhancement` — a new feature, refactor, or improvement that wasn't broken before.
 
-If an issue filed as a bug turns out to be an enhancement after
-investigation, relabel.
+If an issue filed as a bug turns out to be an enhancement after investigation, relabel.
 
 ## 3. PowerShell, not bash, for scripts and commands
 
-Windows-native environment. Shell scripts in the repo are `.ps1`.
-Command examples in documentation use PowerShell syntax. Node/.mjs
-scripts are shell-agnostic and unaffected.
+Windows-native environment. Shell scripts in the repo are `.ps1`. Command examples in documentation use PowerShell syntax. Node/.mjs scripts are shell-agnostic and unaffected.
 
 ## 4. Per-project `dev/DECISIONS.md` log
 
-Each project keeps an append-only one-line-per-entry decision log at
-`dev/DECISIONS.md`:
+Each project keeps an append-only one-line-per-entry decision log at `dev/DECISIONS.md`:
 
 ```
 - YYYY-MM-DD HH:MM — topic → decision. (short rationale)
 ```
 
-Newest entries at the bottom. Grep-friendly. Future contributors (human
-or AI) read this to understand *why* the code looks the way it does
-without diffing every commit.
+Newest entries at the bottom. Grep-friendly. Future contributors (human or AI) read this to understand *why* the code looks the way it does without diffing every commit.
 
 ## 5. Markdown table alignment
 
-Column-align tables by padding cells with spaces so columns line up.
-Fall back to **compact** form (`| cell | cell |` with a minimal
-`| --- | --- |` separator) when any row's cumulative cell content
-exceeds **200 characters** — past that, alignment makes the line so long
-it hurts readability more than it helps.
+Column-align tables by padding cells with spaces so columns line up. Fall back to **compact** form (`| cell | cell |` with a minimal `| --- | --- |` separator) when any row's cumulative cell content exceeds **200 characters** — past that, alignment makes the line so long it hurts readability more than it helps.
 
-A small enforcer lives at `userscripts/discogs_credits/dev/align-md-tables.mjs`
-(generic, takes any markdown files as args).
+A small enforcer lives at `userscripts/discogs_credits/dev/align-md-tables.mjs` (generic, takes any markdown files as args).
 
 ## 6. Markdown — hard line breaks for stacked metadata
 
-When several consecutive `**Key:** value` lines should render as separate
-lines (e.g. start time / command / fixtures / finished / result), append
-two trailing spaces to each — without them GitHub's renderer collapses
-them into a single paragraph.
+When several consecutive `**Key:** value` lines should render as separate lines (e.g. start time / command / fixtures / finished / result), append two trailing spaces to each — without them GitHub's renderer collapses them into a single paragraph.
 
 ## 7. AI-driven git work uses a dedicated bot identity
 
-Commits, branches, Issues, PRs, and Discussions created by an AI
-assistant go through a separate GitHub account, never via the
-maintainer's authenticated session. The bot's PAT lives in a gitignored
-local credentials file (see the per-project DEVELOP.md for path
-conventions). Push-with-token URLs are one-shot — never `git push -u`
-the URL form, which would write the token into `.git/config`.
+Commits, branches, Issues, PRs, and Discussions created by an AI assistant go through a separate GitHub account, never via the maintainer's authenticated session. The bot's PAT lives in a gitignored local credentials file (see the per-project DEVELOP.md for path conventions). Push-with-token URLs are one-shot — never `git push -u` the URL form, which would write the token into `.git/config`.
 
-Keeps human and bot activity clearly attributable in commit / PR
-authors, makes a token-rotation easy (only the bot's PAT, never the
-maintainer's session), and means a bot-misstep is easily revertable.
+Keeps human and bot activity clearly attributable in commit / PR authors, makes a token-rotation easy (only the bot's PAT, never the maintainer's session), and means a bot-misstep is easily revertable.
 
 ## 8. Markdown headers — blank line before and after, always
 
-Every `#`, `##`, `###`, … gets a blank line *before* and a blank line
-*after*. No exceptions for the level-1 at the top of a file (still
-needs the blank line below) or for adjacent subsections (the gap is
-just one blank line between them).
+Every `#`, `##`, `###`, … gets a blank line *before* and a blank line *after*. No exceptions for the level-1 at the top of a file (still needs the blank line below) or for adjacent subsections (the gap is just one blank line between them).
 
 ```markdown
 preceding paragraph.
@@ -125,10 +88,7 @@ Content.
 …
 ```
 
-Common renderers will *sometimes* parse `## Heading` without the
-surrounding blanks, but the result is fragile — list items, inline
-HTML, and `<details>` blocks all break the heuristic. Always include
-the blanks.
+Common renderers will *sometimes* parse `## Heading` without the surrounding blanks, but the result is fragile — list items, inline HTML, and `<details>` blocks all break the heuristic. Always include the blanks.
 
 ## 9. Link every referenced entity to the closest anchor
 

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -129,3 +129,33 @@ Common renderers will *sometimes* parse `## Heading` without the
 surrounding blanks, but the result is fragile — list items, inline
 HTML, and `<details>` blocks all break the heuristic. Always include
 the blanks.
+
+## 9. Link every referenced entity to the closest anchor
+
+When referencing docs, code artifacts, or external entities in chat or
+on GitHub, **always provide a link** — and aim for the most specific
+anchor available, not the project's front page. The reader should be
+able to click straight to the thing being discussed without doing their
+own search.
+
+Apply to:
+
+- **Project docs in this repo** — link with a relative path *and a
+  header anchor* when the relevant section is known. Example:
+  `[ANALYSIS#auto-match](userscripts/discogs_credits/dev/ANALYSIS.md#auto-match)`
+  rather than the bare word `ANALYSIS`.
+- **MusicBrainz entities** — link to the entity page using the MBID,
+  e.g. `[SST GmbH](https://musicbrainz.org/place/0c5c44bc-2d8d-4c72-b007-fbc752dfe8dc)`
+  rather than just `SST GmbH (0c5c44bc-…)`.
+- **Discogs entities** — link to the entity page using the Discogs ID,
+  e.g. `[SST GmbH](https://www.discogs.com/label/3987)` rather than the
+  bare ID.
+- **Issues, PRs, commits** — use `#N` (GitHub auto-links inside the
+  repo) or full URLs when posting elsewhere.
+
+If the closest anchor isn't readily available (e.g. a doc section
+without a header), link the file and quote the relevant line —
+better than leaving the reader to grep for it.
+
+The goal is *zero-friction verification*: every claim that names a
+thing carries its own evidence trail.

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -132,30 +132,26 @@ the blanks.
 
 ## 9. Link every referenced entity to the closest anchor
 
-When referencing docs, code artifacts, or external entities in chat or
-on GitHub, **always provide a link** — and aim for the most specific
-anchor available, not the project's front page. The reader should be
-able to click straight to the thing being discussed without doing their
-own search.
+When referencing docs, code artifacts, or external entities in chat or on GitHub, **always provide a link** — and aim for the most specific anchor available, not the project's front page. The reader should be able to click straight to the thing being discussed without doing their own search.
 
 Apply to:
 
-- **Project docs in this repo** — link with a relative path *and a
-  header anchor* when the relevant section is known. Example:
-  `[ANALYSIS#auto-match](userscripts/discogs_credits/dev/ANALYSIS.md#auto-match)`
-  rather than the bare word `ANALYSIS`.
-- **MusicBrainz entities** — link to the entity page using the MBID,
-  e.g. `[SST GmbH](https://musicbrainz.org/place/0c5c44bc-2d8d-4c72-b007-fbc752dfe8dc)`
-  rather than just `SST GmbH (0c5c44bc-…)`.
-- **Discogs entities** — link to the entity page using the Discogs ID,
-  e.g. `[SST GmbH](https://www.discogs.com/label/3987)` rather than the
-  bare ID.
-- **Issues, PRs, commits** — use `#N` (GitHub auto-links inside the
-  repo) or full URLs when posting elsewhere.
+- **Project docs in this repo** — link with a relative path *and a header anchor* when the relevant section is known. Example: `[ANALYSIS#auto-match](userscripts/discogs_credits/dev/ANALYSIS.md#auto-match)` rather than the bare word `ANALYSIS`.
+- **MusicBrainz entities** — link to the entity page using the MBID, e.g. `[SST GmbH](https://musicbrainz.org/place/0c5c44bc-2d8d-4c72-b007-fbc752dfe8dc)` rather than just `SST GmbH (0c5c44bc-…)`.
+- **Discogs entities** — link to the entity page using the Discogs ID, e.g. `[SST GmbH](https://www.discogs.com/label/3987)` rather than the bare ID.
+- **Issues, PRs, commits** — use `#N` (GitHub auto-links inside the repo) or full URLs when posting elsewhere.
 
-If the closest anchor isn't readily available (e.g. a doc section
-without a header), link the file and quote the relevant line —
-better than leaving the reader to grep for it.
+**Make documents anchorable.** When you need to reference a doc section that has no good link target, *fix the doc first*: add a header (preferred — it shows in the GitHub TOC), or drop an explicit anchor where a header would feel out of place:
 
-The goal is *zero-friction verification*: every claim that names a
-thing carries its own evidence trail.
+```markdown
+<a id="auto-match-disagreement"></a>
+
+A paragraph that other commits / PRs / chat messages can now link
+to via `…/ANALYSIS.md#auto-match-disagreement`.
+```
+
+Both header anchors (`## My Section` → `#my-section`) and explicit `<a id="…"></a>` work on GitHub. Prefer headers; use explicit anchors only when no header fits.
+
+**Don't hard-wrap the prose** in long-form markdown blocks like this one — let the renderer reflow naturally. Hard wraps look like manual line breaks in raw view and are a maintenance burden when the text edits in place. (Code blocks, tables, and lists still wrap where the grammar requires.)
+
+The goal is *zero-friction verification*: every claim that names a thing carries its own evidence trail.


### PR DESCRIPTION
## Summary

Adds a new entry to STANDARDS.md:

> When referencing docs, code artifacts, or external entities in chat or on GitHub, always provide a link — and aim for the most specific anchor available, not the project's front page.

Covers project docs (link to `path#anchor`), MusicBrainz entities (link to the MBID page), Discogs entities (link to the Discogs ID page), and issues/PRs/commits.

Goal: zero-friction verification — every named thing carries its own evidence trail.

## Origin

`standard:` prefix from chat 2026-05-25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)