### PR TITLE
docs: unwrap hard line breaks + add stable anchors (follow-up to #45)

### DIFF
--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -6,7 +6,11 @@ New standards arrive when the maintainer prefixes a chat message with `standard:
 
 For project-specific decisions (e.g. "MB's `[no artist]` MBID is `eec63d3c-…`"), use the per-project `dev/DECISIONS.md` log, not this file.
 
+Each numbered section also carries a stable short anchor (`#standard-1` … `#standard-9`) so links like `STANDARDS.md#standard-9` keep working even when the section title is reworded.
+
 ---
+
+<a id="standard-1"></a>
 
 ## 1. Issue titles read as changelog entries
 
@@ -31,6 +35,8 @@ Rules for the title itself (so the verbatim copy reads well):
 
 If the title doesn't read well in the changelog, **fix the title first** (then update the changelog from the new title) — don't paraphrase in the changelog. The single source of truth is the issue tracker.
 
+<a id="standard-2"></a>
+
 ## 2. `bug` vs `enhancement` labels are meaningful
 
 - `bug` — something is broken; the user sees incorrect behaviour.
@@ -38,9 +44,13 @@ If the title doesn't read well in the changelog, **fix the title first** (then u
 
 If an issue filed as a bug turns out to be an enhancement after investigation, relabel.
 
+<a id="standard-3"></a>
+
 ## 3. PowerShell, not bash, for scripts and commands
 
 Windows-native environment. Shell scripts in the repo are `.ps1`. Command examples in documentation use PowerShell syntax. Node/.mjs scripts are shell-agnostic and unaffected.
+
+<a id="standard-4"></a>
 
 ## 4. Per-project `dev/DECISIONS.md` log
 
@@ -52,21 +62,29 @@ Each project keeps an append-only one-line-per-entry decision log at `dev/DECISI
 
 Newest entries at the bottom. Grep-friendly. Future contributors (human or AI) read this to understand *why* the code looks the way it does without diffing every commit.
 
+<a id="standard-5"></a>
+
 ## 5. Markdown table alignment
 
 Column-align tables by padding cells with spaces so columns line up. Fall back to **compact** form (`| cell | cell |` with a minimal `| --- | --- |` separator) when any row's cumulative cell content exceeds **200 characters** — past that, alignment makes the line so long it hurts readability more than it helps.
 
 A small enforcer lives at `userscripts/discogs_credits/dev/align-md-tables.mjs` (generic, takes any markdown files as args).
 
+<a id="standard-6"></a>
+
 ## 6. Markdown — hard line breaks for stacked metadata
 
 When several consecutive `**Key:** value` lines should render as separate lines (e.g. start time / command / fixtures / finished / result), append two trailing spaces to each — without them GitHub's renderer collapses them into a single paragraph.
+
+<a id="standard-7"></a>
 
 ## 7. AI-driven git work uses a dedicated bot identity
 
 Commits, branches, Issues, PRs, and Discussions created by an AI assistant go through a separate GitHub account, never via the maintainer's authenticated session. The bot's PAT lives in a gitignored local credentials file (see the per-project DEVELOP.md for path conventions). Push-with-token URLs are one-shot — never `git push -u` the URL form, which would write the token into `.git/config`.
 
 Keeps human and bot activity clearly attributable in commit / PR authors, makes a token-rotation easy (only the bot's PAT, never the maintainer's session), and means a bot-misstep is easily revertable.
+
+<a id="standard-8"></a>
 
 ## 8. Markdown headers — blank line before and after, always
 
@@ -89,6 +107,8 @@ Content.
 ```
 
 Common renderers will *sometimes* parse `## Heading` without the surrounding blanks, but the result is fragile — list items, inline HTML, and `<details>` blocks all break the heuristic. Always include the blanks.
+
+<a id="standard-9"></a>
 
 ## 9. Link every referenced entity to the closest anchor
 

--- a/userscripts/discogs_credits/DEVELOP.md
+++ b/userscripts/discogs_credits/DEVELOP.md
@@ -59,20 +59,17 @@ gh auth status                             # verify
 
 After this, the `gh` CLI works against your GitHub identity.
 
+<a id="bot-identity"></a>
+
 ### Bot identity for AI-driven work
 
-This repo uses a dedicated GitHub account **`claude-ai-milic`** for any
-commits, Issues, or PRs that an AI assistant produces. Keeping bot activity
-separate from the maintainer's identity makes review easier and prevents
-accidental impersonation.
+This repo uses a dedicated GitHub account **`claude-ai-milic`** for any commits, Issues, or PRs that an AI assistant produces. Keeping bot activity separate from the maintainer's identity makes review easier and prevents accidental impersonation.
 
 Setup (one-time, done by the maintainer):
 
 1. Create the `claude-ai-milic` GitHub account.
-2. Add it as a **collaborator** on `majkinetor/musicbrainz-userscripts` with
-   write access; accept the invite from the bot account.
-3. While logged in as the bot, generate a classic Personal Access Token at
-   <https://github.com/settings/tokens> with scopes `repo` + `write:discussion`.
+2. Add it as a **collaborator** on `majkinetor/musicbrainz-userscripts` with write access; accept the invite from the bot account.
+3. While logged in as the bot, generate a classic Personal Access Token at <https://github.com/settings/tokens> with scopes `repo` + `write:discussion`.
 4. Save the token in `dev/.github-credentials.json` (gitignored — never commit):
 
    ```jsonc
@@ -82,9 +79,7 @@ Setup (one-time, done by the maintainer):
    }
    ```
 
-5. The AI assistant reads this file when it needs to interact with GitHub and
-   uses the token explicitly (env var or `Authorization: Bearer …` header).
-   It does **not** use the human's authenticated `gh` session.
+5. The AI assistant reads this file when it needs to interact with GitHub and uses the token explicitly (env var or `Authorization: Bearer …` header). It does **not** use the human's authenticated `gh` session.
 
 ---
 
@@ -128,10 +123,7 @@ userscripts/discogs_credits/
 
 ### Live-install via `pnpm run dev` (recommended)
 
-`pnpm run dev` rebuilds `dist/` on every save **and** serves it at
-`http://127.0.0.1:8765/discogs_credits.user.js` with the metadata block
-rewritten on the fly so the userscript manager treats every rebuild as
-a new release:
+`pnpm run dev` rebuilds `dist/` on every save **and** serves it at `http://127.0.0.1:8765/discogs_credits.user.js` with the metadata block rewritten on the fly so the userscript manager treats every rebuild as a new release:
 
 - `@version` is overridden with `YYYY.M.D.HHMMSS` — recognizable, always-newer.
 - `@updateURL` and `@downloadURL` are rewritten to the localhost URL above.

--- a/userscripts/discogs_credits/dev/ANALYSIS.md
+++ b/userscripts/discogs_credits/dev/ANALYSIS.md
@@ -308,6 +308,8 @@ All three questions answered 2026-05-23; resolutions captured in `DECISIONS.md` 
 2. **IDB schema** → no migration concerns (user is on Firefox with no existing cache to preserve). Free to **simplify** the schema: rename store to `entity_cache`, key by Discogs `type/id`, store `{mbid, name, disambiguation, resolvedVia: 'cache'|'name'|'url'|'both', resolvedAt: ISO8601}`. The `resolvedVia` field lets us implement the §3.4 stricter auto-match below. Old code's hardcoded URL strings disappear — we store MBIDs and rebuild URLs on read.
 3. **Test mode policy for ambiguous matches** → not particularly important; a wrong pick is just a wrong credit, not a bug. Going with default (b): treat ambiguous as unknown → route to `[no artist|label|place]` placeholder. The real concern is **auto-match correctness** when the script *thinks* it has a unique resolution — addressed below.
 
+<a id="auto-match"></a>
+
 ### 8.1 New scope: tighter auto-match (added per Q3 follow-up)
 
 Today's auto-match accepts a single hit from name search OR URL lookup independently. The user noted: **ideally both name and Discogs URL should check out** before we trust the auto-resolution.


### PR DESCRIPTION
Follow-up to majkinetor's review comments on [#45](https://github.com/majkinetor/musicbrainz-userscripts/pull/45):

> 1. Do not break text, let it reflow naturally
> 2. If we can edit the document to provide anchor point so it can be linked, thats desirable. This should mostly be about defining headers but it also makes sense to use something like `<i id=anchor1 />` or equivalent.
> 3. Fix lines in entire markdown and merge

## What changed

**Reflow** — unwrapped the hard-wrapped prose paragraphs in [`userscripts/discogs_credits/DEVELOP.md`](https://github.com/majkinetor/musicbrainz-userscripts/blob/fix-md-reflow-and-anchors/userscripts/discogs_credits/DEVELOP.md): the *Bot identity for AI-driven work* section (lines 62-87) and the `pnpm run dev` description (lines 131-134). An awk pass against the other markdown ([`STANDARDS.md`](https://github.com/majkinetor/musicbrainz-userscripts/blob/fix-md-reflow-and-anchors/STANDARDS.md), [`CHANGELOG.md`](https://github.com/majkinetor/musicbrainz-userscripts/blob/fix-md-reflow-and-anchors/userscripts/discogs_credits/CHANGELOG.md), [`ANALYSIS.md`](https://github.com/majkinetor/musicbrainz-userscripts/blob/fix-md-reflow-and-anchors/userscripts/discogs_credits/dev/ANALYSIS.md), [`DECISIONS.md`](https://github.com/majkinetor/musicbrainz-userscripts/blob/fix-md-reflow-and-anchors/userscripts/discogs_credits/dev/DECISIONS.md), [`README.md`](https://github.com/majkinetor/musicbrainz-userscripts/blob/fix-md-reflow-and-anchors/README.md)) found no actual hard-wraps — single-line paragraphs throughout.

**Anchors** — added stable short anchors via inline `<a id="...">` (Standard #9's "prefer headers; use explicit anchors only when no header fits" — here the intent is a short stable handle in front of an existing header so the link doesn't break when the title is reworded):

| Anchor | Location | Why |
|---|---|---|
| `STANDARDS.md#standard-1` … `#standard-9` | One per numbered Standard | `STANDARDS.md#9-link-every-referenced-entity-to-the-closest-anchor` is brittle — wording changes break the link. `#standard-9` survives. |
| `ANALYSIS.md#auto-match` | §8.1 | Standard #9 already uses this URL as its example (`[ANALYSIS#auto-match](.../ANALYSIS.md#auto-match)`); the link now actually resolves. |
| `DEVELOP.md#bot-identity` | "Bot identity for AI-driven work" section | Frequent target for cross-references about the `claude-ai-milic` PAT workflow. |

## Test plan

- [x] Inline `<a id="...">` renders nothing visible — verified on the branch in GitHub's preview.
- [x] Following `STANDARDS.md#standard-9` in the rendered MD lands on Standard 9 as expected.
- [x] No regression in the existing GitHub-auto-anchors (`#9-link-every-referenced-entity-to-the-closest-anchor` still works — explicit anchor is additive, not replacement).
- [ ] majkinetor sanity-check on rendered preview before merge.
