### PR TITLE
Stats in edit note (closes #56)

### DIFF
--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Discogs Credits
 // @namespace    majkinetor
-// @version      2026.5.25.220815
+// @version      2026.5.25.222418
 // @description  Add a button to import Discogs release relationships to MusicBrainz
 // @author       majkinetor
 // @match        https://musicbrainz.org/release/*/edit-relationships
@@ -3304,7 +3304,11 @@
         applyToTracks !== void 0 ? `move-to-tracks:${applyToTracks ? "on" : "off"}` : null,
         createWorks !== void 0 ? `create-works:${createWorks ? "on" : "off"}` : null
       ].filter(Boolean).join(", ");
-      const note = buildEditNote(discogsUrl, opts);
+      const trackCount2 = Array.isArray(discogsTracklist) ? discogsTracklist.length : 0;
+      const inputStats = `Input: ${companies?.length || 0} companies, ${artistRoles?.length || 0} release credits, ${tracklistRels?.length || 0} tracklist credits on ${trackCount2} track${trackCount2 === 1 ? "" : "s"}`;
+      const dedupPart2 = dedupedThisSession > 0 ? `, ${dedupedThisSession} dispatch duplicate${dedupedThisSession === 1 ? "" : "s"}` : "";
+      const resultStats = `Result: ${added} added, ${existedInMb} already in MB${dedupPart2}, ${skipped} skipped, ${failed} failed`;
+      const note = buildEditNote(discogsUrl, opts, [inputStats, resultStats]);
       re.dispatch({ type: "update-edit-note", editNote: note });
     } catch (e) {
     }

--- a/userscripts/discogs_credits/src/dispatch.js
+++ b/userscripts/discogs_credits/src/dispatch.js
@@ -679,7 +679,16 @@ export async function dispatchAllRelationships(companies, artistRoles, tracklist
             applyToTracks   !== undefined ? `move-to-tracks:${applyToTracks ? 'on' : 'off'}` : null,
             createWorks     !== undefined ? `create-works:${createWorks ? 'on' : 'off'}` : null,
         ].filter(Boolean).join(', ');
-        const note = buildEditNote(discogsUrl, opts);
+        // Statistics (issue #56) — surface input size + dispatch outcome in
+        // the edit note so a reviewer can see at a glance how big the import
+        // was without expanding any log section.
+        const trackCount = Array.isArray(discogsTracklist) ? discogsTracklist.length : 0;
+        const inputStats = `Input: ${companies?.length || 0} companies, ${artistRoles?.length || 0} release credits, ${tracklistRels?.length || 0} tracklist credits on ${trackCount} track${trackCount === 1 ? '' : 's'}`;
+        const dedupPart = dedupedThisSession > 0
+            ? `, ${dedupedThisSession} dispatch duplicate${dedupedThisSession === 1 ? '' : 's'}`
+            : '';
+        const resultStats = `Result: ${added} added, ${existedInMb} already in MB${dedupPart}, ${skipped} skipped, ${failed} failed`;
+        const note = buildEditNote(discogsUrl, opts, [inputStats, resultStats]);
         re.dispatch({ type: 'update-edit-note', editNote: note });
     } catch(e) { /* ignore */ }
 


### PR DESCRIPTION
## Summary

Add two new lines to the edit note so a reviewer can see import size at a glance:

```
Import Discogs Credits v2026.5.25.… by majkinetor - …

Release URL: https://musicbrainz.org/release/…
Discogs URL: https://www.discogs.com/release/…
Options: per-track:on, move-to-tracks:on, create-works:on
Input: 5 companies, 8 release credits, 102 tracklist credits on 11 tracks
Result: 95 added, 5 already in MB, 4 skipped, 0 failed
```

## Implementation

[`buildEditNote`](https://github.com/majkinetor/musicbrainz-userscripts/blob/main/userscripts/discogs_credits/src/edit-note.js) already accepted an `extraLines` parameter; dispatch just had to wire it in alongside the existing `opts` line.

The `existedInMb` / `dedupedThisSession` split that [PR #49](https://github.com/majkinetor/musicbrainz-userscripts/pull/49) introduced for the in-log `Done:` summary applies here too — `, N dispatch duplicates` only appears when N > 0, keeping the common-case output compact.

## Verification

`pnpm run lint` + smoke fixture green.

Closes #56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)