### PR TITLE
discogs_credits: dedup options + editable Credited-as (closes #62)

### DIFF
--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Discogs Credits
 // @namespace    majkinetor
-// @version      2026.5.27.132128
+// @version      2026.5.27.132141
 // @description  Add a button to import Discogs release relationships to MusicBrainz
 // @author       majkinetor
 // @match        https://musicbrainz.org/release/*/edit-relationships
@@ -3289,7 +3289,7 @@ Leave empty to use the default (Discogs name, or MB's most-frequent existing cre
     }
     function relAlreadyExists(sourceEntity, linkTypeID, targetGid, attrTree) {
       const rels = sourceEntity?.relationships;
-      if (!Array.isArray(rels) || rels.length === 0) return false;
+      if (!Array.isArray(rels) || rels.length === 0) return null;
       const acceptableLinkTypes = equivalenceLookup.get(linkTypeID) || /* @__PURE__ */ new Set([linkTypeID]);
       const candSig = (() => {
         if (!attrTree) return "";
@@ -3299,14 +3299,29 @@ Leave empty to use the default (Discogs name, or MB's most-frequent existing cre
           return "";
         }
       })();
-      return rels.some((r) => {
-        if (!acceptableLinkTypes.has(r.linkTypeID)) return false;
+      const lookupName = (id) => {
+        try {
+          return pageWindow.MB.linkedEntities.link_type[id]?.name || `#${id}`;
+        } catch (e) {
+          return `#${id}`;
+        }
+      };
+      let dupMatch = null;
+      for (const r of rels) {
+        if (!acceptableLinkTypes.has(r.linkTypeID)) continue;
         const tgt = r.target?.gid || r.entity0?.gid || r.entity1?.gid;
-        if (tgt !== targetGid) return false;
-        if (dedupeDuplicateRoles) return true;
+        if (tgt !== targetGid) continue;
+        const isEquivalent = r.linkTypeID !== linkTypeID;
         const existingSig = (r.attributes || []).map((a) => `${a.typeID}:${a.text_value || ""}`).sort().join(",");
-        return existingSig === candSig;
-      });
+        const exactMatch = existingSig === candSig;
+        if (exactMatch) {
+          return { kind: isEquivalent ? "equivalence" : "exact", existingLinkName: lookupName(r.linkTypeID) };
+        }
+        if (dedupeDuplicateRoles && !dupMatch) {
+          dupMatch = { kind: isEquivalent ? "equivalence" : "duplicate-role", existingLinkName: lookupName(r.linkTypeID) };
+        }
+      }
+      return dupMatch;
     }
     async function processOne(sourceEntity, entityType0, entityType1, linkTypeName, mbUrl, rawAttributes, credit, trackPos) {
       const overrideCredit = creditOverrides.get(mbUrl);
@@ -3373,8 +3388,17 @@ Leave empty to use the default (Discogs name, or MB's most-frequent existing cre
           log.warn(`Entity "${targetEntity.name}" is a ${targetEntity.entityType} but expected ${entityType0}/${entityType1} \u2014 link type "${linkTypeName}" may not apply`);
         }
       }
-      if (relAlreadyExists(sourceEntity, resolvedLinkTypeID, targetEntity.gid, attrTree)) {
-        log.info(`Already in MB: <strong>${linkTypeName}</strong>: ${sourceEntity.name} \u2194 ${targetEntity.name}${credit && credit !== targetEntity.name ? ` (credited: ${credit})` : ""}`);
+      const dedupHit = relAlreadyExists(sourceEntity, resolvedLinkTypeID, targetEntity.gid, attrTree);
+      if (dedupHit) {
+        const pair = `${sourceEntity.name} \u2194 ${targetEntity.name}${credit && credit !== targetEntity.name ? ` (credited: ${credit})` : ""}`;
+        const existing = dedupHit.existingLinkName;
+        if (dedupHit.kind === "equivalence") {
+          log.info(`Deduplication (equivalence sets): <strong>${linkTypeName}</strong> not added \u2014 equivalent <strong>${existing}</strong> already on ${pair}`);
+        } else if (dedupHit.kind === "duplicate-role") {
+          log.info(`Deduplication (duplicate roles): <strong>${linkTypeName}</strong> not added \u2014 same role already exists with different attributes on ${pair}`);
+        } else {
+          log.info(`Already in MB: <strong>${linkTypeName}</strong>: ${pair}`);
+        }
         existedInMb++;
         return;
       }

--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Discogs Credits
 // @namespace    majkinetor
-// @version      2026.5.26.203314
+// @version      2026.5.27.132128
 // @description  Add a button to import Discogs release relationships to MusicBrainz
 // @author       majkinetor
 // @match        https://musicbrainz.org/release/*/edit-relationships
@@ -55,6 +55,9 @@
     TaskInput: "#add-relationship-dialog .attribute-container.task input"
   };
   var DISCOGS_LOGO_URL = "https://volkerzell.de/favicons/discogs.png";
+  var EQUIVALENCE_SETS = [
+    ["writer", "composer"]
+  ];
   var DISCOGS_CHANNEL = new BroadcastChannel("discogs-importer-artist");
   var pageWindow = typeof unsafeWindow !== "undefined" ? unsafeWindow : window;
 
@@ -2101,6 +2104,48 @@
         span.style.cssText = `font-size:0.68rem;background:#f5f5f5;color:${cfg.color};padding:0 0.35rem;border-radius:8px;border:1px solid #ddd;flex-shrink:0;`;
         return span;
       }
+      const creditOverrides = /* @__PURE__ */ new Map();
+      const existingCreditByMbid = computeExistingCreditByMbid();
+      function computeExistingCreditByMbid() {
+        const counts = /* @__PURE__ */ new Map();
+        try {
+          let walk = function(node) {
+            if (!node) return;
+            if (Array.isArray(node)) {
+              for (const r of node) tally(r);
+              return;
+            }
+            if (typeof node === "object") {
+              for (const v of Object.values(node)) walk(v);
+            }
+          }, tally = function(rel) {
+            if (!rel || rel._status === 2) return;
+            const credit = rel.entity1_credit;
+            if (!credit) return;
+            const tgt = rel.entity1?.gid;
+            if (!tgt) return;
+            if (!counts.has(tgt)) counts.set(tgt, /* @__PURE__ */ new Map());
+            const m = counts.get(tgt);
+            m.set(credit, (m.get(credit) || 0) + 1);
+          };
+          const root = pageWindow?.MB?.relationshipEditor?.state?.relationshipsBySource;
+          if (!root) return /* @__PURE__ */ new Map();
+          walk(root);
+        } catch (e) {
+        }
+        const out = /* @__PURE__ */ new Map();
+        for (const [mbid, m] of counts) {
+          let best = null, bestN = 0;
+          for (const [credit, n] of m) {
+            if (n > bestN) {
+              best = credit;
+              bestN = n;
+            }
+          }
+          if (best) out.set(mbid, best);
+        }
+        return out;
+      }
       const panel = document.createElement("div");
       panel.style.cssText = "border:2px solid #c8a000;border-radius:0.5rem;background:#fffef5;padding:1rem 1.5rem;margin:0.5rem 0;";
       {
@@ -2238,6 +2283,37 @@
           });
           tdDiscogs.appendChild(rolesLine);
         }
+        const credLine = document.createElement("div");
+        credLine.style.cssText = "display:flex;align-items:center;gap:0.3rem;margin-top:0.25rem;max-width:280px;";
+        const credLabel = document.createElement("label");
+        credLabel.textContent = "Credited as:";
+        credLabel.style.cssText = "font-size:0.72rem;color:#888;flex-shrink:0;";
+        const credInput = document.createElement("input");
+        credInput.type = "text";
+        credInput.style.cssText = "flex:1;padding:0.1rem 0.3rem;font-size:0.78rem;border:1px solid #ddd;border-radius:3px;background:#fff;";
+        credInput.placeholder = displayName;
+        credInput.title = `Override the credited name dispatched with every rel for this entity.
+Leave empty to use the default (Discogs name, or MB's most-frequent existing credit when known).`;
+        function pickPrefill(mbUrl) {
+          if (mbUrl) {
+            const mbid = (String(mbUrl).split("/").pop() || "").replace(/[^a-f0-9-]/gi, "").slice(0, 36);
+            if (mbid && existingCreditByMbid.has(mbid)) return existingCreditByMbid.get(mbid);
+          }
+          return displayName;
+        }
+        credInput.value = pickPrefill(r.mbUrl);
+        credInput._userTouched = false;
+        credInput.addEventListener("input", () => {
+          credInput._userTouched = true;
+          const url = credInput._activeMbUrl;
+          if (url) creditOverrides.set(url, credInput.value);
+        });
+        credInput._activeMbUrl = r.mbUrl;
+        if (r.mbUrl) creditOverrides.set(r.mbUrl, credInput.value);
+        credLine.appendChild(credLabel);
+        credLine.appendChild(credInput);
+        tdDiscogs.appendChild(credLine);
+        r._credInput = credInput;
         const tdMb = document.createElement("td");
         tdMb.style.cssText = `padding:0.3rem 0.5rem;border:1px solid ${borderColor};min-width:240px;`;
         const candidateList = document.createElement("div");
@@ -2264,6 +2340,16 @@
         function setRowResolved(a) {
           const mbUrl = `//musicbrainz.org/${entityType}/${a.id}`;
           rowState.set(_entityKey, { mbUrl, mbName: a.name, mbDisambig: a.disambiguation || "", confirmed: true, via: "user", fromCache: false });
+          if (r._credInput) {
+            const oldUrl = r._credInput._activeMbUrl;
+            if (oldUrl && oldUrl !== mbUrl) creditOverrides.delete(oldUrl);
+            r._credInput._activeMbUrl = mbUrl;
+            if (!r._credInput._userTouched) {
+              const fresh = pickPrefill(mbUrl);
+              r._credInput.value = fresh;
+            }
+            creditOverrides.set(mbUrl, r._credInput.value);
+          }
           const _idbKey = r.entity?.resource_url ? parseDiscogsUrl(r.entity.resource_url)?.key : null;
           if (_idbKey) {
             writeIdbRecord(_idbKey, {
@@ -2302,6 +2388,10 @@
         }
         function setRowUnresolved() {
           rowState.set(_entityKey, { mbUrl: null, mbName: null, mbDisambig: "", confirmed: false, via: null, fromCache: false });
+          if (r._credInput && r._credInput._activeMbUrl) {
+            creditOverrides.delete(r._credInput._activeMbUrl);
+            r._credInput._activeMbUrl = null;
+          }
           tr.style.background = "#ffe0e0";
           searchInput.disabled = false;
           searchBtn.disabled = false;
@@ -2812,6 +2902,7 @@
         }
         confirmedMap.unresolvedCount = unresolvedCount;
         confirmedMap.totalEntities = allResults.length;
+        confirmedMap.creditOverrides = creditOverrides;
         (panelLi || panel).remove();
         resolve(confirmedMap);
       });
@@ -2990,12 +3081,36 @@
   ];
 
   // src/dispatch.js
-  async function dispatchAllRelationships(companies, artistRoles, tracklistRels, applyToTracks, createWorks, discogsTracklist, processTracklist, resolvedEntityTypes, confirmedMap, discogsUrl) {
+  async function dispatchAllRelationships(companies, artistRoles, tracklistRels, applyToTracks, createWorks, discogsTracklist, processTracklist, resolvedEntityTypes, confirmedMap, discogsUrl, dedupOpts) {
     resolvedEntityTypes = resolvedEntityTypes || /* @__PURE__ */ new Map();
     confirmedMap = confirmedMap || /* @__PURE__ */ new Map();
+    dedupOpts = dedupOpts || {};
+    const dedupeEquivalenceSets = dedupOpts.dedupeEquivalenceSets !== false;
+    const dedupeDuplicateRoles = dedupOpts.dedupeDuplicateRoles !== false;
+    const creditOverrides = dedupOpts.creditOverrides || /* @__PURE__ */ new Map();
     const re = await waitForMBEditor();
     if (!re) return;
     const MB = pageWindow.MB;
+    const equivalenceLookup = (() => {
+      const m = /* @__PURE__ */ new Map();
+      if (!dedupeEquivalenceSets || !MB?.linkedEntities?.link_type) return m;
+      for (const set of EQUIVALENCE_SETS) {
+        const byPair = /* @__PURE__ */ new Map();
+        for (const [id, lt] of Object.entries(MB.linkedEntities.link_type)) {
+          if (!lt?.name) continue;
+          if (!set.includes(String(lt.name).toLowerCase())) continue;
+          const key = `${lt.type0}|${lt.type1}`;
+          if (!byPair.has(key)) byPair.set(key, []);
+          byPair.get(key).push(Number(id));
+        }
+        for (const ids of byPair.values()) {
+          if (ids.length < 2) continue;
+          const sibSet = new Set(ids);
+          for (const id of ids) m.set(id, sibSet);
+        }
+      }
+      return m;
+    })();
     const releaseEntity = re.state.entity;
     let added = 0, existedInMb = 0, dedupedThisSession = 0, skipped = 0, failed = 0;
     const dispatchedThisSession = /* @__PURE__ */ new Set();
@@ -3175,6 +3290,7 @@
     function relAlreadyExists(sourceEntity, linkTypeID, targetGid, attrTree) {
       const rels = sourceEntity?.relationships;
       if (!Array.isArray(rels) || rels.length === 0) return false;
+      const acceptableLinkTypes = equivalenceLookup.get(linkTypeID) || /* @__PURE__ */ new Set([linkTypeID]);
       const candSig = (() => {
         if (!attrTree) return "";
         try {
@@ -3184,14 +3300,19 @@
         }
       })();
       return rels.some((r) => {
-        if (r.linkTypeID !== linkTypeID) return false;
+        if (!acceptableLinkTypes.has(r.linkTypeID)) return false;
         const tgt = r.target?.gid || r.entity0?.gid || r.entity1?.gid;
         if (tgt !== targetGid) return false;
+        if (dedupeDuplicateRoles) return true;
         const existingSig = (r.attributes || []).map((a) => `${a.typeID}:${a.text_value || ""}`).sort().join(",");
         return existingSig === candSig;
       });
     }
     async function processOne(sourceEntity, entityType0, entityType1, linkTypeName, mbUrl, rawAttributes, credit, trackPos) {
+      const overrideCredit = creditOverrides.get(mbUrl);
+      if (overrideCredit && String(overrideCredit).trim()) {
+        credit = String(overrideCredit).trim();
+      }
       const mbid = mbUrl.replace(/.*\//, "").replace(/[^a-f0-9-]/gi, "").substring(0, 36);
       if (!mbid) {
         log.error(`Bad MBID URL: ${mbUrl}`);
@@ -3782,17 +3903,33 @@
       bv("createWorks", true),
       "Create a new inline work for recordings without one, and link composer/lyricist/writer credits to it."
     );
+    const dedupSep = document.createElement("span");
+    dedupSep.textContent = "Dedup:";
+    dedupSep.style.cssText = "margin:0 0.2rem 0 0.6rem;color:#888;font-size:0.85rem;font-weight:600;";
+    row2.appendChild(dedupSep);
+    const dedupeEqCb = makeCheckbox(
+      "Equivalence sets",
+      bv("dedupeEquivalenceSets", true),
+      "Skip a role when an equivalent role already exists on the target (writer \u2261 composer)."
+    );
+    const dedupeDupCb = makeCheckbox(
+      "Duplicate roles",
+      bv("dedupeDuplicateRoles", true),
+      "Skip adding a role when the target already has the same role (regardless of task / dates / attributes)."
+    );
     const saveOpts = () => {
       try {
         localStorage.setItem(OPTS_KEY, JSON.stringify({
           tracklist: tracklistCb.checked,
           applyTracks: applyTracksCb.checked,
-          createWorks: createWorksCb.checked
+          createWorks: createWorksCb.checked,
+          dedupeEquivalenceSets: dedupeEqCb.checked,
+          dedupeDuplicateRoles: dedupeDupCb.checked
         }));
       } catch (e) {
       }
     };
-    [tracklistCb, applyTracksCb, createWorksCb].forEach((cb) => cb.closest("label").addEventListener("click", () => setTimeout(saveOpts, 0)));
+    [tracklistCb, applyTracksCb, createWorksCb, dedupeEqCb, dedupeDupCb].forEach((cb) => cb.closest("label").addEventListener("click", () => setTimeout(saveOpts, 0)));
     bar.appendChild(row2);
     const outputDiv = document.createElement("div");
     outputDiv.className = "discogs-output";
@@ -3923,7 +4060,7 @@ ${lines}
         const html = line.replace(/(https?:\/\/[^\s]+)/g, '<a href="$1" target="_blank" rel="noopener noreferrer nofollow">$1</a>');
         log.info(html);
       });
-      runImport(discogsUrl, tracklistCb.checked, applyTracksCb.checked, createWorksCb.checked).finally(() => {
+      runImport(discogsUrl, tracklistCb.checked, applyTracksCb.checked, createWorksCb.checked, dedupeEqCb.checked, dedupeDupCb.checked).finally(() => {
         importBtn.disabled = false;
         importBtn.textContent = "Import from Discogs";
         progressPct.textContent = "100%";
@@ -3959,7 +4096,7 @@ ${lines}
     } catch (e) {
     }
   })();
-  function runImport(discogsUrl, processTracklist, applyToTracks, createWorks) {
+  function runImport(discogsUrl, processTracklist, applyToTracks, createWorks, dedupeEquivalenceSets, dedupeDuplicateRoles) {
     return getDiscogsReleaseData(discogsUrl).then((json) => {
       let artistRoles = rolesFromDiscogsArtists(json.extraartists?.filter((artist) => !artist.tracks));
       if (!_logs2._releaseInfoAdded) {
@@ -4134,7 +4271,12 @@ ${lines}
             resolvedEntityTypes.set(r.entity.resource_url, r.entityType);
           }
         });
-        return dispatchAllRelationships(json.companies, artistRoles, tracklistRels, applyToTracks, createWorks, json.tracklist, processTracklist, resolvedEntityTypes, capturedConfirmedMap, discogsUrl);
+        const dedupOpts = {
+          dedupeEquivalenceSets,
+          dedupeDuplicateRoles,
+          creditOverrides: capturedConfirmedMap?.creditOverrides
+        };
+        return dispatchAllRelationships(json.companies, artistRoles, tracklistRels, applyToTracks, createWorks, json.tracklist, processTracklist, resolvedEntityTypes, capturedConfirmedMap, discogsUrl, dedupOpts);
       });
     }).then(() => {
     });

--- a/userscripts/discogs_credits/src/constants.js
+++ b/userscripts/discogs_credits/src/constants.js
@@ -48,6 +48,23 @@ export const SELECTORS = {
 export const DISCOGS_LOGO_URL = 'https://volkerzell.de/favicons/discogs.png';
 
 /**
+ * Role-name equivalence groups used by the "Equivalence sets" dedup
+ * option (issue #62). When the option is on, the dispatcher treats any
+ * link type whose `name` falls in the same group as the link type being
+ * dispatched as a hit for the existing-rel check.
+ *
+ * Example: if MB already has a `writer` rel for (target, source), don't
+ * add a `composer` rel for the same pair (and vice versa).
+ *
+ * Sets are bidirectional and applied symmetrically; add new groups as
+ * the maintainer flags them. Names are MB link-type names (lowercased),
+ * matched against `MB.linkedEntities.link_type[id].name`.
+ */
+export const EQUIVALENCE_SETS = [
+    ['writer', 'composer'],
+];
+
+/**
  * Cross-tab channel used by the "Create in MB" flow. The userscript runs on
  * MB artist/label/place pages too — when it detects it was opened from the
  * review table (post-creation), it broadcasts the newly-created entity's

--- a/userscripts/discogs_credits/src/dispatch.js
+++ b/userscripts/discogs_credits/src/dispatch.js
@@ -327,9 +327,16 @@ export async function dispatchAllRelationships(companies, artistRoles, tracklist
     // Compares (linkTypeID, target gid, attributes) — what MB's reducer would
     // dedupe on. Without this check the script counted every dispatch as
     // "added", even when MB silently no-op'd them (issue #14).
+    //
+    // Returns `null` when no match, or `{ kind, existingLinkName }` so the
+    // caller can pick a distinct log message per #62 feedback:
+    //   - 'exact'          identical link type + same attrs ("Already in MB")
+    //   - 'equivalence'    equivalent link type (e.g. writer when adding composer)
+    //   - 'duplicate-role' same link type + same target but DIFFERENT attrs
+    //                      (only counted when `dedupeDuplicateRoles` is on)
     function relAlreadyExists(sourceEntity, linkTypeID, targetGid, attrTree) {
         const rels = sourceEntity?.relationships;
-        if (!Array.isArray(rels) || rels.length === 0) return false;
+        if (!Array.isArray(rels) || rels.length === 0) return null;
         // Equivalence-set expansion: when ON, a writer rel counts as
         // existing for an incoming composer dispatch (and vice versa).
         const acceptableLinkTypes = equivalenceLookup.get(linkTypeID) || new Set([linkTypeID]);
@@ -340,19 +347,31 @@ export async function dispatchAllRelationships(companies, artistRoles, tracklist
                     .map(a => `${a.typeID}:${a.text_value || ''}`).sort().join(',');
             } catch (e) { return ''; }
         })();
-        return rels.some(r => {
-            if (!acceptableLinkTypes.has(r.linkTypeID)) return false;
+        const lookupName = (id) => {
+            try { return pageWindow.MB.linkedEntities.link_type[id]?.name || `#${id}`; }
+            catch (e) { return `#${id}`; }
+        };
+        // Two-pass: prefer exact matches over duplicate-role matches when
+        // both could fire, so the log message reflects the cheaper match.
+        let dupMatch = null;
+        for (const r of rels) {
+            if (!acceptableLinkTypes.has(r.linkTypeID)) continue;
             const tgt = r.target?.gid || r.entity0?.gid || r.entity1?.gid;
-            if (tgt !== targetGid) return false;
-            // Without dedupeDuplicateRoles, only an EXACT attr-signature
-            // match counts as already-there (the conservative default
-            // before #62). With it, any (linkType, target) match wins
-            // regardless of attribute / task / date differences.
-            if (dedupeDuplicateRoles) return true;
+            if (tgt !== targetGid) continue;
+            const isEquivalent = (r.linkTypeID !== linkTypeID);
             const existingSig = (r.attributes || [])
                 .map(a => `${a.typeID}:${a.text_value || ''}`).sort().join(',');
-            return existingSig === candSig;
-        });
+            const exactMatch = (existingSig === candSig);
+            if (exactMatch) {
+                return { kind: isEquivalent ? 'equivalence' : 'exact', existingLinkName: lookupName(r.linkTypeID) };
+            }
+            // Attrs differ. With dedupeDuplicateRoles, still a match;
+            // remember but keep looking for an exact match elsewhere.
+            if (dedupeDuplicateRoles && !dupMatch) {
+                dupMatch = { kind: isEquivalent ? 'equivalence' : 'duplicate-role', existingLinkName: lookupName(r.linkTypeID) };
+            }
+        }
+        return dupMatch;
     }
 
     // ── Helper: process one relationship ─────────────────────────────────────
@@ -436,8 +455,22 @@ export async function dispatchAllRelationships(companies, artistRoles, tracklist
         // reducer would no-op the dispatch and we'd over-count. Detect now,
         // log per-rel (issue #34 — silent count was misleading), count as
         // existed instead of added. (issue #14)
-        if (relAlreadyExists(sourceEntity, resolvedLinkTypeID, targetEntity.gid, attrTree)) {
-            log.info(`Already in MB: <strong>${linkTypeName}</strong>: ${sourceEntity.name} ↔ ${targetEntity.name}${credit && credit !== targetEntity.name ? ` (credited: ${credit})` : ''}`);
+        const dedupHit = relAlreadyExists(sourceEntity, resolvedLinkTypeID, targetEntity.gid, attrTree);
+        if (dedupHit) {
+            // Distinct log message per #62 feedback. Three cases:
+            //   exact          — identical rel already in MB
+            //   equivalence    — equivalent role (writer ↔ composer) already there
+            //   duplicate-role — same role + different attrs (only when
+            //                    the "Duplicate roles" option is on)
+            const pair = `${sourceEntity.name} ↔ ${targetEntity.name}${credit && credit !== targetEntity.name ? ` (credited: ${credit})` : ''}`;
+            const existing = dedupHit.existingLinkName;
+            if (dedupHit.kind === 'equivalence') {
+                log.info(`Deduplication (equivalence sets): <strong>${linkTypeName}</strong> not added — equivalent <strong>${existing}</strong> already on ${pair}`);
+            } else if (dedupHit.kind === 'duplicate-role') {
+                log.info(`Deduplication (duplicate roles): <strong>${linkTypeName}</strong> not added — same role already exists with different attributes on ${pair}`);
+            } else {
+                log.info(`Already in MB: <strong>${linkTypeName}</strong>: ${pair}`);
+            }
             existedInMb++;
             return;
         }

--- a/userscripts/discogs_credits/src/dispatch.js
+++ b/userscripts/discogs_credits/src/dispatch.js
@@ -5,7 +5,7 @@
 // deduplication against this session and against MB's existing rels.
 
 import { log }                  from './log.js';
-import { pageWindow }                   from './constants.js';
+import { pageWindow, EQUIVALENCE_SETS } from './constants.js';
 import {
     mbThrottle,
     fetchMBEntity,
@@ -21,13 +21,63 @@ import { buildEditNote }                from './edit-note.js';
 import { ENTITY_TYPE_MAP }               from './data/entity-map.js';
 import { WORK_ONLY_ARTIST_RELS }         from './data/work-only-rels.js';
 
-export async function dispatchAllRelationships(companies, artistRoles, tracklistRels, applyToTracks, createWorks, discogsTracklist, processTracklist, resolvedEntityTypes, confirmedMap, discogsUrl) {
+// Dedup options come in as a trailing object (default empty). Used by
+// `relAlreadyExists` to honor the maintainer-configurable rules from
+// issue #62:
+//   dedupeEquivalenceSets  — treat writer ≡ composer (etc.) when looking
+//                            up existing rels for skipping.
+//   dedupeDuplicateRoles   — when (linkType, target) is already on the
+//                            source, skip regardless of attr/credit/date
+//                            differences. Without this, only an exact
+//                            attr-signature match counts as "already
+//                            there", so e.g. instrument with different
+//                            tasks would still dispatch.
+//   creditOverrides        — Map<mbUrl, string> from the review table's
+//                            editable "Credited as" input. When present
+//                            for the resolved entity, the override wins
+//                            over the Discogs-side credit. Falls back to
+//                            the Discogs name when no override exists.
+export async function dispatchAllRelationships(companies, artistRoles, tracklistRels, applyToTracks, createWorks, discogsTracklist, processTracklist, resolvedEntityTypes, confirmedMap, discogsUrl, dedupOpts) {
     resolvedEntityTypes = resolvedEntityTypes || new Map();
     confirmedMap = confirmedMap || new Map();
+    dedupOpts = dedupOpts || {};
+    const dedupeEquivalenceSets = dedupOpts.dedupeEquivalenceSets !== false; // default ON
+    const dedupeDuplicateRoles  = dedupOpts.dedupeDuplicateRoles  !== false; // default ON
+    const creditOverrides       = dedupOpts.creditOverrides || new Map();
     const re = await waitForMBEditor();
     if (!re) return;
 
     const MB = pageWindow.MB;
+
+    // Precompute the equivalence-set lookup once: linkTypeID -> Set of
+    // sibling linkTypeIDs (incl. itself) that share a configured group.
+    // `EQUIVALENCE_SETS` lists names like ['writer', 'composer']; we
+    // resolve those against MB.linkedEntities.link_type to MBIDs at the
+    // exact (sourceType, targetType) pair to keep matches strict.
+    const equivalenceLookup = (() => {
+        const m = new Map();
+        if (!dedupeEquivalenceSets || !MB?.linkedEntities?.link_type) return m;
+        for (const set of EQUIVALENCE_SETS) {
+            // For each set, collect all link types whose name lowercase-matches
+            // any member. Group them by (type0, type1) pair so we don't
+            // cross-contaminate (e.g. work-level composer vs recording-level
+            // composer have different IDs but live under the same pair name).
+            const byPair = new Map(); // 'type0|type1' -> [linkTypeID]
+            for (const [id, lt] of Object.entries(MB.linkedEntities.link_type)) {
+                if (!lt?.name) continue;
+                if (!set.includes(String(lt.name).toLowerCase())) continue;
+                const key = `${lt.type0}|${lt.type1}`;
+                if (!byPair.has(key)) byPair.set(key, []);
+                byPair.get(key).push(Number(id));
+            }
+            for (const ids of byPair.values()) {
+                if (ids.length < 2) continue; // single-member pair: no equivalence
+                const sibSet = new Set(ids);
+                for (const id of ids) m.set(id, sibSet);
+            }
+        }
+        return m;
+    })();
     const releaseEntity = re.state.entity;
     // Counter semantics (issues #14, #34):
     //   added       — rels actually dispatched into editor state this session
@@ -280,6 +330,9 @@ export async function dispatchAllRelationships(companies, artistRoles, tracklist
     function relAlreadyExists(sourceEntity, linkTypeID, targetGid, attrTree) {
         const rels = sourceEntity?.relationships;
         if (!Array.isArray(rels) || rels.length === 0) return false;
+        // Equivalence-set expansion: when ON, a writer rel counts as
+        // existing for an incoming composer dispatch (and vice versa).
+        const acceptableLinkTypes = equivalenceLookup.get(linkTypeID) || new Set([linkTypeID]);
         const candSig = (() => {
             if (!attrTree) return '';
             try {
@@ -288,9 +341,14 @@ export async function dispatchAllRelationships(companies, artistRoles, tracklist
             } catch (e) { return ''; }
         })();
         return rels.some(r => {
-            if (r.linkTypeID !== linkTypeID) return false;
+            if (!acceptableLinkTypes.has(r.linkTypeID)) return false;
             const tgt = r.target?.gid || r.entity0?.gid || r.entity1?.gid;
             if (tgt !== targetGid) return false;
+            // Without dedupeDuplicateRoles, only an EXACT attr-signature
+            // match counts as already-there (the conservative default
+            // before #62). With it, any (linkType, target) match wins
+            // regardless of attribute / task / date differences.
+            if (dedupeDuplicateRoles) return true;
             const existingSig = (r.attributes || [])
                 .map(a => `${a.typeID}:${a.text_value || ''}`).sort().join(',');
             return existingSig === candSig;
@@ -299,6 +357,15 @@ export async function dispatchAllRelationships(companies, artistRoles, tracklist
 
     // ── Helper: process one relationship ─────────────────────────────────────
     async function processOne(sourceEntity, entityType0, entityType1, linkTypeName, mbUrl, rawAttributes, credit, trackPos) {
+        // Credited-as override (issue #62): when the user edited the
+        // "Credited as" input on this entity's review-table row, that
+        // value wins over the Discogs-side credit for every rel
+        // dispatched to this target. Empty/missing override falls
+        // through to the caller's credit (typically Discogs ANV).
+        const overrideCredit = creditOverrides.get(mbUrl);
+        if (overrideCredit && String(overrideCredit).trim()) {
+            credit = String(overrideCredit).trim();
+        }
         const mbid = mbUrl.replace(/.*\//, '').replace(/[^a-f0-9-]/gi, '').substring(0, 36);
         if (!mbid) { log.error(`Bad MBID URL: ${mbUrl}`); failed++; return; }
 

--- a/userscripts/discogs_credits/src/review-table.js
+++ b/userscripts/discogs_credits/src/review-table.js
@@ -10,7 +10,7 @@ import { parseDiscogsUrl, getDiscogsEntityData } from './api-discogs.js';
 import { guessSortName }                   from './mappers.js';
 import { getLogContainer }                 from './log.js';
 import { _hideBar }                        from './progress-bar.js';
-import { DISCOGS_CHANNEL }                 from './constants.js';
+import { DISCOGS_CHANNEL, pageWindow }     from './constants.js';
 
 // Session-level URL check cache (avoids localStorage key mismatches across sessions)
 const _urlCheckSessionCache = new Map();
@@ -150,6 +150,58 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
             span.style.cssText = `font-size:0.68rem;background:#f5f5f5;color:${cfg.color};` +
                                  `padding:0 0.35rem;border-radius:8px;border:1px solid #ddd;flex-shrink:0;`;
             return span;
+        }
+
+        // ── Credited-as override map (issue #62) ────────────────────────────
+        // Keyed by mbUrl (final resolved MB entity URL). Populated by the
+        // per-row "Credited as" input. Stashed on `confirmedMap` at
+        // confirm-time so the dispatch layer can pick it up and override
+        // the Discogs-side credit when sending each rel. Empty string =
+        // user explicitly cleared the field; the dispatcher treats
+        // missing/empty as "fall through to Discogs default".
+        const creditOverrides = new Map();
+
+        // Build the pre-fill source: walk MB's currently-loaded state and
+        // collect every existing `entity1_credit` per target entity. The
+        // most-frequent string for each (entity, source-id) pair becomes
+        // the suggested override. If no existing rel mentions the entity,
+        // the input falls through to the Discogs display name (the
+        // current behaviour pre-#62).
+        const existingCreditByMbid = computeExistingCreditByMbid();
+        function computeExistingCreditByMbid() {
+            const counts = new Map(); // mbid -> Map(credit -> count)
+            try {
+                const root = pageWindow?.MB?.relationshipEditor?.state?.relationshipsBySource;
+                if (!root) return new Map();
+                walk(root);
+                function walk(node) {
+                    if (!node) return;
+                    if (Array.isArray(node)) { for (const r of node) tally(r); return; }
+                    if (typeof node === 'object') {
+                        for (const v of Object.values(node)) walk(v);
+                    }
+                }
+                function tally(rel) {
+                    if (!rel || rel._status === 2) return; // skip removed
+                    const credit = rel.entity1_credit;
+                    if (!credit) return;
+                    const tgt = rel.entity1?.gid;
+                    if (!tgt) return;
+                    if (!counts.has(tgt)) counts.set(tgt, new Map());
+                    const m = counts.get(tgt);
+                    m.set(credit, (m.get(credit) || 0) + 1);
+                }
+            } catch (e) { /* MB state shape changed -- best effort, skip */ }
+            // Reduce to mbid -> most-frequent-credit.
+            const out = new Map();
+            for (const [mbid, m] of counts) {
+                let best = null, bestN = 0;
+                for (const [credit, n] of m) {
+                    if (n > bestN) { best = credit; bestN = n; }
+                }
+                if (best) out.set(mbid, best);
+            }
+            return out;
         }
 
         // ── Panel shell ────────────────────────────────────────────────────────
@@ -330,6 +382,53 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
                 tdDiscogs.appendChild(rolesLine);
             }
 
+            // ── "Credited as" editable input (issue #62) ──────────────────
+            // The default value comes from `existingCreditByMbid` if MB
+            // already has the entity on this release; otherwise the
+            // Discogs display name (current behaviour). When the row's
+            // MB entity changes (via search-pick or manual edit), the
+            // pre-fill is recomputed if the user hasn't typed.
+            // The active value is mirrored into `creditOverrides[mbUrl]`
+            // on every edit, ready for the dispatch step to consume.
+            const credLine = document.createElement('div');
+            credLine.style.cssText = 'display:flex;align-items:center;gap:0.3rem;margin-top:0.25rem;max-width:280px;';
+            const credLabel = document.createElement('label');
+            credLabel.textContent = 'Credited as:';
+            credLabel.style.cssText = 'font-size:0.72rem;color:#888;flex-shrink:0;';
+            const credInput = document.createElement('input');
+            credInput.type = 'text';
+            credInput.style.cssText = 'flex:1;padding:0.1rem 0.3rem;font-size:0.78rem;border:1px solid #ddd;border-radius:3px;background:#fff;';
+            credInput.placeholder = displayName;
+            credInput.title = `Override the credited name dispatched with every rel for this entity.\nLeave empty to use the default (Discogs name, or MB's most-frequent existing credit when known).`;
+            // Initial value: most-frequent existing MB credit, or Discogs
+            // display name as fallback.
+            function pickPrefill(mbUrl) {
+                if (mbUrl) {
+                    const mbid = (String(mbUrl).split('/').pop() || '').replace(/[^a-f0-9-]/gi, '').slice(0, 36);
+                    if (mbid && existingCreditByMbid.has(mbid)) return existingCreditByMbid.get(mbid);
+                }
+                return displayName;
+            }
+            credInput.value = pickPrefill(r.mbUrl);
+            credInput._userTouched = false;
+            credInput.addEventListener('input', () => {
+                credInput._userTouched = true;
+                // Mirror into the side-map immediately. The mbUrl on the
+                // row may change later (search → pick a different MBID);
+                // the row.mbUrlForCredits closure is bumped in those
+                // handlers, see `setRowResolved` below.
+                const url = credInput._activeMbUrl;
+                if (url) creditOverrides.set(url, credInput.value);
+            });
+            credInput._activeMbUrl = r.mbUrl;
+            if (r.mbUrl) creditOverrides.set(r.mbUrl, credInput.value);
+            credLine.appendChild(credLabel);
+            credLine.appendChild(credInput);
+            tdDiscogs.appendChild(credLine);
+            // Stash so other parts (search picker, refresh) can re-target
+            // the override key when the row's mbUrl changes.
+            r._credInput = credInput;
+
             // ── Col 2: MB artist / search ──────────────────────────────────────
             const tdMb = document.createElement('td');
             tdMb.style.cssText = `padding:0.3rem 0.5rem;border:1px solid ${borderColor};min-width:240px;`;
@@ -365,6 +464,21 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
                 // a = { id, name, disambiguation }
                 const mbUrl = `//musicbrainz.org/${entityType}/${a.id}`;
                 rowState.set(_entityKey, { mbUrl, mbName: a.name, mbDisambig: a.disambiguation || '', confirmed: true, via: 'user', fromCache: false });
+                // Re-target the Credited-as override for this row to the
+                // newly-selected mbUrl (#62). If the input still holds
+                // the pre-fill (user hasn't touched), recompute the
+                // pre-fill against the new mbid; otherwise preserve
+                // their typed value verbatim.
+                if (r._credInput) {
+                    const oldUrl = r._credInput._activeMbUrl;
+                    if (oldUrl && oldUrl !== mbUrl) creditOverrides.delete(oldUrl);
+                    r._credInput._activeMbUrl = mbUrl;
+                    if (!r._credInput._userTouched) {
+                        const fresh = pickPrefill(mbUrl);
+                        r._credInput.value = fresh;
+                    }
+                    creditOverrides.set(mbUrl, r._credInput.value);
+                }
                 // Persist to IDB immediately so selection survives even without clicking Start import
                 const _idbKey = r.entity?.resource_url ? parseDiscogsUrl(r.entity.resource_url)?.key : null;
                 if (_idbKey) {
@@ -409,6 +523,13 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
 
             function setRowUnresolved() {
                 rowState.set(_entityKey, { mbUrl: null, mbName: null, mbDisambig: '', confirmed: false, via: null, fromCache: false });
+                // Clear the Credited-as override now that there's no
+                // resolved entity to attach it to (#62). Input value is
+                // kept so the user doesn't lose their typing.
+                if (r._credInput && r._credInput._activeMbUrl) {
+                    creditOverrides.delete(r._credInput._activeMbUrl);
+                    r._credInput._activeMbUrl = null;
+                }
                 tr.style.background = '#ffe0e0';
                 searchInput.disabled = false;
                 searchBtn.disabled = false;
@@ -1013,6 +1134,10 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
             // signature change — Maps accept arbitrary properties).
             confirmedMap.unresolvedCount = unresolvedCount;
             confirmedMap.totalEntities   = allResults.length;
+            // Credited-as overrides keyed by final mbUrl (#62). The
+            // dispatcher picks these up via the `dedupOpts` arg and
+            // overrides each rel's `entity1_credit` when present.
+            confirmedMap.creditOverrides = creditOverrides;
             (panelLi || panel).remove();
             resolve(confirmedMap);
         });

--- a/userscripts/discogs_credits/src/ui-bar.js
+++ b/userscripts/discogs_credits/src/ui-bar.js
@@ -309,13 +309,30 @@ export function insertDiscogsBar(discogsUrl) {
         'Move performance credits from the release down to every recording.');
     const createWorksCb  = makeCheckbox('Create missing works',           bv('createWorks', true),
         'Create a new inline work for recordings without one, and link composer/lyricist/writer credits to it.');
+
+    // ── Deduplication section (issue #62) ─────────────────────────────────
+    // Two toggles that change how the dispatcher decides "this rel is
+    // already there" against MB's pre-existing state. The third part of
+    // #62 — editable "Credited as" per entity — lives in the review
+    // table, not as a checkbox.
+    const dedupSep = document.createElement('span');
+    dedupSep.textContent = 'Dedup:';
+    dedupSep.style.cssText = 'margin:0 0.2rem 0 0.6rem;color:#888;font-size:0.85rem;font-weight:600;';
+    row2.appendChild(dedupSep);
+    const dedupeEqCb  = makeCheckbox('Equivalence sets',  bv('dedupeEquivalenceSets', true),
+        'Skip a role when an equivalent role already exists on the target (writer ≡ composer).');
+    const dedupeDupCb = makeCheckbox('Duplicate roles',   bv('dedupeDuplicateRoles', true),
+        'Skip adding a role when the target already has the same role (regardless of task / dates / attributes).');
+
     const saveOpts = () => {
         try { localStorage.setItem(OPTS_KEY, JSON.stringify({
             tracklist: tracklistCb.checked, applyTracks: applyTracksCb.checked,
             createWorks: createWorksCb.checked,
+            dedupeEquivalenceSets: dedupeEqCb.checked,
+            dedupeDuplicateRoles:  dedupeDupCb.checked,
         })); } catch(e) {}
     };
-    [tracklistCb, applyTracksCb, createWorksCb].forEach(cb =>
+    [tracklistCb, applyTracksCb, createWorksCb, dedupeEqCb, dedupeDupCb].forEach(cb =>
         cb.closest('label').addEventListener('click', () => setTimeout(saveOpts, 0)));
 
     bar.appendChild(row2);
@@ -483,7 +500,7 @@ export function insertDiscogsBar(discogsUrl) {
             const html = line.replace(/(https?:\/\/[^\s]+)/g, '<a href="$1" target="_blank" rel="noopener noreferrer nofollow">$1</a>');
             log.info(html);
         });
-        runImport(discogsUrl, tracklistCb.checked, applyTracksCb.checked, createWorksCb.checked).finally(() => {
+        runImport(discogsUrl, tracklistCb.checked, applyTracksCb.checked, createWorksCb.checked, dedupeEqCb.checked, dedupeDupCb.checked).finally(() => {
             importBtn.disabled = false;
             importBtn.textContent = 'Import from Discogs';
             progressPct.textContent = '100%';
@@ -525,7 +542,7 @@ export function insertDiscogsBar(discogsUrl) {
         keysToRemove.forEach(k => localStorage.removeItem(k));
     } catch(e) {}
 })();
-function runImport(discogsUrl, processTracklist, applyToTracks, createWorks) {
+function runImport(discogsUrl, processTracklist, applyToTracks, createWorks, dedupeEquivalenceSets, dedupeDuplicateRoles) {
     return getDiscogsReleaseData(discogsUrl)
         .then(json => {
             let artistRoles = rolesFromDiscogsArtists(json.extraartists?.filter(artist => !artist.tracks));
@@ -746,7 +763,16 @@ function runImport(discogsUrl, processTracklist, applyToTracks, createWorks) {
                             resolvedEntityTypes.set(r.entity.resource_url, r.entityType);
                         }
                     });
-                    return dispatchAllRelationships(json.companies, artistRoles, tracklistRels, applyToTracks, createWorks, json.tracklist, processTracklist, resolvedEntityTypes, capturedConfirmedMap, discogsUrl);
+                    // Bundle the dedup options + the Credited-as override
+                    // map (the review table stashes it on confirmedMap as
+                    // `creditOverrides`). `dispatchAllRelationships` reads
+                    // them from a trailing opts arg per #62.
+                    const dedupOpts = {
+                        dedupeEquivalenceSets,
+                        dedupeDuplicateRoles,
+                        creditOverrides: capturedConfirmedMap?.creditOverrides,
+                    };
+                    return dispatchAllRelationships(json.companies, artistRoles, tracklistRels, applyToTracks, createWorks, json.tracklist, processTracklist, resolvedEntityTypes, capturedConfirmedMap, discogsUrl, dedupOpts);
                 });
         })
         .then(() => { });


### PR DESCRIPTION
Closes #62. Maintainer confirmed implementation in [comment 4554019250](https://github.com/majkinetor/musicbrainz-userscripts/issues/62#issuecomment-4554019250): *"Looks good, merge it."*

## What's in

| Piece | Where |
|---|---|
| **Equivalence sets** toggle (writer ≡ composer) | New checkbox in the bar (`Dedup:` section). `EQUIVALENCE_SETS` in [`src/constants.js`](https://github.com/majkinetor/musicbrainz-userscripts/blob/feature-issue-62-dedup-options/userscripts/discogs_credits/src/constants.js). |
| **Duplicate roles** toggle | New checkbox in the bar. `relAlreadyExists` returns true on any `(linkType, target)` hit when set. |
| **Editable "Credited as" per row** | Inline input below the role line in the review table. Pre-filled from MB's most-frequent existing `entity1_credit`, falling back to Discogs display name. |
| **Distinct dedup log messages** (per [follow-up](https://github.com/majkinetor/musicbrainz-userscripts/issues/62#issuecomment-4552187026)) | Three cases: `Already in MB`, `Deduplication (equivalence sets)`, `Deduplication (duplicate roles)`. |

Build green; 5/5 small fixtures pass post-rebase.
