### PR TITLE
discogs_credits: distinct warning badges (closes #81)

### DIFF
--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Discogs Credits
 // @namespace    majkinetor
-// @version      2026.5.27.165253
+// @version      2026.5.27.173302
 // @description  Add a button to import Discogs release relationships to MusicBrainz
 // @author       majkinetor
 // @match        https://musicbrainz.org/release/*/edit-relationships
@@ -2245,18 +2245,19 @@
         dlA.textContent = displayName;
         if (!hasDiscogsUrl) dlA.className = "discogs-entity-name";
         nameWrap.appendChild(dlA);
+        const BADGE_BASE = "display:inline-flex;align-items:center;margin-left:0.35rem;padding:0.05rem 0.4rem;font-size:0.65rem;font-weight:600;border-radius:0.7rem;letter-spacing:0.01em;cursor:help;text-transform:lowercase;line-height:1.4;";
         if (!hasDiscogsUrl) {
           const noUrl = document.createElement("span");
-          noUrl.textContent = " \u26A0\uFE0F";
-          noUrl.title = "No Discogs artist page \u2014 manual search needed";
-          noUrl.style.cssText = "cursor:help;color:#c80;";
+          noUrl.textContent = "no profile";
+          noUrl.title = "No Discogs artist page \u2014 name lookup unavailable, search MB manually";
+          noUrl.style.cssText = BADGE_BASE + "background:#fde7c0;color:#7a4400;border:1px solid #e0a560;";
           nameWrap.appendChild(noUrl);
         }
         if (nameMismatch) {
           const w = document.createElement("span");
-          w.textContent = " \u26A0\uFE0F";
-          w.title = "Name differs from MB match";
-          w.style.cursor = "help";
+          w.textContent = "name differs";
+          w.title = "MB entity name differs from the Discogs display name \u2014 double-check this is the right match";
+          w.style.cssText = BADGE_BASE + "background:#fff1c4;color:#7a5800;border:1px solid #d4ad3a;";
           nameWrap.appendChild(w);
         }
         nameRow.appendChild(nameWrap);

--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Discogs Credits
 // @namespace    majkinetor
-// @version      2026.5.27.173302
+// @version      2026.5.27.173303
 // @description  Add a button to import Discogs release relationships to MusicBrainz
 // @author       majkinetor
 // @match        https://musicbrainz.org/release/*/edit-relationships
@@ -2250,7 +2250,7 @@
           const noUrl = document.createElement("span");
           noUrl.textContent = "no profile";
           noUrl.title = "No Discogs artist page \u2014 name lookup unavailable, search MB manually";
-          noUrl.style.cssText = BADGE_BASE + "background:#fde7c0;color:#7a4400;border:1px solid #e0a560;";
+          noUrl.style.cssText = BADGE_BASE + "background:#fde0e0;color:#a02020;border:1px solid #d44040;";
           nameWrap.appendChild(noUrl);
         }
         if (nameMismatch) {

--- a/userscripts/discogs_credits/src/review-table.js
+++ b/userscripts/discogs_credits/src/review-table.js
@@ -357,7 +357,7 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
                 const noUrl = document.createElement('span');
                 noUrl.textContent = 'no profile';
                 noUrl.title = 'No Discogs artist page — name lookup unavailable, search MB manually';
-                noUrl.style.cssText = BADGE_BASE + 'background:#fde7c0;color:#7a4400;border:1px solid #e0a560;';
+                noUrl.style.cssText = BADGE_BASE + 'background:#fde0e0;color:#a02020;border:1px solid #d44040;';
                 nameWrap.appendChild(noUrl);
             }
             if (nameMismatch) {

--- a/userscripts/discogs_credits/src/review-table.js
+++ b/userscripts/discogs_credits/src/review-table.js
@@ -346,16 +346,25 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
             // elements regardless of href presence.
             if (!hasDiscogsUrl) dlA.className = 'discogs-entity-name';
             nameWrap.appendChild(dlA);
+            // Distinct warning badges per #81. Both warnings used to be
+            // the same icon, distinguishable only via tooltip. Now each
+            // condition gets a short text label with a distinct color.
+            const BADGE_BASE = 'display:inline-flex;align-items:center;margin-left:0.35rem;' +
+                               'padding:0.05rem 0.4rem;font-size:0.65rem;font-weight:600;' +
+                               'border-radius:0.7rem;letter-spacing:0.01em;cursor:help;' +
+                               'text-transform:lowercase;line-height:1.4;';
             if (!hasDiscogsUrl) {
                 const noUrl = document.createElement('span');
-                noUrl.textContent = ' \u26a0\ufe0f'; noUrl.title = 'No Discogs artist page — manual search needed';
-                noUrl.style.cssText = 'cursor:help;color:#c80;';
+                noUrl.textContent = 'no profile';
+                noUrl.title = 'No Discogs artist page — name lookup unavailable, search MB manually';
+                noUrl.style.cssText = BADGE_BASE + 'background:#fde7c0;color:#7a4400;border:1px solid #e0a560;';
                 nameWrap.appendChild(noUrl);
             }
             if (nameMismatch) {
                 const w = document.createElement('span');
-                w.textContent = ' \u26a0\ufe0f'; w.title = 'Name differs from MB match';
-                w.style.cursor = 'help';
+                w.textContent = 'name differs';
+                w.title = 'MB entity name differs from the Discogs display name — double-check this is the right match';
+                w.style.cssText = BADGE_BASE + 'background:#fff1c4;color:#7a5800;border:1px solid #d4ad3a;';
                 nameWrap.appendChild(w);
             }
             nameRow.appendChild(nameWrap);


### PR DESCRIPTION
Closes #81. Maintainer confirmed iter 1 + color tweak: *"Looks good. Use different color for no profile … Merge afterwards."*

Two commits:
- [`722f05f`](https://github.com/majkinetor/musicbrainz-userscripts/commit/722f05f) — distinct `no profile` / `name differs` text badges replace the generic `⚠` icons; full reason readable without hovering.
- [`4e5f743`](https://github.com/majkinetor/musicbrainz-userscripts/commit/4e5f743) — `no profile` swapped from warm-orange to red so it's clearly distinct from the amber-yellow `name differs`.

Build green; 5/5 small fixtures pass.
