### PR TITLE
fix: DISCOGS_CHANNEL + discogsUrl ReferenceErrors, promote no-undef to error

### DIFF
--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Discogs Credits
 // @namespace    majkinetor
-// @version      2026.5.25.215443
+// @version      2026.5.25.220141
 // @description  Add a button to import Discogs release relationships to MusicBrainz
 // @author       majkinetor
 // @match        https://musicbrainz.org/release/*/edit-relationships
@@ -55,6 +55,7 @@
     TaskInput: "#add-relationship-dialog .attribute-container.task input"
   };
   var DISCOGS_LOGO_URL = "https://volkerzell.de/favicons/discogs.png";
+  var DISCOGS_CHANNEL = new BroadcastChannel("discogs-importer-artist");
   var pageWindow = typeof unsafeWindow !== "undefined" ? unsafeWindow : window;
 
   // src/log.js
@@ -2735,7 +2736,7 @@
   }
 
   // src/edit-note.js
-  function buildEditNote(discogsUrl2, opts, extraLines) {
+  function buildEditNote(discogsUrl, opts, extraLines) {
     const s = GM_info.script;
     const mbUrl = location.href.replace(/\/edit-relationships$/, "");
     const homepage = s.homepageURL || s.homepage || "https://github.com/majkinetor/musicbrainz-userscripts/tree/main/userscripts/discogs_credits";
@@ -2744,7 +2745,7 @@
       header,
       "",
       "Release URL: " + mbUrl,
-      "Discogs URL: " + discogsUrl2
+      "Discogs URL: " + discogsUrl
     ];
     if (opts) lines.push("Options: " + opts);
     if (extraLines) lines.push(...Array.isArray(extraLines) ? extraLines : [extraLines]);
@@ -2774,7 +2775,7 @@
   ];
 
   // src/dispatch.js
-  async function dispatchAllRelationships(companies, artistRoles, tracklistRels, applyToTracks, createWorks, discogsTracklist, processTracklist, resolvedEntityTypes, confirmedMap) {
+  async function dispatchAllRelationships(companies, artistRoles, tracklistRels, applyToTracks, createWorks, discogsTracklist, processTracklist, resolvedEntityTypes, confirmedMap, discogsUrl) {
     resolvedEntityTypes = resolvedEntityTypes || /* @__PURE__ */ new Map();
     confirmedMap = confirmedMap || /* @__PURE__ */ new Map();
     const re = await waitForMBEditor();
@@ -3296,7 +3297,7 @@
   // src/ui-bar.js
   var _logs2;
   var _summary;
-  function insertDiscogsBar(discogsUrl2) {
+  function insertDiscogsBar(discogsUrl) {
     const style = document.createElement("style");
     style.innerText = `
         .discogs-bar {
@@ -3495,7 +3496,7 @@
     row1.appendChild(logo);
     const sourceSpan = document.createElement("span");
     sourceSpan.className = "discogs-source";
-    sourceSpan.innerHTML = `<a href="${discogsUrl2}" target="_blank" rel="noopener noreferrer nofollow">${discogsUrl2}</a>`;
+    sourceSpan.innerHTML = `<a href="${discogsUrl}" target="_blank" rel="noopener noreferrer nofollow">${discogsUrl}</a>`;
     row1.appendChild(sourceSpan);
     const importBtn = document.createElement("button");
     importBtn.className = "discogs-import-btn";
@@ -3663,13 +3664,13 @@
       };
       requestAnimationFrame(_showBar);
       const opts = `per-track:${tracklistCb.checked ? "on" : "off"}, move-to-tracks:${applyTracksCb.checked ? "on" : "off"}, create-works:${createWorksCb.checked ? "on" : "off"}`;
-      const editNote = buildEditNote(discogsUrl2, opts);
+      const editNote = buildEditNote(discogsUrl, opts);
       editNote.split("\n").forEach((line) => {
         if (!line.trim()) return;
         const html = line.replace(/(https?:\/\/[^\s]+)/g, '<a href="$1" target="_blank" rel="noopener noreferrer nofollow">$1</a>');
         log.info(html);
       });
-      runImport(discogsUrl2, tracklistCb.checked, applyTracksCb.checked, createWorksCb.checked).finally(() => {
+      runImport(discogsUrl, tracklistCb.checked, applyTracksCb.checked, createWorksCb.checked).finally(() => {
         importBtn.disabled = false;
         importBtn.textContent = "Import from Discogs";
         progressPct.textContent = "100%";
@@ -3705,8 +3706,8 @@
     } catch (e) {
     }
   })();
-  function runImport(discogsUrl2, processTracklist, applyToTracks, createWorks) {
-    return getDiscogsReleaseData(discogsUrl2).then((json) => {
+  function runImport(discogsUrl, processTracklist, applyToTracks, createWorks) {
+    return getDiscogsReleaseData(discogsUrl).then((json) => {
       let artistRoles = rolesFromDiscogsArtists(json.extraartists?.filter((artist) => !artist.tracks));
       if (!_logs2._releaseInfoAdded) {
         _logs2._releaseInfoAdded = true;
@@ -3880,14 +3881,13 @@
             resolvedEntityTypes.set(r.entity.resource_url, r.entityType);
           }
         });
-        return dispatchAllRelationships(json.companies, artistRoles, tracklistRels, applyToTracks, createWorks, json.tracklist, processTracklist, resolvedEntityTypes, capturedConfirmedMap);
+        return dispatchAllRelationships(json.companies, artistRoles, tracklistRels, applyToTracks, createWorks, json.tracklist, processTracklist, resolvedEntityTypes, capturedConfirmedMap, discogsUrl);
       });
     }).then(() => {
     });
   }
 
   // src/discogs_credits.user.js
-  var DISCOGS_CHANNEL2 = new BroadcastChannel("discogs-importer-artist");
   (function handleEntityPageIfNeeded() {
     const entityMatch = location.href.match(
       /musicbrainz\.org\/(artist|label|place)\/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})(?:[^/]|$)/i
@@ -3900,7 +3900,7 @@
     if (!pending) return;
     sessionStorage.removeItem(pendingKey);
     fetch(`//musicbrainz.org/ws/2/${entityType}/${mbid}?fmt=json`).then((r) => r.json()).then((json) => {
-      DISCOGS_CHANNEL2.postMessage({
+      DISCOGS_CHANNEL.postMessage({
         type: "artist-created",
         // keep same message type for compatibility
         id: mbid,
@@ -3910,7 +3910,7 @@
       });
       setTimeout(() => window.close(), 800);
     }).catch(() => {
-      DISCOGS_CHANNEL2.postMessage({
+      DISCOGS_CHANNEL.postMessage({
         type: "artist-created",
         id: mbid,
         name: "",
@@ -3924,9 +3924,9 @@
     const re = /musicbrainz\.org\/release\/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})\/edit-relationships/i;
     const m = window.location.href.match(re);
     if (!m) return;
-    getDiscogsUrlForRelease(m[1]).then((discogsUrl2) => {
-      if (discogsUrl2) {
-        insertDiscogsBar(discogsUrl2);
+    getDiscogsUrlForRelease(m[1]).then((discogsUrl) => {
+      if (discogsUrl) {
+        insertDiscogsBar(discogsUrl);
       }
     });
   });

--- a/userscripts/discogs_credits/eslint.config.mjs
+++ b/userscripts/discogs_credits/eslint.config.mjs
@@ -91,10 +91,17 @@ export default [
             'no-cond-assign':           'warn',
             'no-empty':                ['warn', { allowEmptyCatch: true }],
 
-            // ── Deliberately off until commit 3 cleans up legacy code ────────
-            'no-undef':                 'off',
-            'no-unused-vars':           'off',
+            // ── On now that the source split is in (was 'off' under
+            //     `sourceType: 'script'` to suppress legacy noise; flipping
+            //     them to 'error' caught two real undef ReferenceErrors —
+            //     `DISCOGS_CHANNEL` in review-table, `discogsUrl` in
+            //     dispatch — that the test gate's try/catch was swallowing.)
+            'no-undef':                 'error',
             'no-prototype-builtins':    'off',
+            // 'no-unused-vars' deliberately still 'off' — the modules
+            // import things they don't use yet (intentionally — keeps the
+            // import surface intact during incremental work).
+            'no-unused-vars':           'off',
         },
     },
 ];

--- a/userscripts/discogs_credits/src/constants.js
+++ b/userscripts/discogs_credits/src/constants.js
@@ -48,6 +48,19 @@ export const SELECTORS = {
 export const DISCOGS_LOGO_URL = 'https://volkerzell.de/favicons/discogs.png';
 
 /**
+ * Cross-tab channel used by the "Create in MB" flow. The userscript runs on
+ * MB artist/label/place pages too — when it detects it was opened from the
+ * review table (post-creation), it broadcasts the newly-created entity's
+ * MBID + name back here so the review-table row auto-fills.
+ *
+ * One channel module-wide so both the entry-bootstrap listener and the
+ * review-table-side `renderActions` see the same instance. Without this
+ * export, review-table.js referenced a free `DISCOGS_CHANNEL` symbol that
+ * only existed in the entry module's scope → ReferenceError at runtime.
+ */
+export const DISCOGS_CHANNEL = new BroadcastChannel('discogs-importer-artist');
+
+/**
  * The page's real `window` — Tampermonkey exposes it as `unsafeWindow` to
  * userscripts; Greasemonkey/Violentmonkey too. In Playwright (test mode) or
  * any environment without that grant, we fall through to plain `window`.

--- a/userscripts/discogs_credits/src/discogs_credits.user.js
+++ b/userscripts/discogs_credits/src/discogs_credits.user.js
@@ -15,13 +15,16 @@
 
 import { getDiscogsUrlForRelease } from './api-mb.js';
 import { insertDiscogsBar }      from './ui-bar.js';
+import { DISCOGS_CHANNEL }       from './constants.js';
 import                                './storage.js';   // opens IndexedDB on load
 
 // ── BroadcastChannel: cross-tab artist creation signalling ────────────────────
-// When this script runs on an MB artist page that was opened by the "Create in MB"
-// button, it detects the successful creation (URL contains a MBID) and posts the
-// new artist data back to the opener tab, then closes itself.
-const DISCOGS_CHANNEL = new BroadcastChannel('discogs-importer-artist');
+// `DISCOGS_CHANNEL` is created once in `constants.js` and imported here +
+// in `review-table.js` so both sides share one channel instance. The bootstrap
+// below is the LISTENER half — when this script runs on an MB
+// artist/label/place page that was opened by the "Create in MB" button, it
+// detects the successful creation (URL contains a MBID), posts the new entity
+// back to the opener tab via the channel, then closes itself.
 
 (function handleEntityPageIfNeeded() {
     // Match artist, label, or place pages with a MBID

--- a/userscripts/discogs_credits/src/dispatch.js
+++ b/userscripts/discogs_credits/src/dispatch.js
@@ -21,7 +21,7 @@ import { buildEditNote }                from './edit-note.js';
 import { ENTITY_TYPE_MAP }               from './data/entity-map.js';
 import { WORK_ONLY_ARTIST_RELS }         from './data/work-only-rels.js';
 
-export async function dispatchAllRelationships(companies, artistRoles, tracklistRels, applyToTracks, createWorks, discogsTracklist, processTracklist, resolvedEntityTypes, confirmedMap) {
+export async function dispatchAllRelationships(companies, artistRoles, tracklistRels, applyToTracks, createWorks, discogsTracklist, processTracklist, resolvedEntityTypes, confirmedMap, discogsUrl) {
     resolvedEntityTypes = resolvedEntityTypes || new Map();
     confirmedMap = confirmedMap || new Map();
     const re = await waitForMBEditor();

--- a/userscripts/discogs_credits/src/review-table.js
+++ b/userscripts/discogs_credits/src/review-table.js
@@ -10,6 +10,7 @@ import { parseDiscogsUrl }                 from './api-discogs.js';
 import { guessSortName }                   from './mappers.js';
 import { getLogContainer }                 from './log.js';
 import { _hideBar }                        from './progress-bar.js';
+import { DISCOGS_CHANNEL }                 from './constants.js';
 
 // Session-level URL check cache (avoids localStorage key mismatches across sessions)
 const _urlCheckSessionCache = new Map();

--- a/userscripts/discogs_credits/src/ui-bar.js
+++ b/userscripts/discogs_credits/src/ui-bar.js
@@ -698,7 +698,7 @@ function runImport(discogsUrl, processTracklist, applyToTracks, createWorks) {
                             resolvedEntityTypes.set(r.entity.resource_url, r.entityType);
                         }
                     });
-                    return dispatchAllRelationships(json.companies, artistRoles, tracklistRels, applyToTracks, createWorks, json.tracklist, processTracklist, resolvedEntityTypes, capturedConfirmedMap);
+                    return dispatchAllRelationships(json.companies, artistRoles, tracklistRels, applyToTracks, createWorks, json.tracklist, processTracklist, resolvedEntityTypes, capturedConfirmedMap, discogsUrl);
                 });
         })
         .then(() => { });


### PR DESCRIPTION
## Summary

Two real undef ReferenceErrors that the test gate's `try { … } catch(e) {}` had been swallowing — surfaced as soon as eslint's `no-undef` was actually enabled.

## Bugs fixed

### 1. `DISCOGS_CHANNEL is not defined` (user-reported)

`const DISCOGS_CHANNEL = new BroadcastChannel(...)` lived as a module-private top-level in `src/discogs_credits.user.js` (the entry) but was referenced from `src/review-table.js`'s `renderActions` without an import. In the IIFE bundle, free references survived the build but exploded at runtime:

```
Uncaught ReferenceError: DISCOGS_CHANNEL is not defined
  at renderActions (… :2362)
```

User-visible: after creating an entity via the "Create in MB" button, the review-table row didn't auto-fill with the newly-created MBID.

Fix: move the channel to `src/constants.js`, export it, import both in the entry-bootstrap listener and in review-table.

### 2. `discogsUrl is not defined` in dispatch.js

`buildEditNote(discogsUrl, …)` in the edit-note update block referenced an identifier that had been a global before the source split and was never wired through after. The crash was caught by an outer `try { … } catch(e) { /* ignore */ }`, so the edit note silently failed to update on every import.

Fix: thread `discogsUrl` as the final parameter of `dispatchAllRelationships`, pass it from `runImport` in ui-bar.

### 3. Promote `no-undef` to `error`

The config comment said *"until commit 3 cleans up legacy code"* — that pre-source-split cleanup landed long ago. Both bugs above would have been caught earlier. Future ones will be.

## Verification

`pnpm test --name=spiritual` smoke green. `pnpm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)