### PR TITLE
dev: hide notif-poller console flash via wscript+vbs

### DIFF
--- a/userscripts/discogs_credits/dev/install-notification-task.ps1
+++ b/userscripts/discogs_credits/dev/install-notification-task.ps1
@@ -15,6 +15,7 @@ $ErrorActionPreference = 'Stop'
 
 $here       = Split-Path -Parent $MyInvocation.MyCommand.Path
 $pollerPath = (Resolve-Path (Join-Path $here 'check-gh-notifications.ps1')).Path
+$vbsPath    = (Resolve-Path (Join-Path $here 'run-hidden.vbs')).Path
 $taskName   = 'MB-Userscripts notif poller'
 
 # Default: every 10 minutes from 09:00 to 23:50 local = 90 polls/day.
@@ -35,9 +36,13 @@ $repeatPattern = (New-ScheduledTaskTrigger -Once -At $startTime `
 $dailyTrigger.Repetition = $repeatPattern
 $triggers = @($dailyTrigger)
 
+# wscript + `run-hidden.vbs` instead of direct `powershell -WindowStyle
+# Hidden` — the latter still flashes a console window for one frame
+# before applying Hidden; wscript spawns the process with no window from
+# the start. See `run-hidden.vbs` for the rationale.
 $action = New-ScheduledTaskAction `
-    -Execute 'powershell.exe' `
-    -Argument "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$pollerPath`""
+    -Execute 'wscript.exe' `
+    -Argument "`"$vbsPath`" `"$pollerPath`""
 
 $principal = New-ScheduledTaskPrincipal `
     -UserId  ([System.Security.Principal.WindowsIdentity]::GetCurrent().Name) `

--- a/userscripts/discogs_credits/dev/run-hidden.vbs
+++ b/userscripts/discogs_credits/dev/run-hidden.vbs
@@ -1,0 +1,26 @@
+' Launch a PowerShell script with NO console window flash.
+'
+' Background: Task Scheduler invoking `powershell.exe -WindowStyle Hidden
+' -File <script>.ps1` still flashes a console window for one frame before
+' the runtime applies the Hidden style — long-standing Windows quirk.
+' WScript.Shell.Run with intWindowStyle = 0 starts the process with no
+' window from the very first frame, eliminating the flicker.
+'
+' Usage:
+'   wscript.exe run-hidden.vbs <absolute-path-to-script.ps1>
+'
+' Wired in from `install-notification-task.ps1`; the registered task
+' invokes wscript on this file instead of powershell directly.
+
+If WScript.Arguments.Count < 1 Then
+    WScript.Quit 1
+End If
+
+Dim shell, cmd
+Set shell = CreateObject("WScript.Shell")
+cmd = "powershell.exe -NoProfile -ExecutionPolicy Bypass -File """ & WScript.Arguments(0) & """"
+
+' Run(command, intWindowStyle, bWaitOnReturn)
+'   intWindowStyle = 0  -> hidden, no window ever shown
+'   bWaitOnReturn  = True -> propagate exit code so Task Scheduler logs it
+shell.Run cmd, 0, True


### PR DESCRIPTION
Maintainer feedback after merging [#65](https://github.com/majkinetor/musicbrainz-userscripts/pull/65): *"powershell window shortly appear when it is triggered. It should be hidden."*

`powershell.exe -WindowStyle Hidden` still creates a console window for one frame before the runtime applies the Hidden style. Long-standing Windows quirk that's visible as a flicker on every Task Scheduler fire.

## Fix

Added [`dev/run-hidden.vbs`](https://github.com/majkinetor/musicbrainz-userscripts/blob/fix-task-scheduler-window-flash/userscripts/discogs_credits/dev/run-hidden.vbs) — a 4-line VBScript that uses `WScript.Shell.Run(cmd, 0, True)` where `intWindowStyle = 0` spawns the process with no window from the very first frame. `bWaitOnReturn = True` preserves the exit code so Task Scheduler still logs failures.

[`install-notification-task.ps1`](https://github.com/majkinetor/musicbrainz-userscripts/blob/fix-task-scheduler-window-flash/userscripts/discogs_credits/dev/install-notification-task.ps1) now registers the task to execute `wscript.exe run-hidden.vbs <poller.ps1>` instead of `powershell.exe -WindowStyle Hidden -File <poller.ps1>`.

## Verification

Re-registered the task on this machine and triggered it manually — fresh entry in [`.notif-poll.log`](https://github.com/majkinetor/musicbrainz-userscripts/blob/fix-task-scheduler-window-flash/userscripts/discogs_credits/dev/check-gh-notifications.ps1) at `17:26:42` with no console flash. Next 10-min cycle (and all subsequent ones) run flicker-free.

## After merge

One-line refresh to pick up the new Action shape:

```powershell
powershell -ExecutionPolicy Bypass -File userscripts\discogs_credits\dev\install-notification-task.ps1
```

(Existing task entries on already-set-up machines keep the old `powershell -WindowStyle Hidden` invocation until refreshed.)
