### PR TITLE
Create (Dis) button — popup with Discogs profile (closes #5)

### DIFF
--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Discogs Credits
 // @namespace    majkinetor
-// @version      2026.5.25.223940
+// @version      2026.5.25.224351
 // @description  Add a button to import Discogs release relationships to MusicBrainz
 // @author       majkinetor
 // @match        https://musicbrainz.org/release/*/edit-relationships
@@ -343,6 +343,25 @@
       _releaseDataCache.set(url, json);
       return json;
     });
+  }
+  var _entityDataCache = /* @__PURE__ */ new Map();
+  function getDiscogsEntityData(resourceUrl) {
+    if (!resourceUrl) return Promise.resolve(null);
+    if (_entityDataCache.has(resourceUrl)) return Promise.resolve(_entityDataCache.get(resourceUrl));
+    return fetch(`${resourceUrl}?token=gYAnSAmIoXiHezHBmHoqcBCuJRyQLJBYSjurbGTZ`).then((r) => r.ok ? r.json() : null).then((json) => {
+      if (!json) {
+        _entityDataCache.set(resourceUrl, null);
+        return null;
+      }
+      const slim = {
+        profile: json.profile || "",
+        name: json.name || "",
+        namevariations: json.namevariations || [],
+        realname: json.realname || ""
+      };
+      _entityDataCache.set(resourceUrl, slim);
+      return slim;
+    }).catch(() => null);
   }
 
   // src/data/entity-map.js
@@ -2346,12 +2365,11 @@
               );
             }
           }
-          const createBtn = document.createElement("button");
-          createBtn.textContent = "Create in MB \u2197";
-          createBtn.style.cssText = "font-size:0.8rem;cursor:pointer;display:block;white-space:nowrap;";
-          createBtn.addEventListener("click", () => {
+          function openCreateTab(disambiguation) {
+            let createUrl;
+            let createParams;
             if (entityType === "artist") {
-              const createParams = {
+              createParams = {
                 "edit-artist.name": displayName,
                 "edit-artist.sort_name": guessSortName(displayName),
                 "edit-artist.type_id": "1"
@@ -2360,53 +2378,133 @@
                 createParams["edit-artist.url.0.text"] = discogsHref;
                 createParams["edit-artist.url.0.link_type_id"] = "180";
               }
-              const p = new URLSearchParams(createParams);
-              const newTab = window.open(`https://musicbrainz.org/artist/create?${p}`, "_blank");
-              if (newTab) {
-                const trySet = () => {
-                  try {
-                    newTab.sessionStorage.setItem("discogs-importer-pending-artist", r.entity.resource_url);
-                  } catch (e2) {
-                    setTimeout(trySet, 50);
-                  }
-                };
-                trySet();
-              }
-              const onCreated = (evt) => {
-                if (evt.data?.type !== "artist-created") return;
-                if (evt.data.resourceUrl !== r.entity.resource_url) return;
-                DISCOGS_CHANNEL.removeEventListener("message", onCreated);
-                setRowResolved({ id: evt.data.id, name: evt.data.name, disambiguation: evt.data.disambiguation });
-              };
-              DISCOGS_CHANNEL.addEventListener("message", onCreated);
+              if (disambiguation) createParams["edit-artist.comment"] = disambiguation;
+              createUrl = "https://musicbrainz.org/artist/create";
             } else {
               const ltId = entityType === "label" ? "217" : "705";
-              const p = new URLSearchParams({
+              createParams = {
                 [`edit-${entityType}.name`]: displayName,
                 [`edit-${entityType}.url.0.text`]: discogsHref,
                 [`edit-${entityType}.url.0.link_type_id`]: ltId
-              });
-              const newTab = window.open(`https://musicbrainz.org/${entityType}/create?${p}`, "_blank");
-              if (newTab) {
-                const trySet = () => {
-                  try {
-                    newTab.sessionStorage.setItem("discogs-importer-pending-artist", r.entity.resource_url);
-                  } catch (e2) {
-                    setTimeout(trySet, 50);
-                  }
-                };
-                trySet();
-              }
-              const onCreated = (evt) => {
-                if (evt.data?.type !== "artist-created") return;
-                if (evt.data.resourceUrl !== r.entity.resource_url) return;
-                DISCOGS_CHANNEL.removeEventListener("message", onCreated);
-                setRowResolved({ id: evt.data.id, name: evt.data.name, disambiguation: evt.data.disambiguation });
               };
-              DISCOGS_CHANNEL.addEventListener("message", onCreated);
+              if (disambiguation) createParams[`edit-${entityType}.comment`] = disambiguation;
+              createUrl = `https://musicbrainz.org/${entityType}/create`;
             }
-          });
+            const p = new URLSearchParams(createParams);
+            const newTab = window.open(`${createUrl}?${p}`, "_blank");
+            if (newTab) {
+              const trySet = () => {
+                try {
+                  newTab.sessionStorage.setItem("discogs-importer-pending-artist", r.entity.resource_url);
+                } catch (e2) {
+                  setTimeout(trySet, 50);
+                }
+              };
+              trySet();
+            }
+            const onCreated = (evt) => {
+              if (evt.data?.type !== "artist-created") return;
+              if (evt.data.resourceUrl !== r.entity.resource_url) return;
+              DISCOGS_CHANNEL.removeEventListener("message", onCreated);
+              setRowResolved({ id: evt.data.id, name: evt.data.name, disambiguation: evt.data.disambiguation });
+            };
+            DISCOGS_CHANNEL.addEventListener("message", onCreated);
+          }
+          const createBtn = document.createElement("button");
+          createBtn.textContent = "Create in MB \u2197";
+          createBtn.style.cssText = "font-size:0.8rem;cursor:pointer;display:block;white-space:nowrap;";
+          createBtn.addEventListener("click", () => openCreateTab(null));
           tdAction.appendChild(createBtn);
+          const createDisBtn = document.createElement("button");
+          createDisBtn.textContent = "Create (Dis) \u2197";
+          createDisBtn.title = "Create in MB with a disambiguation comment \u2014 pre-fills from the Discogs role, lets you adjust";
+          createDisBtn.style.cssText = "font-size:0.8rem;cursor:pointer;display:block;white-space:nowrap;margin-top:0.15rem;";
+          createDisBtn.addEventListener("click", () => openDisambiguationPopup());
+          tdAction.appendChild(createDisBtn);
+          async function openDisambiguationPopup() {
+            const distinctRoles = [];
+            const seen = /* @__PURE__ */ new Set();
+            for (const role of r._roles || []) {
+              const label2 = (role.displayLabel || role.linkType || "").trim();
+              if (!label2 || seen.has(label2)) continue;
+              seen.add(label2);
+              distinctRoles.push(label2);
+              if (distinctRoles.length === 3) break;
+            }
+            const defaultDis = distinctRoles.join(", ");
+            const overlay = document.createElement("div");
+            overlay.style.cssText = "position:fixed;inset:0;background:rgba(0,0,0,0.45);z-index:10000;display:flex;align-items:center;justify-content:center;";
+            const modal = document.createElement("div");
+            modal.style.cssText = "background:#fff;border-radius:0.5rem;padding:1rem 1.25rem;max-width:560px;width:90%;max-height:80vh;display:flex;flex-direction:column;gap:0.65rem;box-shadow:0 8px 24px rgba(0,0,0,0.3);";
+            const heading2 = document.createElement("div");
+            heading2.style.cssText = "font-weight:bold;font-size:1rem;";
+            heading2.textContent = `Create "${displayName}" in MB with disambiguation`;
+            modal.appendChild(heading2);
+            const label = document.createElement("label");
+            label.style.cssText = "font-size:0.85rem;color:#555;";
+            label.textContent = "Disambiguation (MB comment):";
+            modal.appendChild(label);
+            const disInput = document.createElement("input");
+            disInput.type = "text";
+            disInput.value = defaultDis;
+            disInput.style.cssText = "padding:0.4rem 0.5rem;border:1px solid #ccc;border-radius:0.25rem;font-size:0.95rem;";
+            modal.appendChild(disInput);
+            const profileLabel = document.createElement("div");
+            profileLabel.style.cssText = "font-size:0.82rem;color:#888;margin-top:0.35rem;";
+            profileLabel.textContent = "Discogs profile (select text to copy into the field above):";
+            modal.appendChild(profileLabel);
+            const profileBox = document.createElement("div");
+            profileBox.style.cssText = "border:1px solid #e0e0e0;border-radius:0.25rem;padding:0.45rem 0.55rem;background:#fafafa;font-size:0.85rem;line-height:1.45;white-space:pre-wrap;overflow:auto;max-height:18rem;flex:1;";
+            profileBox.textContent = "Loading profile from Discogs\u2026";
+            modal.appendChild(profileBox);
+            const btnRow2 = document.createElement("div");
+            btnRow2.style.cssText = "display:flex;gap:0.5rem;justify-content:flex-end;margin-top:0.35rem;";
+            const cancelBtn = document.createElement("button");
+            cancelBtn.textContent = "Cancel";
+            cancelBtn.style.cssText = "padding:0.4rem 0.9rem;cursor:pointer;";
+            const submitBtn = document.createElement("button");
+            submitBtn.textContent = "Create \u2197";
+            submitBtn.style.cssText = "padding:0.4rem 0.9rem;cursor:pointer;font-weight:bold;background:#2ecc40;color:#fff;border:none;border-radius:0.25rem;";
+            btnRow2.appendChild(cancelBtn);
+            btnRow2.appendChild(submitBtn);
+            modal.appendChild(btnRow2);
+            overlay.appendChild(modal);
+            document.body.appendChild(overlay);
+            const close = () => {
+              document.removeEventListener("keydown", onKey);
+              overlay.remove();
+            };
+            const onKey = (ev) => {
+              if (ev.key === "Escape") close();
+              else if (ev.key === "Enter" && ev.target === disInput) submit();
+            };
+            const submit = () => {
+              const dis = disInput.value.trim();
+              close();
+              openCreateTab(dis || null);
+            };
+            document.addEventListener("keydown", onKey);
+            overlay.addEventListener("click", (ev) => {
+              if (ev.target === overlay) close();
+            });
+            cancelBtn.addEventListener("click", close);
+            submitBtn.addEventListener("click", submit);
+            disInput.focus();
+            disInput.select();
+            try {
+              const data = await getDiscogsEntityData(r.entity?.resource_url);
+              const lines = [];
+              if (data?.realname && data.realname !== displayName) lines.push(`Real name: ${data.realname}`);
+              if (data?.namevariations?.length) lines.push(`Also known as: ${data.namevariations.slice(0, 6).join(", ")}`);
+              if (data?.profile) {
+                if (lines.length) lines.push("");
+                lines.push(data.profile);
+              }
+              profileBox.textContent = lines.length ? lines.join("\n") : "(no Discogs profile)";
+            } catch (e2) {
+              profileBox.textContent = "(failed to load Discogs profile)";
+            }
+          }
         }
         function makeCandidateRow(a) {
           const row = document.createElement("div");

--- a/userscripts/discogs_credits/src/api-discogs.js
+++ b/userscripts/discogs_credits/src/api-discogs.js
@@ -59,3 +59,45 @@ export function getDiscogsReleaseData(url) {
 export function clearReleaseDataCache(url) {
     _releaseDataCache.delete(url);
 }
+
+// Session cache for individual entity JSON (artist / label). Only the
+// fields the "Create (Dis)" popup needs are kept; nothing else fetches
+// these so a separate cache from `_releaseDataCache` is fine.
+const _entityDataCache = new Map();
+
+/**
+ * Fetch a Discogs entity's JSON (artist or label) and return the slim
+ * subset the create-with-disambiguation flow needs.
+ *
+ *   @param {string} resourceUrl — the Discogs entity's `resource_url`
+ *     (`https://api.discogs.com/<type>s/<id>`) — same shape that the
+ *     release JSON carries on every credited entity.
+ *
+ *   Returns `{ profile, name, namevariations, realname }` (each string
+ *   or `null`/absent), or `null` on fetch / parse failure.
+ *
+ * `profile` is Discogs's free-form biography blurb. The popup surfaces
+ * it so the user can pick a phrase for the MB disambiguation field —
+ * MB-side disambiguation should be short (a few words), while Discogs
+ * profiles can be paragraphs, so the popup shows the text + a default
+ * suggestion (first ~3 roles) and lets the user select / edit before
+ * submitting.
+ */
+export function getDiscogsEntityData(resourceUrl) {
+    if (!resourceUrl) return Promise.resolve(null);
+    if (_entityDataCache.has(resourceUrl)) return Promise.resolve(_entityDataCache.get(resourceUrl));
+    return fetch(`${resourceUrl}?token=gYAnSAmIoXiHezHBmHoqcBCuJRyQLJBYSjurbGTZ`)
+        .then(r => r.ok ? r.json() : null)
+        .then(json => {
+            if (!json) { _entityDataCache.set(resourceUrl, null); return null; }
+            const slim = {
+                profile:        json.profile        || '',
+                name:           json.name           || '',
+                namevariations: json.namevariations || [],
+                realname:       json.realname       || '',
+            };
+            _entityDataCache.set(resourceUrl, slim);
+            return slim;
+        })
+        .catch(() => null);
+}

--- a/userscripts/discogs_credits/src/review-table.js
+++ b/userscripts/discogs_credits/src/review-table.js
@@ -6,7 +6,7 @@
 
 import { readIdbRecord, writeIdbRecord }   from './storage.js';
 import { mbThrottle, fetchWithRetry }      from './api-mb.js';
-import { parseDiscogsUrl }                 from './api-discogs.js';
+import { parseDiscogsUrl, getDiscogsEntityData } from './api-discogs.js';
 import { guessSortName }                   from './mappers.js';
 import { getLogContainer }                 from './log.js';
 import { _hideBar }                        from './progress-bar.js';
@@ -498,61 +498,168 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
                         );
                     }
                 }
+                // Opens the MB create-entity tab pre-filled with name + Discogs
+                // URL relation, optionally also `comment` (= disambiguation).
+                // Used by both "Create in MB" (no disambiguation) and the
+                // "Create (Dis)" popup flow (issue #5).
+                function openCreateTab(disambiguation) {
+                    let createUrl;
+                    let createParams;
+                    if (entityType === 'artist') {
+                        createParams = {
+                            'edit-artist.name':      displayName,
+                            'edit-artist.sort_name': guessSortName(displayName),
+                            'edit-artist.type_id':   '1',
+                        };
+                        if (discogsHref) {
+                            createParams['edit-artist.url.0.text']         = discogsHref;
+                            createParams['edit-artist.url.0.link_type_id'] = '180';
+                        }
+                        if (disambiguation) createParams['edit-artist.comment'] = disambiguation;
+                        createUrl = 'https://musicbrainz.org/artist/create';
+                    } else {
+                        const ltId = entityType === 'label' ? '217' : '705';
+                        createParams = {
+                            [`edit-${entityType}.name`]:                displayName,
+                            [`edit-${entityType}.url.0.text`]:          discogsHref,
+                            [`edit-${entityType}.url.0.link_type_id`]: ltId,
+                        };
+                        if (disambiguation) createParams[`edit-${entityType}.comment`] = disambiguation;
+                        createUrl = `https://musicbrainz.org/${entityType}/create`;
+                    }
+                    const p = new URLSearchParams(createParams);
+                    const newTab = window.open(`${createUrl}?${p}`, '_blank');
+                    if (newTab) {
+                        const trySet = () => {
+                            try { newTab.sessionStorage.setItem('discogs-importer-pending-artist', r.entity.resource_url); }
+                            catch(e) { setTimeout(trySet, 50); }
+                        };
+                        trySet();
+                    }
+                    const onCreated = (evt) => {
+                        if (evt.data?.type !== 'artist-created') return;
+                        if (evt.data.resourceUrl !== r.entity.resource_url) return;
+                        DISCOGS_CHANNEL.removeEventListener('message', onCreated);
+                        setRowResolved({ id: evt.data.id, name: evt.data.name, disambiguation: evt.data.disambiguation });
+                    };
+                    DISCOGS_CHANNEL.addEventListener('message', onCreated);
+                }
+
                 const createBtn = document.createElement('button');
                 createBtn.textContent = 'Create in MB ↗';
                 createBtn.style.cssText = 'font-size:0.8rem;cursor:pointer;display:block;white-space:nowrap;';
-                createBtn.addEventListener('click', () => {
-                    if (entityType === 'artist') {
-                        const createParams = {
-                            'edit-artist.name': displayName,
-                            'edit-artist.sort_name': guessSortName(displayName),
-                            'edit-artist.type_id': '1',
-                        };
-                        if (discogsHref) {
-                            createParams['edit-artist.url.0.text'] = discogsHref;
-                            createParams['edit-artist.url.0.link_type_id'] = '180';
-                        }
-                        const p = new URLSearchParams(createParams);
-                        const newTab = window.open(`https://musicbrainz.org/artist/create?${p}`, '_blank');
-                        if (newTab) {
-                            const trySet = () => {
-                                try { newTab.sessionStorage.setItem('discogs-importer-pending-artist', r.entity.resource_url); }
-                                catch(e) { setTimeout(trySet, 50); }
-                            };
-                            trySet();
-                        }
-                        const onCreated = (evt) => {
-                            if (evt.data?.type !== 'artist-created') return;
-                            if (evt.data.resourceUrl !== r.entity.resource_url) return;
-                            DISCOGS_CHANNEL.removeEventListener('message', onCreated);
-                            setRowResolved({ id: evt.data.id, name: evt.data.name, disambiguation: evt.data.disambiguation });
-                        };
-                        DISCOGS_CHANNEL.addEventListener('message', onCreated);
-                    } else {
-                        const ltId = entityType === 'label' ? '217' : '705';
-                        const p = new URLSearchParams({
-                            [`edit-${entityType}.name`]: displayName,
-                            [`edit-${entityType}.url.0.text`]: discogsHref,
-                            [`edit-${entityType}.url.0.link_type_id`]: ltId,
-                        });
-                        const newTab = window.open(`https://musicbrainz.org/${entityType}/create?${p}`, '_blank');
-                        if (newTab) {
-                            const trySet = () => {
-                                try { newTab.sessionStorage.setItem('discogs-importer-pending-artist', r.entity.resource_url); }
-                                catch(e) { setTimeout(trySet, 50); }
-                            };
-                            trySet();
-                        }
-                        const onCreated = (evt) => {
-                            if (evt.data?.type !== 'artist-created') return;
-                            if (evt.data.resourceUrl !== r.entity.resource_url) return;
-                            DISCOGS_CHANNEL.removeEventListener('message', onCreated);
-                            setRowResolved({ id: evt.data.id, name: evt.data.name, disambiguation: evt.data.disambiguation });
-                        };
-                        DISCOGS_CHANNEL.addEventListener('message', onCreated);
-                    }
-                });
+                createBtn.addEventListener('click', () => openCreateTab(null));
                 tdAction.appendChild(createBtn);
+
+                // "Create (Dis)" — pops up a disambiguation editor. The user
+                // edits the suggested value (defaults to the row's first 3
+                // distinct roles), sees the Discogs profile blurb for context,
+                // and clicks Create to open the MB create tab with `comment`
+                // pre-filled. Issue #5.
+                const createDisBtn = document.createElement('button');
+                createDisBtn.textContent = 'Create (Dis) ↗';
+                createDisBtn.title = 'Create in MB with a disambiguation comment — pre-fills from the Discogs role, lets you adjust';
+                createDisBtn.style.cssText = 'font-size:0.8rem;cursor:pointer;display:block;white-space:nowrap;margin-top:0.15rem;';
+                createDisBtn.addEventListener('click', () => openDisambiguationPopup());
+                tdAction.appendChild(createDisBtn);
+
+                async function openDisambiguationPopup() {
+                    // Default suggestion: first 3 distinct role labels.
+                    const distinctRoles = [];
+                    const seen = new Set();
+                    for (const role of (r._roles || [])) {
+                        const label = (role.displayLabel || role.linkType || '').trim();
+                        if (!label || seen.has(label)) continue;
+                        seen.add(label);
+                        distinctRoles.push(label);
+                        if (distinctRoles.length === 3) break;
+                    }
+                    const defaultDis = distinctRoles.join(', ');
+
+                    const overlay = document.createElement('div');
+                    overlay.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,0.45);z-index:10000;display:flex;align-items:center;justify-content:center;';
+                    const modal = document.createElement('div');
+                    modal.style.cssText = 'background:#fff;border-radius:0.5rem;padding:1rem 1.25rem;max-width:560px;width:90%;max-height:80vh;display:flex;flex-direction:column;gap:0.65rem;box-shadow:0 8px 24px rgba(0,0,0,0.3);';
+
+                    const heading = document.createElement('div');
+                    heading.style.cssText = 'font-weight:bold;font-size:1rem;';
+                    heading.textContent = `Create "${displayName}" in MB with disambiguation`;
+                    modal.appendChild(heading);
+
+                    const label = document.createElement('label');
+                    label.style.cssText = 'font-size:0.85rem;color:#555;';
+                    label.textContent = 'Disambiguation (MB comment):';
+                    modal.appendChild(label);
+
+                    const disInput = document.createElement('input');
+                    disInput.type = 'text';
+                    disInput.value = defaultDis;
+                    disInput.style.cssText = 'padding:0.4rem 0.5rem;border:1px solid #ccc;border-radius:0.25rem;font-size:0.95rem;';
+                    modal.appendChild(disInput);
+
+                    const profileLabel = document.createElement('div');
+                    profileLabel.style.cssText = 'font-size:0.82rem;color:#888;margin-top:0.35rem;';
+                    profileLabel.textContent = 'Discogs profile (select text to copy into the field above):';
+                    modal.appendChild(profileLabel);
+
+                    const profileBox = document.createElement('div');
+                    profileBox.style.cssText = 'border:1px solid #e0e0e0;border-radius:0.25rem;padding:0.45rem 0.55rem;background:#fafafa;font-size:0.85rem;line-height:1.45;white-space:pre-wrap;overflow:auto;max-height:18rem;flex:1;';
+                    profileBox.textContent = 'Loading profile from Discogs…';
+                    modal.appendChild(profileBox);
+
+                    const btnRow = document.createElement('div');
+                    btnRow.style.cssText = 'display:flex;gap:0.5rem;justify-content:flex-end;margin-top:0.35rem;';
+                    const cancelBtn = document.createElement('button');
+                    cancelBtn.textContent = 'Cancel';
+                    cancelBtn.style.cssText = 'padding:0.4rem 0.9rem;cursor:pointer;';
+                    const submitBtn = document.createElement('button');
+                    submitBtn.textContent = 'Create ↗';
+                    submitBtn.style.cssText = 'padding:0.4rem 0.9rem;cursor:pointer;font-weight:bold;background:#2ecc40;color:#fff;border:none;border-radius:0.25rem;';
+                    btnRow.appendChild(cancelBtn);
+                    btnRow.appendChild(submitBtn);
+                    modal.appendChild(btnRow);
+
+                    overlay.appendChild(modal);
+                    document.body.appendChild(overlay);
+
+                    // Cleanup helpers — handle Esc, overlay click, Cancel, Submit.
+                    const close = () => {
+                        document.removeEventListener('keydown', onKey);
+                        overlay.remove();
+                    };
+                    const onKey = (ev) => {
+                        if (ev.key === 'Escape') close();
+                        else if (ev.key === 'Enter' && ev.target === disInput) submit();
+                    };
+                    const submit = () => {
+                        const dis = disInput.value.trim();
+                        close();
+                        openCreateTab(dis || null);
+                    };
+                    document.addEventListener('keydown', onKey);
+                    overlay.addEventListener('click', ev => { if (ev.target === overlay) close(); });
+                    cancelBtn.addEventListener('click', close);
+                    submitBtn.addEventListener('click', submit);
+
+                    // Focus + select the default so user can immediately type-replace.
+                    disInput.focus(); disInput.select();
+
+                    // Fetch the Discogs entity for the profile blurb (lazy —
+                    // doesn't block opening the modal).
+                    try {
+                        const data = await getDiscogsEntityData(r.entity?.resource_url);
+                        const lines = [];
+                        if (data?.realname && data.realname !== displayName) lines.push(`Real name: ${data.realname}`);
+                        if (data?.namevariations?.length) lines.push(`Also known as: ${data.namevariations.slice(0, 6).join(', ')}`);
+                        if (data?.profile) {
+                            if (lines.length) lines.push('');
+                            lines.push(data.profile);
+                        }
+                        profileBox.textContent = lines.length ? lines.join('\n') : '(no Discogs profile)';
+                    } catch (e) {
+                        profileBox.textContent = '(failed to load Discogs profile)';
+                    }
+                }
             }
 
             function makeCandidateRow(a) {


### PR DESCRIPTION
## Summary

Per your [comment on #5](https://github.com/majkinetor/musicbrainz-userscripts/issues/5#issuecomment-4537064554): a second create button (labeled `Create (Dis)`) that opens a popup with the Discogs profile text + a disambiguation field, pre-filled with the row's first 3 distinct roles.

## Flow

1. Click **Create (Dis) ↗** on any attention row.
2. Modal opens immediately. Top field is a text input pre-filled with e.g. `bass, vocal, writer` — the row's first 3 distinct role labels.
3. Beneath the input, the entity's Discogs profile loads (lazy, doesn't block opening). Includes `realname`, `namevariations`, and the free-form `profile` blurb. User can select / copy phrases from this text into the input.
4. Submit → opens `https://musicbrainz.org/<type>/create?…` in a new tab with `edit-<type>.comment` pre-populated alongside name + URL relation.

Keyboard: Enter submits, Esc / overlay-click / Cancel close. Default text is selected so type-to-replace works.

## Implementation

- `openCreateTab(disambiguation)` — factored out of the original click handler. The existing "Create in MB" button calls it with `null` (unchanged behaviour); the new popup flow calls it with the user's edited value.
- `getDiscogsEntityData(resourceUrl)` (new in [api-discogs.js](https://github.com/majkinetor/musicbrainz-userscripts/blob/fix-issue-5-create-with-disambiguation/userscripts/discogs_credits/src/api-discogs.js)) — slim fetch of `profile` / `name` / `namevariations` / `realname` with a session cache.
- Modal is plain DOM (no library). Overlay covers the page; click outside or Esc to dismiss.

## Verification

`pnpm run lint` + smoke fixture green. The popup path isn't exercised by the fixture suite (fixtures auto-confirm everything in the review table) — manual verification recommended on an attention row, e.g. the [Midwest Funk](https://musicbrainz.org/release/62a764a8-cf05-459c-a358-2c65dbf0b729) fixture which has 161 unresolved rows.

Closes #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)