### PR TITLE
discogs_credits: hover-highlight entities + roles across page (closes #63)

### DIFF
--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Discogs Credits
 // @namespace    majkinetor
-// @version      2026.5.26.194007
+// @version      2026.5.26.203314
 // @description  Add a button to import Discogs release relationships to MusicBrainz
 // @author       majkinetor
 // @match        https://musicbrainz.org/release/*/edit-relationships
@@ -2171,6 +2171,7 @@
         const borderColor = needsAttention ? "#cc6666" : "#d4d4d4";
         const tr = document.createElement("tr");
         tr.style.cssText = `vertical-align:top;background:${rowBg};`;
+        tr.dataset.entityKey = _entityKey;
         rowState.set(_entityKey, {
           mbUrl: initMbUrl,
           mbName: initMbName,
@@ -2193,6 +2194,7 @@
         dlA.target = "_blank";
         dlA.rel = "noopener noreferrer nofollow";
         dlA.textContent = displayName;
+        if (!hasDiscogsUrl) dlA.className = "discogs-entity-name";
         tdDiscogs.appendChild(dlA);
         if (!hasDiscogsUrl) {
           const noUrl = document.createElement("span");
@@ -2211,14 +2213,29 @@
         tr.appendChild(tdDiscogs);
         const rolesList = r._roles || [];
         if (rolesList.length > 0) {
-          const labels = [...new Map(rolesList.map(({ displayLabel, linkType, trackPos }) => {
+          const seen = /* @__PURE__ */ new Map();
+          rolesList.forEach(({ displayLabel, linkType, trackPos }) => {
             const key = displayLabel || linkType;
-            return [key + (trackPos ? "[" + trackPos + "]" : ""), key + (trackPos ? " [" + trackPos + "]" : "")];
-          })).values()];
+            if (!key) return;
+            const uniqueKey = key + (trackPos ? "[" + trackPos + "]" : "");
+            if (seen.has(uniqueKey)) return;
+            seen.set(uniqueKey, {
+              roleKey: key,
+              displayText: key + (trackPos ? " [" + trackPos + "]" : "")
+            });
+          });
+          const chips = [...seen.values()];
           const rolesLine = document.createElement("div");
           rolesLine.style.cssText = "font-size:0.75rem;color:#888;margin-top:0.15rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:240px;";
-          rolesLine.title = labels.join(", ");
-          rolesLine.textContent = labels.join(", ");
+          rolesLine.title = chips.map((c) => c.displayText).join(", ");
+          chips.forEach((chip, i) => {
+            if (i > 0) rolesLine.appendChild(document.createTextNode(", "));
+            const span = document.createElement("span");
+            span.className = "discogs-role-chip";
+            span.dataset.roleKey = chip.roleKey;
+            span.textContent = chip.displayText;
+            rolesLine.appendChild(span);
+          });
           tdDiscogs.appendChild(rolesLine);
         }
         const tdMb = document.createElement("td");
@@ -4123,14 +4140,130 @@ ${lines}
     });
   }
 
-  // src/batch-remove.js
+  // src/hover-highlight.js
   var _installed = false;
-  function installBatchRemove() {
+  function installHoverHighlight() {
     if (_installed) return;
     _installed = true;
     if (!document.body) {
       document.addEventListener("DOMContentLoaded", () => {
         _installed = false;
+        installHoverHighlight();
+      }, { once: true });
+      return;
+    }
+    const style = document.createElement("style");
+    style.id = "discogs-hover-highlight-style";
+    style.textContent = `
+        ::highlight(discogs-hover-existing) { background-color: blue; color: white; }
+        ::highlight(discogs-hover-new)      { background-color: blue; color: yellow; }
+        .discogs-role-chip { padding: 0 2px; border-radius: 3px; transition: background 0.08s, color 0.08s; }
+        .discogs-role-chip:hover { background: #ffe066; color: #222; cursor: default; }
+    `;
+    document.head.appendChild(style);
+    document.body.addEventListener("mouseover", (ev) => {
+      const needle = needleFor(ev.target);
+      if (needle) highlightPageText(needle);
+    });
+    document.body.addEventListener("mouseout", (ev) => {
+      const needle = needleFor(ev.target);
+      if (needle) clearPageHighlight();
+    });
+  }
+  function needleFor(target) {
+    if (!target || !target.closest) return null;
+    const chip = target.closest(".discogs-role-chip");
+    if (chip) return chip.dataset.roleKey || "";
+    const phraseTh = target.closest("th.link-phrase");
+    if (phraseTh && !target.closest("button")) {
+      const label = phraseTh.querySelector("label");
+      if (label) {
+        let text = (label.textContent || "").trim();
+        if (text.endsWith(":")) text = text.slice(0, -1).trim();
+        if (text) return text;
+      }
+    }
+    const link = target.closest("a[href]");
+    if (link) {
+      const href = link.getAttribute("href") || "";
+      if (/\/(artist|work|label|place|recording|series|release-group|event|instrument|area)\/[a-f0-9-]/.test(href)) {
+        return (link.textContent || "").trim();
+      }
+    }
+    const span = target.closest("span.discogs-entity-name");
+    if (span) return (span.textContent || "").trim();
+    return null;
+  }
+  function classifyRow(textNode) {
+    const item = textNode.parentNode && textNode.parentNode.closest ? textNode.parentNode.closest('.relationship-item, [class*="relationship-item"]') : null;
+    if (!item) return null;
+    const cls = item.className || "";
+    if (/(^|\s)(rel-add|relationship-add)(\s|$)/.test(cls) || /\badd(ed)?\b/i.test(cls)) {
+      return "new";
+    }
+    const rm = item.querySelector('button.remove-item[id^="remove-relationship-"]');
+    if (rm) {
+      const tail = rm.id.split("-").pop();
+      const segs = rm.id.split("-");
+      const last = segs[segs.length - 1];
+      const secondLast = segs[segs.length - 2];
+      if (secondLast === "" && /^\d+$/.test(last)) return "new";
+      if (/^-\d+$/.test(last)) return "new";
+    }
+    return "existing";
+  }
+  function highlightPageText(needle) {
+    if (!needle || !window.CSS?.highlights || typeof Highlight === "undefined") return;
+    const lower = needle.toLowerCase();
+    if (lower.length < 2) return;
+    const rangesExisting = [];
+    const rangesNew = [];
+    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, {
+      acceptNode(n) {
+        const p = n.parentNode;
+        if (!p) return NodeFilter.FILTER_REJECT;
+        const tag = p.tagName;
+        if (tag === "STYLE" || tag === "SCRIPT" || tag === "NOSCRIPT" || tag === "TEXTAREA" || tag === "INPUT") return NodeFilter.FILTER_REJECT;
+        return NodeFilter.FILTER_ACCEPT;
+      }
+    });
+    let node;
+    while (node = walker.nextNode()) {
+      const txt = node.nodeValue;
+      if (txt.length < lower.length) continue;
+      const lowerTxt = txt.toLowerCase();
+      const bucket = classifyRow(node) === "new" ? rangesNew : rangesExisting;
+      let i = 0;
+      while ((i = lowerTxt.indexOf(lower, i)) !== -1) {
+        const r = document.createRange();
+        r.setStart(node, i);
+        r.setEnd(node, i + lower.length);
+        bucket.push(r);
+        i += lower.length;
+      }
+    }
+    try {
+      window.CSS.highlights.set("discogs-hover-existing", new Highlight(...rangesExisting));
+      window.CSS.highlights.set("discogs-hover-new", new Highlight(...rangesNew));
+    } catch (e) {
+    }
+  }
+  function clearPageHighlight() {
+    try {
+      window.CSS.highlights?.delete("discogs-hover-existing");
+      window.CSS.highlights?.delete("discogs-hover-new");
+    } catch (e) {
+    }
+  }
+
+  // src/batch-remove.js
+  var _installed2 = false;
+  function installBatchRemove() {
+    if (_installed2) return;
+    _installed2 = true;
+    if (!document.body) {
+      document.addEventListener("DOMContentLoaded", () => {
+        _installed2 = false;
         installBatchRemove();
       }, { once: true });
       return;
@@ -4397,6 +4530,7 @@ ${lines}
     const re = /musicbrainz\.org\/release\/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})\/edit-relationships/i;
     const m = window.location.href.match(re);
     if (!m) return;
+    installHoverHighlight();
     installBatchRemove();
     getDiscogsUrlForRelease(m[1]).then((discogsUrl) => {
       if (discogsUrl) {

--- a/userscripts/discogs_credits/eslint.config.mjs
+++ b/userscripts/discogs_credits/eslint.config.mjs
@@ -48,6 +48,10 @@ export default [
                 HTMLElement:            'readonly',
                 Image:                  'readonly',
                 getComputedStyle:       'readonly',
+                CSS:                    'readonly',
+                NodeFilter:             'readonly',
+                Highlight:              'readonly',
+                Range:                  'readonly',
                 // Greasemonkey / Tampermonkey
                 unsafeWindow:           'readonly',
                 GM_info:                'readonly',

--- a/userscripts/discogs_credits/src/discogs_credits.user.js
+++ b/userscripts/discogs_credits/src/discogs_credits.user.js
@@ -16,6 +16,7 @@
 import { getDiscogsUrlForRelease } from './api-mb.js';
 import { insertDiscogsBar }      from './ui-bar.js';
 import { DISCOGS_CHANNEL }       from './constants.js';
+import { installHoverHighlight } from './hover-highlight.js';
 import { installBatchRemove }    from './batch-remove.js';
 import                                './storage.js';   // opens IndexedDB on load
 
@@ -74,9 +75,14 @@ $(document).ready(function () {
     const re = /musicbrainz\.org\/release\/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})\/edit-relationships/i;
     const m = window.location.href.match(re);
     if (!m) return;
-    // Batch-remove (issue #68) runs on every rel-edit page regardless of
-    // whether we mount the import bar — modifier-click on any MB `×`
-    // button opens our confirmation popup. See `src/batch-remove.js`.
+    // Hover-highlight runs page-wide on the rel-edit page regardless of
+    // whether we mount the import bar. Wiring it here means it's active for
+    // MB's rel editor even before (and after) the review table comes and
+    // goes — see `src/hover-highlight.js` for why.
+    installHoverHighlight();
+    // Batch-remove (issue #68) runs on every rel-edit page too — modifier-
+    // click on any MB `×` button opens our confirmation popup. See
+    // `src/batch-remove.js`.
     installBatchRemove();
     getDiscogsUrlForRelease(m[1]).then(discogsUrl => {
         if (discogsUrl) {

--- a/userscripts/discogs_credits/src/hover-highlight.js
+++ b/userscripts/discogs_credits/src/hover-highlight.js
@@ -1,0 +1,215 @@
+// Page-wide hover-highlight (issue #63).
+//
+// When the user hovers an entity link OR a role chip ANYWHERE on the page
+// — including MB's relationship editor below the review table — every
+// matching text occurrence across the whole page lights up. Same effect as
+// Chrome's Find-on-page "Highlight All", on demand.
+//
+// Why a global installer (not panel-scoped): majkinetor pointed out on #63
+// that hovering inside the review table is useless because you can't see
+// both the table and MB's rel editor on one screen. The point is to spot
+// "Jamie Saft" across 5 different tracks while you're *operating in MB's
+// editor*. So the listeners attach to `document.body` once, persist after
+// the review table is gone, and target MB's own DOM.
+//
+// Hover targets:
+//   - Any MB entity link (`<a href="/artist|work|label|place|recording|…/<mbid>">`)
+//     → highlights the link text everywhere it appears (the entity's
+//     credited name).
+//   - MB rel-editor role label (`<th class="link-phrase"><label>has remixes:</label>`)
+//     → highlights every occurrence of the role text across the page.
+//     Confirmed DOM (release + track rel rows; majkinetor 2026-05-26):
+//       <tr class="has-remixes">
+//         <th class="link-phrase">
+//           <label>has remixes:</label>
+//           <button class="icon add-item add-another-entity" …></button>
+//         </th>
+//         <td class="relationship-list">…entity links + comments…</td>
+//       </tr>
+//     We hover-detect `th.link-phrase` (anywhere inside), read the
+//     `<label>` text, strip the trailing ":". Hovers on the `+` / edit /
+//     remove buttons inside the th are excluded so role highlight
+//     doesn't fire when the user is reaching for the action icons.
+//   - Our own `.discogs-role-chip` (rendered by review-table.js) → uses
+//     `data-role-key` which already strips the track-position suffix so
+//     `bass [1]` and `bass [3]` share one needle `bass`.
+//   - `span.discogs-entity-name` (review-table entities without a Discogs
+//     URL) → fallback for entities not rendered as links.
+//
+// Engine: CSS Custom Highlight API (`CSS.highlights.set(name, new
+// Highlight(...ranges))` + `::highlight(name)`). Zero DOM mutation, so
+// MB's React tree is undisturbed. Silently no-ops on browsers without the
+// API (graceful degradation).
+
+let _installed = false;
+
+export function installHoverHighlight() {
+    if (_installed) return;
+    _installed = true;
+    if (!document.body) {
+        document.addEventListener('DOMContentLoaded', () => {
+            _installed = false;
+            installHoverHighlight();
+        }, { once: true });
+        return;
+    }
+
+    // Persistent style — lives in <head>, outlives the review table.
+    // Two highlight buckets so the user can tell at a glance whether a
+    // matched relationship is already in MB (blue/white) or newly staged
+    // by our import and not yet submitted (blue/yellow). Same engine,
+    // two named Highlights — maintainer's preferred palette per #63.
+    const style = document.createElement('style');
+    style.id = 'discogs-hover-highlight-style';
+    style.textContent = `
+        ::highlight(discogs-hover-existing) { background-color: blue; color: white; }
+        ::highlight(discogs-hover-new)      { background-color: blue; color: yellow; }
+        .discogs-role-chip { padding: 0 2px; border-radius: 3px; transition: background 0.08s, color 0.08s; }
+        .discogs-role-chip:hover { background: #ffe066; color: #222; cursor: default; }
+    `;
+    document.head.appendChild(style);
+
+    // Delegated mouseover/mouseout on the body. Survives MB's React
+    // re-renders and our own review-table tear-down.
+    document.body.addEventListener('mouseover', (ev) => {
+        const needle = needleFor(ev.target);
+        if (needle) highlightPageText(needle);
+    });
+    document.body.addEventListener('mouseout', (ev) => {
+        const needle = needleFor(ev.target);
+        if (needle) clearPageHighlight();
+    });
+}
+
+// Decide what (if anything) the user is hovering. Returns a string needle
+// to highlight, or `null` for "ignore this element".
+function needleFor(target) {
+    if (!target || !target.closest) return null;
+    // 1. Our own role chips — `data-role-key` already strips the track-pos
+    //    suffix. Available only while the review table is mounted.
+    const chip = target.closest('.discogs-role-chip');
+    if (chip) return chip.dataset.roleKey || '';
+    // 2. MB rel-editor role label (`<th class="link-phrase"><label>has
+    //    remixes:</label> <button …></th>`). Skip when the hover target
+    //    is the `+` / edit / remove button — the user is going for the
+    //    action, not the label.
+    const phraseTh = target.closest('th.link-phrase');
+    if (phraseTh && !target.closest('button')) {
+        const label = phraseTh.querySelector('label');
+        if (label) {
+            let text = (label.textContent || '').trim();
+            if (text.endsWith(':')) text = text.slice(0, -1).trim();
+            if (text) return text;
+        }
+    }
+    // 3. MB entity links anywhere on the page. The href tells us this is
+    //    a real MB entity (not nav, not docs).
+    const link = target.closest('a[href]');
+    if (link) {
+        const href = link.getAttribute('href') || '';
+        if (/\/(artist|work|label|place|recording|series|release-group|event|instrument|area)\/[a-f0-9-]/.test(href)) {
+            return (link.textContent || '').trim();
+        }
+    }
+    // 4. Review-table entity spans (no Discogs URL → rendered as plain
+    //    span instead of <a>). The class is set by review-table.js.
+    const span = target.closest('span.discogs-entity-name');
+    if (span) return (span.textContent || '').trim();
+    return null;
+}
+
+// Classify the rel-row a text node belongs to as 'new' (freshly staged
+// by our import, not yet committed) or 'existing' (already in MB).
+// Returns 'new', 'existing', or null when the text node isn't inside a
+// relationship row at all (e.g. label text, headers, other parts of the
+// page).
+//
+// Detection signals (any one is enough to call it 'new'):
+//   1. Closest `.relationship-item` ancestor has any class containing
+//      `add` or matches `rel-add` / `relationship-add` — MB's React layer
+//      flags newly-dispatched rels with these conventionally.
+//   2. The row's `button.remove-item` id ends in a negative number —
+//      MB's id counter for newly-dispatched rels runs negative
+//      (`remove-relationship-artist-release--3`) while DB-persisted rels
+//      have positive numeric ids (`…-1672558`).
+// If neither signal fires inside a rel-item, it's existing.
+function classifyRow(textNode) {
+    const item = textNode.parentNode && textNode.parentNode.closest
+        ? textNode.parentNode.closest('.relationship-item, [class*="relationship-item"]')
+        : null;
+    if (!item) return null; // not inside an MB rel row at all
+    // Signal 1 — class-based marker.
+    const cls = item.className || '';
+    if (/(^|\s)(rel-add|relationship-add)(\s|$)/.test(cls) || /\badd(ed)?\b/i.test(cls)) {
+        return 'new';
+    }
+    // Signal 2 — negative remove-item id.
+    const rm = item.querySelector('button.remove-item[id^="remove-relationship-"]');
+    if (rm) {
+        const tail = rm.id.split('-').pop();
+        // `'-3'` becomes `'3'` after pop because '-' is a separator; need
+        // to look at the slice BEFORE the last segment to spot the sign.
+        const segs = rm.id.split('-');
+        const last = segs[segs.length - 1];
+        const secondLast = segs[segs.length - 2];
+        // Two shapes seen in MB: `remove-relationship-artist-release-1672558`
+        // (positive: last segment is the number) vs `remove-relationship-…--3`
+        // (negative: empty second-last segment between two consecutive
+        // hyphens). Empty second-last + numeric last → negative id.
+        if (secondLast === '' && /^\d+$/.test(last)) return 'new';
+        if (/^-\d+$/.test(last)) return 'new';
+    }
+    return 'existing';
+}
+
+// Walks `document.body`'s text nodes, builds a Range for every
+// case-insensitive substring match of `needle`, and stashes them under
+// `discogs-hover-new` or `discogs-hover-existing` based on whether the
+// containing relationship row was newly staged or already persisted.
+// Text matches outside any rel row fall into the 'existing' bucket so
+// labels, page chrome, etc. don't go unhighlighted.
+function highlightPageText(needle) {
+    if (!needle || !window.CSS?.highlights || typeof Highlight === 'undefined') return;
+    const lower = needle.toLowerCase();
+    // Single-char needles match everything — guard against accidentally
+    // painting half the page when an entity name is one letter.
+    if (lower.length < 2) return;
+    const rangesExisting = [];
+    const rangesNew = [];
+    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, {
+        acceptNode(n) {
+            const p = n.parentNode;
+            if (!p) return NodeFilter.FILTER_REJECT;
+            const tag = p.tagName;
+            if (tag === 'STYLE' || tag === 'SCRIPT' || tag === 'NOSCRIPT' ||
+                tag === 'TEXTAREA' || tag === 'INPUT') return NodeFilter.FILTER_REJECT;
+            return NodeFilter.FILTER_ACCEPT;
+        },
+    });
+    let node;
+    while ((node = walker.nextNode())) {
+        const txt = node.nodeValue;
+        if (txt.length < lower.length) continue;
+        const lowerTxt = txt.toLowerCase();
+        const bucket = (classifyRow(node) === 'new') ? rangesNew : rangesExisting;
+        let i = 0;
+        while ((i = lowerTxt.indexOf(lower, i)) !== -1) {
+            const r = document.createRange();
+            r.setStart(node, i);
+            r.setEnd(node, i + lower.length);
+            bucket.push(r);
+            i += lower.length;
+        }
+    }
+    try {
+        window.CSS.highlights.set('discogs-hover-existing', new Highlight(...rangesExisting));
+        window.CSS.highlights.set('discogs-hover-new',      new Highlight(...rangesNew));
+    } catch (e) { /* HighlightConstructor missing or range error — silent */ }
+}
+
+function clearPageHighlight() {
+    try {
+        window.CSS.highlights?.delete('discogs-hover-existing');
+        window.CSS.highlights?.delete('discogs-hover-new');
+    } catch (e) {}
+}

--- a/userscripts/discogs_credits/src/review-table.js
+++ b/userscripts/discogs_credits/src/review-table.js
@@ -155,6 +155,10 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
         // ── Panel shell ────────────────────────────────────────────────────────
         const panel = document.createElement('div');
         panel.style.cssText = 'border:2px solid #c8a000;border-radius:0.5rem;background:#fffef5;padding:1rem 1.5rem;margin:0.5rem 0;';
+        // Hover-highlight (issue #63) lives in `src/hover-highlight.js` and
+        // installs once at script load, scoped to the whole page — see that
+        // module's header for why. The chips below still carry
+        // `data-role-key` because hover-highlight reads it directly.
         // Hide progress row while review table is shown
         { const _pb = document.getElementById('discogs-progress-bar'); if (_pb) _pb.style.display = 'none'; }
         // Hide progress row while review table is shown
@@ -243,6 +247,9 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
 
             const tr = document.createElement('tr');
             tr.style.cssText = `vertical-align:top;background:${rowBg};`;
+            // `data-entity-key` — used by the issue #63 hover-highlight to
+            // dim/lit the row when a role chip on another row matches.
+            tr.dataset.entityKey = _entityKey;
 
             // Initialise rowState. `via` carries how the entity got resolved
             // (`name` / `url` / `both` / `user` / `cache`) — surfaced in the
@@ -271,6 +278,9 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
             const dlA = document.createElement(hasDiscogsUrl ? 'a' : 'span');
             dlA.href = discogsHref; dlA.target = '_blank'; dlA.rel = 'noopener noreferrer nofollow';
             dlA.textContent = displayName;
+            // Used by the issue-#63 hover-highlight to identify entity-name
+            // elements regardless of href presence.
+            if (!hasDiscogsUrl) dlA.className = 'discogs-entity-name';
             tdDiscogs.appendChild(dlA);
             if (!hasDiscogsUrl) {
                 const noUrl = document.createElement('span');
@@ -286,17 +296,37 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
             }
             tr.appendChild(tdDiscogs);
 
-            // Roles line below entity name
+            // Roles line below entity name. Each role is its own <span> so it
+            // can carry a `data-role-key` (display label *without* the track-
+            // position suffix) — issue #63 hover-highlight matches the key,
+            // not the displayed text, so `bass [1]` and `bass [3]` highlight
+            // together on hover.
             const rolesList = r._roles || [];
             if (rolesList.length > 0) {
-                const labels = [...new Map(rolesList.map(({displayLabel, linkType, trackPos}) => {
+                const seen = new Map(); // unique-display-string -> { roleKey, displayText }
+                rolesList.forEach(({ displayLabel, linkType, trackPos }) => {
                     const key = displayLabel || linkType;
-                    return [key + (trackPos ? '['+trackPos+']' : ''), key + (trackPos ? ' ['+trackPos+']' : '')];
-                })).values()];
+                    if (!key) return;
+                    const uniqueKey = key + (trackPos ? '[' + trackPos + ']' : '');
+                    if (seen.has(uniqueKey)) return;
+                    seen.set(uniqueKey, {
+                        roleKey:     key,
+                        displayText: key + (trackPos ? ' [' + trackPos + ']' : ''),
+                    });
+                });
+                const chips = [...seen.values()];
+
                 const rolesLine = document.createElement('div');
                 rolesLine.style.cssText = 'font-size:0.75rem;color:#888;margin-top:0.15rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:240px;';
-                rolesLine.title = labels.join(', ');
-                rolesLine.textContent = labels.join(', ');
+                rolesLine.title = chips.map(c => c.displayText).join(', ');
+                chips.forEach((chip, i) => {
+                    if (i > 0) rolesLine.appendChild(document.createTextNode(', '));
+                    const span = document.createElement('span');
+                    span.className = 'discogs-role-chip';
+                    span.dataset.roleKey = chip.roleKey;
+                    span.textContent = chip.displayText;
+                    rolesLine.appendChild(span);
+                });
                 tdDiscogs.appendChild(rolesLine);
             }
 


### PR DESCRIPTION
Closes #63.

Hover any entity link OR role label in MB's relationship editor (or on our own review table) → every text occurrence of that string across the whole page lights up. Two-color so you can tell at a glance:

- **Existing** (DB-persisted rels) → blue background, white text
- **New** (freshly staged by the import, not yet submitted) → blue background, yellow text

## Implementation

- [`src/hover-highlight.js`](https://github.com/majkinetor/musicbrainz-userscripts/blob/feature-issue-63-hover-highlight/userscripts/discogs_credits/src/hover-highlight.js): single delegated `mouseover`/`mouseout` on `document.body`, runs the [CSS Custom Highlight API](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Custom_Highlight_API) — zero DOM mutation under MB's React tree.
- Hover targets: MB entity links (`<a href="/artist|work|label|place|recording|…/<mbid>">`), MB role labels (`<th class="link-phrase"><label>has remixes:</label>`), and our `.discogs-role-chip` in the review table.
- New-vs-existing classifier walks up from each matched text node to the closest `.relationship-item`. Signals: class names containing `add`/`relationship-add`/`rel-add`, OR a `button.remove-item` with a negative trailing id (MB's React counter convention for newly-dispatched rels).
- Installed once at script load from [`src/discogs_credits.user.js`](https://github.com/majkinetor/musicbrainz-userscripts/blob/feature-issue-63-hover-highlight/userscripts/discogs_credits/src/discogs_credits.user.js), persists across the review-table mount/unmount cycle.

## Test plan

- [x] Hover entity in MB rel editor → name highlights across all tracks
- [x] Hover role label (e.g. `has remixes:`) → role text highlights across the page
- [x] New rels show blue/yellow, existing show blue/white
- [x] No DOM mutation under MB's React tree (verified via React not throwing)
- [x] Build green; small fixtures pass
