### PR TITLE
Restore "🔄 Refresh from MB" button in review table

### DIFF
--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name         Import Discogs Credits (fix-issue-34-existed-count-and-logging)
+// @name         Import Discogs Credits (restore-refresh-button)
 // @namespace    majkinetor
 // @version      2026.5.25
 // @description  Add a button to import Discogs release relationships to MusicBrainz
@@ -1943,7 +1943,7 @@
   async function showReviewTable(allResults, rolesMap, companiesRolesMap, opts) {
     rolesMap = rolesMap || /* @__PURE__ */ new Map();
     companiesRolesMap = companiesRolesMap || /* @__PURE__ */ new Map();
-    void opts;
+    const onRefresh = opts?.onRefresh || null;
     const _preloadedNames = /* @__PURE__ */ new Map();
     const _nullNames = allResults.filter((r) => r.type === "resolved" && r.mbUrl && !r.mbName);
     for (const r of _nullNames) {
@@ -2055,6 +2055,21 @@
       headingText.style.cssText = "font-weight:bold;font-size:1rem;color:#5a4000;flex:1;";
       headingText.textContent = `Review \u2014 ${allResults.length} entit${allResults.length === 1 ? "y" : "ies"}`;
       heading.appendChild(headingText);
+      if (onRefresh) {
+        const refreshBtn = document.createElement("button");
+        refreshBtn.textContent = "\u{1F504} Refresh from MB";
+        refreshBtn.title = "Re-resolve every entity via MusicBrainz API, ignoring the local IDB cache";
+        refreshBtn.style.cssText = "font-size:0.8rem;cursor:pointer;padding:0.2rem 0.5rem;border:1px solid #b59a00;border-radius:3px;background:#fff;color:#5a4000;";
+        refreshBtn.addEventListener("click", () => {
+          refreshBtn.disabled = true;
+          refreshBtn.textContent = "\u{1F504} Refreshing\u2026";
+          (panelLi || panel).remove();
+          onRefresh().then((freshResults) => {
+            showReviewTable(freshResults, rolesMap, companiesRolesMap, { onRefresh }).then((confirmedMap) => resolve(confirmedMap));
+          });
+        });
+        heading.appendChild(refreshBtn);
+      }
       panel.appendChild(heading);
       const intro = document.createElement("p");
       intro.style.cssText = "margin:0 0 0.75rem;font-size:0.85rem;color:#666;";
@@ -3768,7 +3783,7 @@
           uniqueCompanies.push(c);
         }
       });
-      function runPreflight() {
+      function runPreflight(bypassIdb = false) {
         const artistProgressLi = document.createElement("li");
         artistProgressLi.textContent = `Checking ${uniqueArtists.length} artist(s) against MusicBrainz\u2026`;
         _logs2.appendChild(artistProgressLi);
@@ -3779,25 +3794,38 @@
           resolveAll(uniqueArtists, {
             progressLi: artistProgressLi,
             progressLabel: "Checking artists against MusicBrainz",
-            kindOf: ARTIST_KIND
+            kindOf: ARTIST_KIND,
+            bypassIdb
           }),
           resolveAll(uniqueCompanies, {
             progressLi: companyProgressLi,
             progressLabel: "Checking labels/places against MusicBrainz",
-            kindOf: COMPANY_KIND
+            kindOf: COMPANY_KIND,
+            bypassIdb
           })
         ]).then(([artistResults, companyResults]) => [...artistResults.allResults, ...companyResults.allResults].filter(Boolean));
       }
-      let capturedResults = null;
-      let capturedConfirmedMap = null;
-      return runPreflight().then((allResults) => {
+      function annotateRoles(allResults) {
         allResults.forEach((r) => {
           if (!r) return;
           const url = r.entity?.resource_url || r.entity?._syntheticKey;
           if (url) r._roles = rolesMap.get(url) || companiesRolesMap.get(url) || [];
         });
+      }
+      let capturedResults = null;
+      let capturedConfirmedMap = null;
+      return runPreflight().then((allResults) => {
+        annotateRoles(allResults);
         capturedResults = allResults;
-        return showReviewTable(capturedResults, rolesMap, companiesRolesMap, {});
+        return showReviewTable(capturedResults, rolesMap, companiesRolesMap, {
+          // "🔄 Refresh from MB" — bypass the IDB cache and re-resolve
+          // every entity via MB API. Used when a cached MBID is stale.
+          onRefresh: () => runPreflight(true).then((freshResults) => {
+            annotateRoles(freshResults);
+            capturedResults = freshResults;
+            return freshResults;
+          })
+        });
       }).then((confirmedMap) => {
         capturedConfirmedMap = confirmedMap;
         const cachePromises = [];

--- a/userscripts/discogs_credits/src/review-table.js
+++ b/userscripts/discogs_credits/src/review-table.js
@@ -26,11 +26,10 @@ const _urlCheckSessionCache = new Map();
 export async function showReviewTable(allResults, rolesMap, companiesRolesMap, opts) {
     rolesMap = rolesMap || new Map();
     companiesRolesMap = companiesRolesMap || new Map();
-    // `opts` is reserved for future configuration. The release-level preflight
-    // cache (and its `isFromCache` / `cacheKey` / `onRefresh` hooks) was
-    // removed — IDB-backed entity caching covers the practical wins on its
-    // own, without the stale-shape footguns of an extra cache layer.
-    void opts;
+    // `opts.onRefresh` — optional callback wired by ui-bar; when invoked, it
+    // re-runs preflight with `bypassIdb=true` and returns the fresh results.
+    // The review table exposes a "🔄 Refresh from MB" button that calls it.
+    const onRefresh = opts?.onRefresh || null;
 
     // Pre-load missing names into a Map — IDB first, then MB WS2 fetch.
     const _preloadedNames = new Map();
@@ -170,6 +169,25 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
         headingText.style.cssText = 'font-weight:bold;font-size:1rem;color:#5a4000;flex:1;';
         headingText.textContent = `Review — ${allResults.length} entit${allResults.length === 1 ? 'y' : 'ies'}`;
         heading.appendChild(headingText);
+        if (onRefresh) {
+            // Refresh-from-MB button — re-runs preflight with the IDB cache
+            // bypassed, so stale entries (entity merged, renamed, etc.) get
+            // re-resolved from the live MB API.
+            const refreshBtn = document.createElement('button');
+            refreshBtn.textContent = '🔄 Refresh from MB';
+            refreshBtn.title = 'Re-resolve every entity via MusicBrainz API, ignoring the local IDB cache';
+            refreshBtn.style.cssText = 'font-size:0.8rem;cursor:pointer;padding:0.2rem 0.5rem;border:1px solid #b59a00;border-radius:3px;background:#fff;color:#5a4000;';
+            refreshBtn.addEventListener('click', () => {
+                refreshBtn.disabled = true;
+                refreshBtn.textContent = '🔄 Refreshing…';
+                (panelLi || panel).remove();
+                onRefresh().then(freshResults => {
+                    showReviewTable(freshResults, rolesMap, companiesRolesMap, { onRefresh })
+                        .then(confirmedMap => resolve(confirmedMap));
+                });
+            });
+            heading.appendChild(refreshBtn);
+        }
         panel.appendChild(heading);
 
         const intro = document.createElement('p');

--- a/userscripts/discogs_credits/src/ui-bar.js
+++ b/userscripts/discogs_credits/src/ui-bar.js
@@ -609,7 +609,11 @@ function runImport(discogsUrl, processTracklist, applyToTracks, createWorks) {
             // review-table state was net-negative once the entity layer
             // existed (stale-shape footguns > the marginal speedup on
             // same-release re-opens, which are rare).
-            function runPreflight() {
+            // `bypassIdb` forces a fresh MB lookup per entity even when the
+            // IDB `entity_cache` already has it — wired to the review-table's
+            // "🔄 Refresh from MB" button so the user can re-resolve when a
+            // cached entry is stale (entity got merged, renamed, etc.).
+            function runPreflight(bypassIdb = false) {
                 const artistProgressLi = document.createElement('li');
                 artistProgressLi.textContent = `Checking ${uniqueArtists.length} artist(s) against MusicBrainz…`;
                 _logs.appendChild(artistProgressLi);
@@ -623,28 +627,43 @@ function runImport(discogsUrl, processTracklist, applyToTracks, createWorks) {
                         progressLi:    artistProgressLi,
                         progressLabel: 'Checking artists against MusicBrainz',
                         kindOf:        ARTIST_KIND,
+                        bypassIdb,
                     }),
                     resolveAll(uniqueCompanies, {
                         progressLi:    companyProgressLi,
                         progressLabel: 'Checking labels/places against MusicBrainz',
                         kindOf:        COMPANY_KIND,
+                        bypassIdb,
                     }),
                 ]).then(([artistResults, companyResults]) =>
                     [...artistResults.allResults, ...companyResults.allResults].filter(Boolean));
+            }
+
+            // Annotate each result with its Discogs roles. Used both on the
+            // initial run and on the refresh-from-MB pass below.
+            function annotateRoles(allResults) {
+                allResults.forEach(r => {
+                    if (!r) return;
+                    const url = r.entity?.resource_url || r.entity?._syntheticKey;
+                    if (url) r._roles = rolesMap.get(url) || companiesRolesMap.get(url) || [];
+                });
             }
 
             let capturedResults = null; // shared across promise chain
             let capturedConfirmedMap = null;
 
             return runPreflight().then(allResults => {
-                // Annotate each result with its Discogs roles
-                allResults.forEach(r => {
-                    if (!r) return;
-                    const url = r.entity?.resource_url || r.entity?._syntheticKey;
-                    if (url) r._roles = rolesMap.get(url) || companiesRolesMap.get(url) || [];
-                });
+                annotateRoles(allResults);
                 capturedResults = allResults;
-                return showReviewTable(capturedResults, rolesMap, companiesRolesMap, {});
+                return showReviewTable(capturedResults, rolesMap, companiesRolesMap, {
+                    // "🔄 Refresh from MB" — bypass the IDB cache and re-resolve
+                    // every entity via MB API. Used when a cached MBID is stale.
+                    onRefresh: () => runPreflight(true).then(freshResults => {
+                        annotateRoles(freshResults);
+                        capturedResults = freshResults;
+                        return freshResults;
+                    }),
+                });
             })
                 .then(confirmedMap => {
                     capturedConfirmedMap = confirmedMap;


### PR DESCRIPTION
## Summary

The Refresh button got dropped along with the preflight-cache layer in [commit 2a7e47c](https://github.com/majkinetor/musicbrainz-userscripts/commit/2a7e47c). The underlying need — *force a fresh MB lookup when a cached MBID is stale* — is still real, the button just needs to do the right thing now (bypass IDB) instead of clearing a localStorage cache that no longer exists.

## Wire-up

- **`ui-bar.js`** — `runPreflight(bypassIdb = false)` parameter restored. Passes `bypassIdb` through `resolveAll` → `resolveEntity` (the preflight layer's `bypassIdb` knob was kept even after ui-bar stopped using it). Wires an `onRefresh` callback to the review table that re-runs preflight with `bypassIdb=true`.
- **`review-table.js`** — accepts `opts.onRefresh`; when present, shows a "🔄 Refresh from MB" button in the heading. Click → disables itself, tears down the panel, awaits fresh results, re-shows the table with the same panel/promise chain.

## Tooltip

Old: *"Clear cache and re-run pre-flight checks"* — referred to the localStorage cache.
New: *"Re-resolve every entity via MusicBrainz API, ignoring the local IDB cache"* — accurate for the post-cache architecture.

## Verification

`pnpm run lint` + smoke fixture green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)