### PR TITLE
Refresh "Add Discogs link" row on focus return (closes #6)

### DIFF
--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name         Import Discogs Credits (restore-refresh-button)
+// @name         Import Discogs Credits (fix-issue-6-add-link-button-stale)
 // @namespace    majkinetor
 // @version      2026.5.25
 // @description  Add a button to import Discogs release relationships to MusicBrainz
@@ -2235,7 +2235,25 @@
         function renderActions(selected) {
           tdAction.innerHTML = "";
           if (selected) {
-            let applyUrlCheckResult = function(result) {
+            let recheckUrlBypassCache = function() {
+              _urlCheckSessionCache.delete(urlCheckCacheKey);
+              try {
+                localStorage.removeItem(urlCheckLsKey);
+              } catch (e2) {
+              }
+              queuedUrlCheck(
+                () => fetchWithRetry(`//musicbrainz.org/ws/2/url?resource=${encodeURIComponent(discogsHref)}&inc=${entityType}-rels&fmt=json`).then((json) => {
+                  const linkedIds = (json.relations || []).filter((r2) => r2[entityType]).map((r2) => r2[entityType].id);
+                  const result = linkedIds.includes(selected.id) ? "linked" : linkedIds.length > 0 ? "other" : "none";
+                  _urlCheckSessionCache.set(urlCheckCacheKey, result);
+                  try {
+                    localStorage.setItem(urlCheckLsKey, JSON.stringify({ date: urlCheckToday, result }));
+                  } catch (e2) {
+                  }
+                  applyUrlCheckResult(result);
+                }).catch(() => applyUrlCheckResult("none"))
+              );
+            }, applyUrlCheckResult = function(result) {
               if (result === "linked") {
                 linkSlot.textContent = "\u2713 Discogs URL already linked";
                 linkSlot.style.color = "#5a5";
@@ -2244,6 +2262,7 @@
                 linkSlot.style.color = "#c80";
               } else {
                 linkSlot.textContent = "";
+                linkSlot.style.color = "";
                 const addLinkBtn = document.createElement("button");
                 addLinkBtn.textContent = "Add Discogs link \u2197";
                 addLinkBtn.style.cssText = "font-size:0.8rem;cursor:pointer;display:block;white-space:nowrap;";
@@ -2252,6 +2271,19 @@
                   const p = new URLSearchParams({ [`edit-${entityType}.url.0.text`]: discogsHref, [`edit-${entityType}.url.0.link_type_id`]: ltId });
                   const mbid = selected.id.replace(/.*\//, "").replace(/[^a-f0-9-]/gi, "").substring(0, 36);
                   window.open(`https://musicbrainz.org/${entityType}/${mbid}/edit?${p}`, "_blank", "noopener,noreferrer");
+                  linkSlot.innerHTML = "";
+                  const pending = document.createElement("span");
+                  pending.textContent = "\u2026 verifying on return";
+                  pending.style.cssText = "font-size:0.8rem;color:#888;font-style:italic;";
+                  linkSlot.appendChild(pending);
+                  const onReturn = () => {
+                    if (document.visibilityState !== "visible") return;
+                    document.removeEventListener("visibilitychange", onReturn);
+                    window.removeEventListener("focus", onReturn);
+                    recheckUrlBypassCache();
+                  };
+                  document.addEventListener("visibilitychange", onReturn);
+                  window.addEventListener("focus", onReturn);
                 });
                 linkSlot.appendChild(addLinkBtn);
               }

--- a/userscripts/discogs_credits/src/review-table.js
+++ b/userscripts/discogs_credits/src/review-table.js
@@ -413,6 +413,27 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
                         if (urlCheckCached !== null) _urlCheckSessionCache.set(urlCheckCacheKey, urlCheckCached);
                     }
 
+                    // Re-runs the MB URL-relation check for THIS row, bypassing
+                    // both session and localStorage caches. Used by the
+                    // "Add Discogs link" focus-return handler so the button
+                    // updates to "\u2713 already linked" once the user has actually
+                    // submitted the link edit on the other tab (issue #6).
+                    function recheckUrlBypassCache() {
+                        _urlCheckSessionCache.delete(urlCheckCacheKey);
+                        try { localStorage.removeItem(urlCheckLsKey); } catch(e) {}
+                        queuedUrlCheck(() =>
+                            fetchWithRetry(`//musicbrainz.org/ws/2/url?resource=${encodeURIComponent(discogsHref)}&inc=${entityType}-rels&fmt=json`)
+                                .then(json => {
+                                    const linkedIds = (json.relations || []).filter(r => r[entityType]).map(r => r[entityType].id);
+                                    const result = linkedIds.includes(selected.id) ? 'linked' : linkedIds.length > 0 ? 'other' : 'none';
+                                    _urlCheckSessionCache.set(urlCheckCacheKey, result);
+                                    try { localStorage.setItem(urlCheckLsKey, JSON.stringify({ date: urlCheckToday, result })); } catch(e) {}
+                                    applyUrlCheckResult(result);
+                                })
+                                .catch(() => applyUrlCheckResult('none'))
+                        );
+                    }
+
                     function applyUrlCheckResult(result) {
                         if (result === 'linked') {
                             linkSlot.textContent = '\u2713 Discogs URL already linked';
@@ -422,6 +443,7 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
                             linkSlot.style.color = '#c80';
                         } else {
                             linkSlot.textContent = '';
+                            linkSlot.style.color = '';
                             const addLinkBtn = document.createElement('button');
                             addLinkBtn.textContent = 'Add Discogs link \u2197';
                             addLinkBtn.style.cssText = 'font-size:0.8rem;cursor:pointer;display:block;white-space:nowrap;';
@@ -430,6 +452,26 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
                                 const p = new URLSearchParams({ [`edit-${entityType}.url.0.text`]: discogsHref, [`edit-${entityType}.url.0.link_type_id`]: ltId });
                                 const mbid = selected.id.replace(/.*\//, '').replace(/[^a-f0-9-]/gi, '').substring(0, 36);
                                 window.open(`https://musicbrainz.org/${entityType}/${mbid}/edit?${p}`, '_blank', 'noopener,noreferrer');
+                                // Replace button with a "pending verification" badge.
+                                // When the user comes back to this tab, we re-run the
+                                // URL check (cache-bypassed) and the row flips to
+                                // "\u2713 Discogs URL already linked" \u2014 or, if the user
+                                // didn't actually submit the edit, the button is
+                                // restored. Issue #6: previously the button just sat
+                                // there forever, not reflecting the link.
+                                linkSlot.innerHTML = '';
+                                const pending = document.createElement('span');
+                                pending.textContent = '\u2026 verifying on return';
+                                pending.style.cssText = 'font-size:0.8rem;color:#888;font-style:italic;';
+                                linkSlot.appendChild(pending);
+                                const onReturn = () => {
+                                    if (document.visibilityState !== 'visible') return;
+                                    document.removeEventListener('visibilitychange', onReturn);
+                                    window.removeEventListener('focus', onReturn);
+                                    recheckUrlBypassCache();
+                                };
+                                document.addEventListener('visibilitychange', onReturn);
+                                window.addEventListener('focus', onReturn);
                             });
                             linkSlot.appendChild(addLinkBtn);
                         }


### PR DESCRIPTION
## Summary

Issue #6: clicking "Add Discogs link ↗" opened MB's URL-edit form in a new tab, but the original tab's button just sat there forever — even after the link was successfully added. The row never flipped to "✓ Discogs URL already linked".

## Fix

When the user clicks the button:

1. `window.open` the URL-edit page (unchanged).
2. Replace the button with a *"… verifying on return"* badge.
3. Register one-shot `visibilitychange` + `focus` listeners on the original tab.
4. When the tab next becomes visible (user returned from the edit tab), drop the cached URL-check result (session + localStorage) and re-run the URL-relation check.

`applyUrlCheckResult` handles both outcomes:
- Link is now in MB → row shows ✓.
- Link isn't in MB (user closed the tab without submitting) → the "Add Discogs link" button is restored, ready for another try.

`recheckUrlBypassCache` is the cache-bust + re-check helper — factored out so it can be reused.

## Verification

Smoke + lint green. The fix only adds a `visibilitychange` / `focus` listener flow; it doesn't change the URL-check logic, so the 12-fixture suite isn't affected (the fixtures don't exercise the Add-link click path).

Closes #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)