### PR TITLE
Dispatch trusts confirmedMap — unselected entity no longer added (closes #35)

### DIFF
--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name         Import Discogs Credits (refactor)
+// @name         Import Discogs Credits (fix-issue-35-unselected-entities)
 // @namespace    majkinetor
 // @version      2026.5.25
 // @description  Add a button to import Discogs release relationships to MusicBrainz
@@ -2900,14 +2900,14 @@
       }
       return null;
     }
-    async function getMbidForEntity(entity, entityType) {
-      const key = parseDiscogsUrl(entity.resource_url)?.key;
-      if (!key) throw new Error(`No Discogs key for ${entity.name}`);
-      const rec = await readIdbRecord(key);
-      if (!rec?.mbUrl) {
-        throw new Error(`${entity.name} not in IDB cache \u2014 run pre-flight check first`);
+    function confirmedMbUrl(entity) {
+      if (!entity) return null;
+      const direct = confirmedMap.get(entity.resource_url) || confirmedMap.get(entity._syntheticKey) || null;
+      if (direct) return direct;
+      if (entity.name) {
+        return confirmedMap.get(`_nourl_${entity.name}`) || null;
       }
-      return rec.mbUrl;
+      return null;
     }
     function relAlreadyExists(sourceEntity, linkTypeID, targetGid, attrTree) {
       const rels = sourceEntity?.relationships;
@@ -3008,10 +3008,8 @@
             continue;
           }
         }
-        let mbUrl;
-        try {
-          mbUrl = await getMbidForEntity(company, resolvedEt);
-        } catch (e) {
+        const mbUrl = confirmedMbUrl(company);
+        if (!mbUrl) {
           log.warn(`Skipped ${company.name} \u2014 not resolved in review`);
           skipped++;
           tickProgress();
@@ -3027,31 +3025,12 @@
       for (const role of artistRoles) {
         if (applyToTracks && RECORDING_LINK_TYPES.has(role.linkType)) continue;
         if (WORK_ONLY_ARTIST_RELS.includes(role.linkType)) continue;
-        const _artKey = role.artist.resource_url || role.artist._syntheticKey || `_nourl_${role.artist.name}`;
-        let mbUrl = confirmedMap.get(_artKey) || (role.artist.resource_url ? confirmedMap.get(role.artist.resource_url) : null);
+        const mbUrl = confirmedMbUrl(role.artist);
         if (!mbUrl) {
-          for (const [k, v] of confirmedMap) {
-            if (k === `_nourl_${role.artist.name}`) {
-              mbUrl = v;
-              break;
-            }
-          }
-        }
-        if (!mbUrl && !role.artist.resource_url) {
-          log.warn(`Skipped ${role.artist.name} (${role.linkType}) \u2014 no Discogs page, not confirmed in review`);
+          log.warn(`Skipped ${role.artist.name} (${role.linkType}) \u2014 not resolved in review`);
           skipped++;
           tickProgress();
           continue;
-        }
-        if (!mbUrl) {
-          try {
-            mbUrl = await getMbidForEntity(role.artist, "artist");
-          } catch (e) {
-            log.warn(`Skipped ${role.artist.name} \u2014 not resolved in review (${role.linkType})`);
-            skipped++;
-            tickProgress();
-            continue;
-          }
         }
         const credit = role.artist.anv?.trim() || role.artist.name;
         await processOne(releaseEntity, "artist", "release", role.linkType, mbUrl, role.attributes || [], credit);
@@ -3064,10 +3043,8 @@
         if (applicable.length > 0) {
           log.info(`Applying ${applicable.length} release credit(s) to ${recordingByGid.size} recording(s)\u2026`);
           for (const role of applicable) {
-            let mbUrl;
-            try {
-              mbUrl = await getMbidForEntity(role.artist, "artist");
-            } catch (e) {
+            const mbUrl = confirmedMbUrl(role.artist);
+            if (!mbUrl) {
               log.warn(`Skipped ${role.artist.name} (${role.linkType}) in applyToTracks \u2014 not resolved in review`);
               continue;
             }
@@ -3199,10 +3176,8 @@
           workEntity = getWorkFromEditorState(recEntity) || workEntity;
         }
         for (const { role } of entries) {
-          let mbUrl;
-          try {
-            mbUrl = await getMbidForEntity(role.artist, "artist");
-          } catch (e) {
+          const mbUrl = confirmedMbUrl(role.artist);
+          if (!mbUrl) {
             log.warn(`Skipped ${role.artist.name} \u2014 not resolved in review (${role.linkType})`);
             continue;
           }
@@ -3229,27 +3204,10 @@
       const seenTrackRels = /* @__PURE__ */ new Set();
       for (const role of tracklistRels) {
         if (WORK_ONLY_ARTIST_RELS.includes(role.linkType)) continue;
-        const _tArtKey = role.artist.resource_url || role.artist._syntheticKey || `_nourl_${role.artist.name}`;
-        let mbUrl = confirmedMap.get(_tArtKey) || (role.artist.resource_url ? confirmedMap.get(role.artist.resource_url) : null);
+        const mbUrl = confirmedMbUrl(role.artist);
         if (!mbUrl) {
-          for (const [k, v] of confirmedMap) {
-            if (k === `_nourl_${role.artist.name}`) {
-              mbUrl = v;
-              break;
-            }
-          }
-        }
-        if (!mbUrl && !role.artist.resource_url) {
-          log.warn(`Skipped ${role.artist.name} on track ${role.track.position} \u2014 no Discogs page, not confirmed`);
+          log.warn(`Skipped ${role.artist.name} on track ${role.track.position} \u2014 not resolved in review`);
           continue;
-        }
-        if (!mbUrl) {
-          try {
-            mbUrl = await getMbidForEntity(role.artist, "artist");
-          } catch (e) {
-            log.warn(`Skipped ${role.artist.name} on track ${role.track.position} \u2014 not resolved in review`);
-            continue;
-          }
         }
         const recEntity = getRecordingEntity(role.track);
         if (!recEntity) {

--- a/userscripts/discogs_credits/eslint.config.mjs
+++ b/userscripts/discogs_credits/eslint.config.mjs
@@ -13,7 +13,7 @@ export default [
         ignores: ['dist/**', 'node_modules/**', '.pw-profile/**', 'test/**'],
         languageOptions: {
             ecmaVersion: 2022,
-            sourceType:  'script',
+            sourceType:  'module',
             globals: {
                 // Browser
                 window:                 'readonly',

--- a/userscripts/discogs_credits/src/dispatch.js
+++ b/userscripts/discogs_credits/src/dispatch.js
@@ -6,8 +6,6 @@
 
 import { log }                  from './log.js';
 import { pageWindow }                   from './constants.js';
-import { readIdbRecord }                  from './storage.js';
-import { parseDiscogsUrl }               from './api-discogs.js';
 import {
     mbThrottle,
     fetchMBEntity,
@@ -249,15 +247,25 @@ export async function dispatchAllRelationships(companies, artistRoles, tracklist
         return null;
     }
 
-    // ── Helper: resolve MB URL from IDB cache for a Discogs entity ───────────
-    async function getMbidForEntity(entity, entityType) {
-        const key = parseDiscogsUrl(entity.resource_url)?.key;
-        if (!key) throw new Error(`No Discogs key for ${entity.name}`);
-        const rec = await readIdbRecord(key);
-        if (!rec?.mbUrl) {
-            throw new Error(`${entity.name} not in IDB cache — run pre-flight check first`);
+    // ── Helper: confirmedMap lookup for a Discogs entity ───────────────────
+    // Single source of truth for "is this entity authorised to be dispatched":
+    // the review-table phase populates `confirmedMap` with everything the user
+    // (or auto-match) approved. If the entity isn't in the map, it's been
+    // either explicitly unresolved by the user OR was never resolved at all —
+    // either way we skip it. Used to be: fall back to IDB on miss, which
+    // let unselected entities sneak through (issue #35) because IDB still
+    // had the preflight auto-match cached.
+    function confirmedMbUrl(entity) {
+        if (!entity) return null;
+        const direct = confirmedMap.get(entity.resource_url)
+                    || confirmedMap.get(entity._syntheticKey)
+                    || null;
+        if (direct) return direct;
+        // Artists without a Discogs page get keyed by `_nourl_<name>`.
+        if (entity.name) {
+            return confirmedMap.get(`_nourl_${entity.name}`) || null;
         }
-        return rec.mbUrl;
+        return null;
     }
 
     // ── Helper: does a matching rel already exist on the source entity? ─────
@@ -378,13 +386,12 @@ export async function dispatchAllRelationships(companies, artistRoles, tracklist
                     skipped++; tickProgress(); continue;
                 }
             }
-            // Resolution must come from the review-table phase: confirmedMap → IDB cache.
-            // The old `getMbId` (network) fallback added ~1-3s per unresolved entity (bug
-            // majkinetor/musicbrainz-userscripts#8) and was redundant — preflight already
-            // tried the same `/ws/2/url` lookup. Unresolved here = unresolved by user.
-            let mbUrl;
-            try { mbUrl = await getMbidForEntity(company, resolvedEt); }
-            catch(e) {
+            // Resolution comes from the review-table phase (`confirmedMap`).
+            // No IDB fallback: if the user explicitly cleared the auto-match
+            // (issue #35), IDB still has the cached MBID but `confirmedMap`
+            // doesn't — and the user wins.
+            const mbUrl = confirmedMbUrl(company);
+            if (!mbUrl) {
                 log.warn(`Skipped ${company.name} — not resolved in review`);
                 skipped++; tickProgress(); continue;
             }
@@ -403,27 +410,10 @@ export async function dispatchAllRelationships(companies, artistRoles, tracklist
             // Work-only rels (writer, composer, etc.) go to works, not the release
             if (WORK_ONLY_ARTIST_RELS.includes(role.linkType)) continue;
 
-            // Try confirmedMap first (handles artists with no resource_url)
-            const _artKey = role.artist.resource_url || role.artist._syntheticKey || `_nourl_${role.artist.name}`;
-            let mbUrl = confirmedMap.get(_artKey) || (role.artist.resource_url ? confirmedMap.get(role.artist.resource_url) : null);
-            // Name-based fallback: search all confirmedMap keys for _nourl_ match
+            const mbUrl = confirmedMbUrl(role.artist);
             if (!mbUrl) {
-                for (const [k, v] of confirmedMap) {
-                    if (k === `_nourl_${role.artist.name}`) { mbUrl = v; break; }
-                }
-            }
-            if (!mbUrl && !role.artist.resource_url) {
-                // No Discogs page, not in confirmedMap — skip with clear message
-                log.warn(`Skipped ${role.artist.name} (${role.linkType}) — no Discogs page, not confirmed in review`);
+                log.warn(`Skipped ${role.artist.name} (${role.linkType}) — not resolved in review`);
                 skipped++; tickProgress(); continue;
-            }
-            if (!mbUrl) {
-                // See bug #8 — no network fallback; unresolved = skip immediately.
-                try { mbUrl = await getMbidForEntity(role.artist, 'artist'); }
-                catch(e) {
-                    log.warn(`Skipped ${role.artist.name} — not resolved in review (${role.linkType})`);
-                    skipped++; tickProgress(); continue;
-                }
             }
             const credit = role.artist.anv?.trim() || role.artist.name;
             await processOne(releaseEntity, 'artist', 'release', role.linkType, mbUrl, role.attributes || [], credit);
@@ -439,10 +429,8 @@ export async function dispatchAllRelationships(companies, artistRoles, tracklist
             if (applicable.length > 0) {
                 log.info(`Applying ${applicable.length} release credit(s) to ${recordingByGid.size} recording(s)…`);
                 for (const role of applicable) {
-                    let mbUrl;
-                    // See bug #8 — no network fallback.
-                    try { mbUrl = await getMbidForEntity(role.artist, 'artist'); }
-                    catch(e) {
+                    const mbUrl = confirmedMbUrl(role.artist);
+                    if (!mbUrl) {
                         log.warn(`Skipped ${role.artist.name} (${role.linkType}) in applyToTracks — not resolved in review`);
                         continue;
                     }
@@ -611,10 +599,8 @@ export async function dispatchAllRelationships(companies, artistRoles, tracklist
 
             // Apply all work-only artist rels to the work
             for (const { role } of entries) {
-                let mbUrl;
-                // See bug #8 — no network fallback.
-                try { mbUrl = await getMbidForEntity(role.artist, 'artist'); }
-                catch(e) {
+                const mbUrl = confirmedMbUrl(role.artist);
+                if (!mbUrl) {
                     log.warn(`Skipped ${role.artist.name} — not resolved in review (${role.linkType})`);
                     continue;
                 }
@@ -644,25 +630,10 @@ export async function dispatchAllRelationships(companies, artistRoles, tracklist
         for (const role of tracklistRels) {
             if (WORK_ONLY_ARTIST_RELS.includes(role.linkType)) continue; // handled by dispatchWorks
 
-            // Try confirmedMap first (handles artists with no resource_url)
-            const _tArtKey = role.artist.resource_url || role.artist._syntheticKey || `_nourl_${role.artist.name}`;
-            let mbUrl = confirmedMap.get(_tArtKey) || (role.artist.resource_url ? confirmedMap.get(role.artist.resource_url) : null);
+            const mbUrl = confirmedMbUrl(role.artist);
             if (!mbUrl) {
-                for (const [k, v] of confirmedMap) {
-                    if (k === `_nourl_${role.artist.name}`) { mbUrl = v; break; }
-                }
-            }
-            if (!mbUrl && !role.artist.resource_url) {
-                log.warn(`Skipped ${role.artist.name} on track ${role.track.position} — no Discogs page, not confirmed`);
+                log.warn(`Skipped ${role.artist.name} on track ${role.track.position} — not resolved in review`);
                 continue;
-            }
-            if (!mbUrl) {
-                // See bug #8 — no network fallback.
-                try { mbUrl = await getMbidForEntity(role.artist, 'artist'); }
-                catch(e) {
-                    log.warn(`Skipped ${role.artist.name} on track ${role.track.position} — not resolved in review`);
-                    continue;
-                }
             }
 
             const recEntity = getRecordingEntity(role.track);


### PR DESCRIPTION
## Summary

Issue #35: clearing an auto-matched entity in the review table (✕ button) didn't actually stop dispatch from adding the relation. Concrete repro from the report: [Disctronics S](https://www.discogs.com/label/329811) was an auto-matched proposal, user unselected it, Import still added \"glass mastered at\" and \"pressed at\" relations using the cached MBID.

## Root cause

`review-table.js` builds `confirmedMap` — the user-authoritative \"what got approved\" map — and passes it to `dispatchAllRelationships`. But five dispatch sites had IDB fallback logic (`getMbidForEntity` → `readIdbRecord`):

| Site | Behavior |
|---|---|
| `dispatchCompanies` | Read IDB directly, ignored `confirmedMap` entirely |
| `dispatchReleaseArtists` | `confirmedMap` first, IDB on miss |
| `dispatchTracklist` (release→track propagation) | Read IDB directly |
| `dispatchWorks` (work-only rels) | Read IDB directly |
| `dispatchTracklistArtists` | `confirmedMap` first, IDB on miss |

IDB always had the preflight auto-match, so unselecting in the review table didn't propagate.

## Fix

Single helper `confirmedMbUrl(entity)` that looks up `confirmedMap` by `resource_url` / `_syntheticKey` / `_nourl_<name>` and returns `null` on miss. All five sites call it and skip on null — no more IDB fallback. `getMbidForEntity` (and the `readIdbRecord` / `parseDiscogsUrl` imports it pulled in) gone. Net –71 lines.

The review table is now the single source of truth for which entities dispatch is authorised to use.

## Drive-by

`eslint.config.mjs` still had `sourceType: 'script'` from before the source split — lint was silently erroring on every ESM file. Flipped to `'module'`. Lint is now actually useful again.

## Verification

- `pnpm run lint` green
- `pnpm test` (full 12-fixture suite) green
- Midwest_Funk staged count went 115 → 116 (one more rel now correctly skipped that previously slipped through via IDB — the test gate caught it implicitly)

Closes #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)