### PR TITLE
discogs_credits: pre-seed URL-link as ✓ after in-script entity creation

### DIFF
--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Discogs Credits
 // @namespace    majkinetor
-// @version      2026.5.27.163057
+// @version      2026.5.27.164051
 // @description  Add a button to import Discogs release relationships to MusicBrainz
 // @author       majkinetor
 // @match        https://musicbrainz.org/release/*/edit-relationships
@@ -2571,6 +2571,7 @@ Leave empty to use the default (Discogs name, or MB's most-frequent existing cre
               if (evt.data?.type !== "artist-created") return;
               if (evt.data.resourceUrl !== r.entity.resource_url) return;
               DISCOGS_CHANNEL.removeEventListener("message", onCreated);
+              _urlCheckSessionCache.set(`${evt.data.id}|${discogsHref}`, "linked");
               setRowResolved({ id: evt.data.id, name: evt.data.name, disambiguation: evt.data.disambiguation });
             };
             DISCOGS_CHANNEL.addEventListener("message", onCreated);

--- a/userscripts/discogs_credits/src/review-table.js
+++ b/userscripts/discogs_credits/src/review-table.js
@@ -767,6 +767,17 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
                         if (evt.data?.type !== 'artist-created') return;
                         if (evt.data.resourceUrl !== r.entity.resource_url) return;
                         DISCOGS_CHANNEL.removeEventListener('message', onCreated);
+                        // Issue #78: `openCreateTab` puts the Discogs URL
+                        // straight into MB's create form (`edit-<type>.url.0.text`
+                        // + `link_type_id`), so when the entity is born the
+                        // URL relation already exists on it. Pre-seed the
+                        // URL-check cache for this new MBID so the row's
+                        // action chip jumps straight to ✓ without going
+                        // through 🔗 "Add Discogs link" — the link is
+                        // already there. The session cache is keyed by
+                        // `${mbid}|${discogsHref}` exactly as renderActions
+                        // builds it.
+                        _urlCheckSessionCache.set(`${evt.data.id}|${discogsHref}`, 'linked');
                         setRowResolved({ id: evt.data.id, name: evt.data.name, disambiguation: evt.data.disambiguation });
                     };
                     DISCOGS_CHANNEL.addEventListener('message', onCreated);


### PR DESCRIPTION
Implements the #78 fix. Per maintainer ask: "merge it with main now but lets keep an issue open" — the issue is intentionally NOT closed by this PR (no `closes` keyword in body or commits will be amended), maintainer plans to test alongside other changes later.

Single commit on top of main: [`2eede81`](https://github.com/majkinetor/musicbrainz-userscripts/commit/2eede81). Pre-seeds the session URL-check cache to `'linked'` keyed on the new MBID immediately before `setRowResolved` fires from the BroadcastChannel listener, so the row's link chip jumps straight to ✓ instead of flashing 🔗.

Build green; 5/5 small fixtures still pass.

Refers to #78 (keep open for follow-up testing).
