### PR TITLE
Skip redundant per-row URL checks — reuse preflight's lookup

### DIFF
--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Discogs Credits
 // @namespace    majkinetor
-// @version      2026.5.25.231643
+// @version      2026.5.26.100439
 // @description  Add a button to import Discogs release relationships to MusicBrainz
 // @author       majkinetor
 // @match        https://musicbrainz.org/release/*/edit-relationships
@@ -1767,7 +1767,7 @@
     const searchName = entity.name;
     const displayName = kind === "artist" ? entity.anv && entity.anv.trim() || entity.name : entity.name;
     const discogsHref = entity.resource_url.replace(/https:\/\/api\.discogs\.com\/(\w+?)s\/(\d+)/, "https://www.discogs.com/$1/$2");
-    function buildResolved(mbUrl, mbName, mbDisambig, via2, actualKind = kind, fromCache = false) {
+    function buildResolved(mbUrl, mbName, mbDisambig, via2, actualKind = kind, fromCache = false, urlLinkedIds2) {
       return {
         type: "resolved",
         entityType: actualKind,
@@ -1777,6 +1777,18 @@
         mbUrl,
         mbName,
         mbDisambig,
+        // `urlLinkedIds` — MBIDs that have a relation to this Discogs URL,
+        //                  harvested from the URL lookup done during
+        //                  preflight. The review-table uses this to render
+        //                  the "Add Discogs link" / "already linked" / "linked
+        //                  to different MB <type>" badge without issuing
+        //                  another `/ws/2/url?…` query per row. `undefined`
+        //                  means "preflight didn't ask MB" (IDB hit on a
+        //                  legacy record that predates this field), in which
+        //                  case review-table falls back to its own per-row
+        //                  fetch. `[]` means "asked MB, got no relations" —
+        //                  no fallback needed.
+        urlLinkedIds: urlLinkedIds2,
         // `via`      — the resolution mechanism (`name` / `url` / `both` / `user`,
         //              or `cache` only when a legacy IDB record predates the
         //              `resolvedVia` field and we genuinely can't recover it).
@@ -1787,7 +1799,7 @@
         logEntry: { displayName, discogsHref, mbUrl, mbName, mbDisambig, via: via2, fromCache }
       };
     }
-    function buildAttention(nameMatches2, nameSearchFailed2, ambiguityReason) {
+    function buildAttention(nameMatches2, nameSearchFailed2, ambiguityReason, urlLinkedIds2) {
       return {
         type: "attention",
         entityType: kind,
@@ -1795,6 +1807,10 @@
         displayName,
         discogsHref,
         nameMatches: nameMatches2 || [],
+        // Same `urlLinkedIds` contract as on the resolved shape — review-table
+        // uses it to skip the per-row URL fetch even for attention rows once
+        // the user picks an MBID from the candidate list.
+        urlLinkedIds: urlLinkedIds2,
         // Only artists track this — used by the review table to badge
         // entries that failed because of a rate-limited name search vs
         // entries that genuinely don't exist in MB.
@@ -1810,6 +1826,10 @@
       const cachedRec = await readIdbRecord(key);
       if (cachedRec?.mbid && cachedRec?.entityType) {
         const via2 = cachedRec.resolvedVia || "cache";
+        let cachedLinkedIds = cachedRec.urlLinkedIds;
+        if (cachedLinkedIds === void 0 && (via2 === "url" || via2 === "both")) {
+          cachedLinkedIds = [cachedRec.mbid];
+        }
         if (cachedRec.name) {
           return buildResolved(
             cachedRec.mbUrl,
@@ -1817,7 +1837,8 @@
             cachedRec.disambiguation || "",
             via2,
             cachedRec.entityType,
-            true
+            true,
+            cachedLinkedIds
           );
         }
         const info = await fetchMbEntityInfo(cachedRec.entityType, cachedRec.mbid);
@@ -1833,11 +1854,12 @@
           info.disambiguation,
           via2,
           cachedRec.entityType,
-          true
+          true,
+          cachedLinkedIds
         );
       }
       if (cachedRec && Array.isArray(cachedRec.nameMatches)) {
-        return buildAttention(cachedRec.nameMatches, false);
+        return buildAttention(cachedRec.nameMatches, false, null, cachedRec.urlLinkedIds);
       }
     }
     const [nameJson, urlJson] = await Promise.all([
@@ -1864,6 +1886,7 @@
       disambiguation: exactNameMatches[0].disambiguation || ""
     } : null;
     let urlHit = null;
+    const urlLinkedIds = (urlJson?.relations || []).map((r) => kind === "place" ? r.place?.id || r.label?.id || null : r[kind]?.id || null).filter(Boolean);
     if (urlJson?.relations?.length > 0) {
       const rel = kind === "place" ? urlJson.relations.find((r) => r.place || r.label) : urlJson.relations.find((r) => r[kind]);
       if (rel) {
@@ -1886,7 +1909,8 @@
           mbUrl: null,
           disambiguation: "",
           resolvedVia: null,
-          nameMatches: matches
+          nameMatches: matches,
+          urlLinkedIds
         });
       }
     }
@@ -1901,7 +1925,8 @@
         return buildAttention(
           nameMatches,
           false,
-          `name \u2192 ${nameHit.kind}/${nameHit.mbid}, URL \u2192 ${urlHit.kind}/${urlHit.mbid}`
+          `name \u2192 ${nameHit.kind}/${nameHit.mbid}, URL \u2192 ${urlHit.kind}/${urlHit.mbid}`,
+          urlLinkedIds
         );
       }
     } else if (urlHit) {
@@ -1926,13 +1951,14 @@
           entityType: resolved.kind,
           name: finalName,
           disambiguation: finalDisam || "",
-          resolvedVia: via
+          resolvedVia: via,
+          urlLinkedIds
         });
       }
-      return buildResolved(mbUrl, finalName, finalDisam || "", via, resolved.kind);
+      return buildResolved(mbUrl, finalName, finalDisam || "", via, resolved.kind, false, urlLinkedIds);
     }
     await cacheAttention(nameMatches);
-    return buildAttention(nameMatches, nameSearchFailed);
+    return buildAttention(nameMatches, nameSearchFailed, null, urlLinkedIds);
   }
   async function resolveAll(entities, opts) {
     const { kindOf, progressLi, bypassIdb, progressLabel } = opts;
@@ -2348,6 +2374,14 @@
             if (!discogsHref) {
               linkSlot.textContent = "\u26A0 No Discogs page";
               linkSlot.style.color = "#c80";
+            } else if (Array.isArray(r.urlLinkedIds)) {
+              const result = r.urlLinkedIds.includes(selected.id) ? "linked" : r.urlLinkedIds.length > 0 ? "other" : "none";
+              _urlCheckSessionCache.set(urlCheckCacheKey, result);
+              try {
+                localStorage.setItem(urlCheckLsKey, JSON.stringify({ date: urlCheckToday, result }));
+              } catch (e2) {
+              }
+              applyUrlCheckResult(result);
             } else if (urlCheckCached !== null) {
               applyUrlCheckResult(urlCheckCached);
             } else {

--- a/userscripts/discogs_credits/src/preflight.js
+++ b/userscripts/discogs_credits/src/preflight.js
@@ -63,10 +63,22 @@ async function resolveEntity(entity, kind, opts) {
     const discogsHref = entity.resource_url
         .replace(/https:\/\/api\.discogs\.com\/(\w+?)s\/(\d+)/, 'https://www.discogs.com/$1/$2');
 
-    function buildResolved(mbUrl, mbName, mbDisambig, via, actualKind = kind, fromCache = false) {
+    function buildResolved(mbUrl, mbName, mbDisambig, via, actualKind = kind, fromCache = false, urlLinkedIds) {
         return {
             type: 'resolved', entityType: actualKind, entity,
             displayName, discogsHref, mbUrl, mbName, mbDisambig,
+            // `urlLinkedIds` — MBIDs that have a relation to this Discogs URL,
+            //                  harvested from the URL lookup done during
+            //                  preflight. The review-table uses this to render
+            //                  the "Add Discogs link" / "already linked" / "linked
+            //                  to different MB <type>" badge without issuing
+            //                  another `/ws/2/url?…` query per row. `undefined`
+            //                  means "preflight didn't ask MB" (IDB hit on a
+            //                  legacy record that predates this field), in which
+            //                  case review-table falls back to its own per-row
+            //                  fetch. `[]` means "asked MB, got no relations" —
+            //                  no fallback needed.
+            urlLinkedIds,
             // `via`      — the resolution mechanism (`name` / `url` / `both` / `user`,
             //              or `cache` only when a legacy IDB record predates the
             //              `resolvedVia` field and we genuinely can't recover it).
@@ -78,10 +90,14 @@ async function resolveEntity(entity, kind, opts) {
         };
     }
 
-    function buildAttention(nameMatches, nameSearchFailed, ambiguityReason) {
+    function buildAttention(nameMatches, nameSearchFailed, ambiguityReason, urlLinkedIds) {
         return {
             type: 'attention', entityType: kind, entity,
             displayName, discogsHref, nameMatches: nameMatches || [],
+            // Same `urlLinkedIds` contract as on the resolved shape — review-table
+            // uses it to skip the per-row URL fetch even for attention rows once
+            // the user picks an MBID from the candidate list.
+            urlLinkedIds,
             // Only artists track this — used by the review table to badge
             // entries that failed because of a rate-limited name search vs
             // entries that genuinely don't exist in MB.
@@ -109,10 +125,17 @@ async function resolveEntity(entity, kind, opts) {
             // existed fall back to the literal `cache` (still flagged
             // `fromCache: true` for symmetry, but the label is just `cache`).
             const via = cachedRec.resolvedVia || 'cache';
+            // `urlLinkedIds` was added later — old records lack it. Synthesise
+            // for via='url'/'both' (we know the linked MBID by definition);
+            // leave undefined otherwise so review-table falls back to query.
+            let cachedLinkedIds = cachedRec.urlLinkedIds;
+            if (cachedLinkedIds === undefined && (via === 'url' || via === 'both')) {
+                cachedLinkedIds = [cachedRec.mbid];
+            }
             if (cachedRec.name) {
                 return buildResolved(cachedRec.mbUrl, cachedRec.name,
                                      cachedRec.disambiguation || '', via,
-                                     cachedRec.entityType, true);
+                                     cachedRec.entityType, true, cachedLinkedIds);
             }
             // Name missing — fetch it once, write back, return.
             const info = await fetchMbEntityInfo(cachedRec.entityType, cachedRec.mbid);
@@ -123,7 +146,7 @@ async function resolveEntity(entity, kind, opts) {
                 });
             }
             return buildResolved(cachedRec.mbUrl, info.name, info.disambiguation,
-                                 via, cachedRec.entityType, true);
+                                 via, cachedRec.entityType, true, cachedLinkedIds);
         }
         if (cachedRec && Array.isArray(cachedRec.nameMatches)) {
             // Negative cache hit — we previously ran MB queries for this
@@ -131,7 +154,7 @@ async function resolveEntity(entity, kind, opts) {
             // remembered candidate list without re-querying MB so that an
             // immediate page reload doesn't redo every unresolved-entity
             // round-trip. Use the "🔄 Refresh from MB" button to bypass.
-            return buildAttention(cachedRec.nameMatches, false);
+            return buildAttention(cachedRec.nameMatches, false, null, cachedRec.urlLinkedIds);
         }
     }
 
@@ -167,8 +190,13 @@ async function resolveEntity(entity, kind, opts) {
 
     // URL relation — extract the first matching rel (kind-specific; places
     // also accept label rels because MB editors often file a facility as a
-    // label rather than a place).
+    // label rather than a place). Also collect ALL linked MBIDs (regardless
+    // of which one we pick) so the review-table can answer "is the chosen
+    // entity already linked?" without re-querying MB per row.
     let urlHit = null;
+    const urlLinkedIds = (urlJson?.relations || [])
+        .map(r => kind === 'place' ? (r.place?.id || r.label?.id || null) : (r[kind]?.id || null))
+        .filter(Boolean);
     if (urlJson?.relations?.length > 0) {
         const rel = kind === 'place'
             ? urlJson.relations.find(r => r.place || r.label)
@@ -200,6 +228,7 @@ async function resolveEntity(entity, kind, opts) {
                 disambiguation: '',
                 resolvedVia:    null,
                 nameMatches:    matches,
+                urlLinkedIds,
             });
         }
     }
@@ -222,7 +251,8 @@ async function resolveEntity(entity, kind, opts) {
             await cacheAttention(nameMatches);
             return buildAttention(
                 nameMatches, false,
-                `name → ${nameHit.kind}/${nameHit.mbid}, URL → ${urlHit.kind}/${urlHit.mbid}`
+                `name → ${nameHit.kind}/${nameHit.mbid}, URL → ${urlHit.kind}/${urlHit.mbid}`,
+                urlLinkedIds,
             );
         }
     } else if (urlHit) {
@@ -251,14 +281,15 @@ async function resolveEntity(entity, kind, opts) {
                 name:           finalName,
                 disambiguation: finalDisam || '',
                 resolvedVia:    via,
+                urlLinkedIds,
             });
         }
-        return buildResolved(mbUrl, finalName, finalDisam || '', via, resolved.kind);
+        return buildResolved(mbUrl, finalName, finalDisam || '', via, resolved.kind, false, urlLinkedIds);
     }
 
     // Nothing resolved.
     await cacheAttention(nameMatches);
-    return buildAttention(nameMatches, nameSearchFailed);
+    return buildAttention(nameMatches, nameSearchFailed, null, urlLinkedIds);
 }
 
 /**

--- a/userscripts/discogs_credits/src/review-table.js
+++ b/userscripts/discogs_credits/src/review-table.js
@@ -482,6 +482,18 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
                         // No Discogs URL — skip URL check entirely
                         linkSlot.textContent = '⚠ No Discogs page';
                         linkSlot.style.color = '#c80';
+                    } else if (Array.isArray(r.urlLinkedIds)) {
+                        // Preflight already harvested the Discogs-URL → MB-entity
+                        // relations (parallel with name search). Compute the row's
+                        // state from that without firing another `/ws/2/url?…`
+                        // request per row. Populates both caches so post-import
+                        // re-checks (focus-return) stay equally cheap.
+                        const result = r.urlLinkedIds.includes(selected.id) ? 'linked'
+                                     : r.urlLinkedIds.length > 0          ? 'other'
+                                                                          : 'none';
+                        _urlCheckSessionCache.set(urlCheckCacheKey, result);
+                        try { localStorage.setItem(urlCheckLsKey, JSON.stringify({ date: urlCheckToday, result })); } catch(e) {}
+                        applyUrlCheckResult(result);
                     } else if (urlCheckCached !== null) {
                         applyUrlCheckResult(urlCheckCached);
                     } else {

--- a/userscripts/discogs_credits/src/storage.js
+++ b/userscripts/discogs_credits/src/storage.js
@@ -21,6 +21,12 @@
 //                      //   both  — name AND url agreed (high confidence)
 //                      //   user  — user picked / confirmed in the review table
 //     resolvedAt,      // ISO8601 timestamp of the resolution
+//     urlLinkedIds,    // MBIDs that have a relation to this Discogs URL,
+//                      // harvested from preflight's `/ws/2/url?inc=<kind>-rels`
+//                      // call. Lets the review-table answer "is X linked to
+//                      // this Discogs URL?" without re-fetching per row.
+//                      // Absent on legacy records — review-table falls back
+//                      // to its own query in that case.
 //   }
 //
 // Record shape — UNRESOLVED (preflight found no auto-match, user needs to
@@ -36,6 +42,7 @@
 //     disambiguation: '',
 //     resolvedVia:    null,
 //     nameMatches:    [ { id, name, disambiguation, score }, … ],  // search hits
+//     urlLinkedIds:   [ <mbid>, … ],                                // see above
 //     resolvedAt,
 //   }
 //


### PR DESCRIPTION
## Summary

Per your observation: preflight runs `/ws/2/url?resource=<discogs-url>&inc=<kind>-rels` in parallel with the name search, and the review-table then fires the **same request** again per row. ~80 redundant MB requests on a typical full-fixture release, right before the dispatch phase that needs MB for the WS2 position-map fetch — if MB rate-limits the burst, the pause cascades.

## Fix

Preflight harvests `urlLinkedIds` (the array of MBIDs linked to the Discogs URL) from its existing URL lookup and propagates it through:

- The result object (both `'resolved'` and `'attention'` shapes)
- The IDB cache record (both positive and negative)

Review-table reads `r.urlLinkedIds` and computes the `linked` / `other` / `none` state locally without firing its own request.

## Backward compatibility

Legacy IDB records (written before this PR) keep working:

| Cached `via` | Behavior |
|---|---|
| `'url'` or `'both'` | linkedIds synthesised as `[cachedRec.mbid]` (we know that MBID is linked by definition) → review-table skips query |
| `'name'`, `'cache'`, `null` | `urlLinkedIds` left undefined → review-table falls back to its per-row query (same as before) |

Records get the new field naturally as users re-resolve via the 🔄 Refresh from MB button.

## Verification

Smoke + lint green. The test profile's IDB is entirely legacy entries (all `via='cache'`), so the new path can't fire there — but the fallback is unchanged. Once you run a fresh release on the new bundle, the second visit will skip the per-row URL queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)