### PR TITLE
dev: deterministic merge detection + blank-count fix (follow-up to #71)

### DIFF
--- a/userscripts/discogs_credits/dev/check-gh-notifications.ps1
+++ b/userscripts/discogs_credits/dev/check-gh-notifications.ps1
@@ -215,11 +215,69 @@ foreach ($n in $notifs) {
     }
 }
 
+# =====================================================================
+# Pass 2: deterministic merge detection (independent of GH notifications)
+# =====================================================================
+# GH doesn't reliably emit a notification when a PR is merged — esp.
+# when the bot opened the PR and the maintainer merges with no further
+# interaction. This second pass uses the Search API to find bot-authored
+# PRs merged since `lastPolled`, regardless of whether GH bothered to
+# notify the bot. Surfaced as `kind='event'` with `reason='merged'`.
+# Repository is hardcoded -- this poller is single-project by design.
+$mergeRepo = 'majkinetor/musicbrainz-userscripts'
+# Search needs a lower-bound timestamp. `lastPolled` already covers
+# everything we've reacted to; reuse it. If empty (first run), look back
+# 1 hour so we don't flood with historical merges.
+$mergeSinceText = $sinceText
+if (-not $mergeSinceText) {
+    $mergeSinceText = (Get-Date).ToUniversalTime().AddHours(-1).ToString('yyyy-MM-ddTHH:mm:ssZ', [System.Globalization.CultureInfo]::InvariantCulture)
+}
+$searchQuery = "repo:$mergeRepo is:pr is:merged author:$botLogin merged:>=$mergeSinceText"
+$searchUrl   = 'https://api.github.com/search/issues?q=' + [System.Uri]::EscapeDataString($searchQuery)
+Log-Line "  GET $searchUrl"
+try {
+    $sresp = Invoke-WebRequest -Uri $searchUrl -Headers $headers -UseBasicParsing -ErrorAction Stop
+    $sstatus = [int]$sresp.StatusCode
+    $sbody = if ($sresp.Content) { $sresp.Content | ConvertFrom-Json } else { $null }
+    $merged = @()
+    if ($sbody -and $sbody.items) { foreach ($it in $sbody.items) { $merged += $it } }
+    Log-Line "    -> HTTP $sstatus, $($merged.Count) merged PR(s) by $botLogin since $mergeSinceText"
+    foreach ($pr in $merged) {
+        $prNum = '#' + [string]$pr.number
+        $prTitle = $pr.title
+        # Search returns `closed_at` but not the precise merged_at. For
+        # PRs `closed_at` == `merged_at` when `state=closed,merged=true`.
+        $mergedAt = $pr.closed_at
+        $mergeKey = "pr-merge${prNum}@$mergedAt"
+        Log-Line "  $prNum '$prTitle'  (merged_at=$mergedAt)"
+        if ($state.seenComments -contains $mergeKey) {
+            Log-Line '    -> skip: already seen (dedupe)'
+            continue
+        }
+        Log-Line "    -> ACTIONABLE (event): merged"
+        $actionable += [pscustomobject]@{
+            kind       = 'event'
+            number     = $prNum
+            title      = $prTitle
+            author     = $botLogin   # the PR's author (filter target)
+            type       = 'PullRequest'
+            reason     = 'merged'
+            url        = $pr.html_url
+            commentUrl = $mergeKey
+        }
+    }
+} catch {
+    # Search failures shouldn't kill the rest of the poll. Log and move
+    # on -- next tick will retry.
+    Log-Line "    -> WARN: merge search failed: $($_.Exception.Message)"
+}
+
 Log-Line "  result: $($notifs.Count) unread, $($actionable.Count) actionable"
 if ($actionable.Count -gt 0) {
     # One-line summary of every actionable item:
     #   '#65 by majkinetor: title'             (comment)
-    #   '#70 event (state_change): title'      (event)
+    #   '#70 event (state_change): title'      (event from notification)
+    #   '#71 event (merged): title'            (event from search)
     foreach ($a in $actionable) {
         $tag = if ($a.number) { $a.number } else { '#?' }
         $who = if ($a.kind -eq 'event') { "event ($($a.reason))" } else { "by $($a.author)" }

--- a/userscripts/discogs_credits/dev/check-gh-notifications.ps1
+++ b/userscripts/discogs_credits/dev/check-gh-notifications.ps1
@@ -96,7 +96,14 @@ try {
     # body once afterwards. `-UseBasicParsing` keeps it light.
     $resp = Invoke-WebRequest -Uri $apiUrl -Headers $headers -UseBasicParsing -ErrorAction Stop
     $status = [int]$resp.StatusCode
-    $notifs = if ($resp.Content) { @(($resp.Content | ConvertFrom-Json)) } else { @() }
+    # `@(...)` collapses a 1-element JSON array into a bare PSCustomObject
+    # before we get to wrap it, so .Count renders blank. Explicit
+    # ForEach-Object pipe through an intermediate ArrayList guarantees we
+    # end with a real array even for the 1-item case.
+    $notifs = @()
+    if ($resp.Content) {
+        foreach ($item in ($resp.Content | ConvertFrom-Json)) { $notifs += $item }
+    }
     Log-Line "    -> HTTP $status, $($notifs.Count) thread(s)"
 } catch {
     $msg = $_.Exception.Message


### PR DESCRIPTION
Two commits that landed on the [`surface-merge-notifications`](https://github.com/majkinetor/musicbrainz-userscripts/tree/surface-merge-notifications) branch *after* [#71](https://github.com/majkinetor/musicbrainz-userscripts/pull/71) had already merged — so they never made it to `main`. Re-opening here to land them.

## Commits

- [`3d3bc27`](https://github.com/majkinetor/musicbrainz-userscripts/commit/3d3bc27) — Fix blank `unread` count in log when GH returns exactly 1 thread. `@($resp.Content | ConvertFrom-Json)` collapses a 1-item JSON array into a bare PSCustomObject before our `@()` wrap takes effect; rebuild via foreach to keep it a real array.
- [`7384c28`](https://github.com/majkinetor/musicbrainz-userscripts/commit/7384c28) — Deterministic merge detection. After the notifications loop, runs a second pass against the Search API for bot-authored PRs merged since `lastPolled`. Surfaces each as `kind='event' reason='merged'`. Covers the gap where GH chooses not to notify the bot for its own PR being merged. Maintainer's specific ask: *"I don't want to think about commenting or not when merging."*

## Test plan

- [x] Both visible in the local poll log already (TS picked them up from on-disk script)
- [x] Search call returns HTTP 200 + 0 hits when nothing has merged since last poll
- [ ] Verifies live on next bot-PR merge: should arrive as `#N event (merged): <title>` channel block
