### PR TITLE
discogs_credits: determinate progress bar in both phases (closes #82)

### DIFF
--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Discogs Credits
 // @namespace    majkinetor
-// @version      2026.5.27.173303
+// @version      2026.5.27.173610
 // @description  Add a button to import Discogs release relationships to MusicBrainz
 // @author       majkinetor
 // @match        https://musicbrainz.org/release/*/edit-relationships
@@ -296,24 +296,44 @@
       pb.style.cssText = "position:fixed;left:0;right:0;height:5px;z-index:99999;background:#ddd;overflow:hidden;";
       const fill = document.createElement("div");
       fill.id = "discogs-pb-fill";
-      fill.style.cssText = "position:absolute;top:0;height:100%;width:40%;background:#e8771d;";
+      fill.style.cssText = "position:absolute;top:0;height:100%;width:40%;background:#e8771d;transition:width 0.2s linear;";
       pb.appendChild(fill);
       document.body.appendChild(pb);
     }
     pb.style.top = r1h + "px";
     pb.style.display = "block";
     if (row2) row2.style.marginTop = r1h + 5 + "px";
+    _startMarquee();
+  }
+  function _startMarquee() {
     clearInterval(_pInterval);
+    const fill = document.getElementById("discogs-pb-fill");
+    if (fill) {
+      fill.style.width = "40%";
+      fill.style.left = _pPos + "%";
+      fill.style.transition = "";
+    }
     _pPos = -40;
     _pInterval = setInterval(() => {
       _pPos += 1.5;
       if (_pPos > 100) _pPos = -40;
-      const fill = document.getElementById("discogs-pb-fill");
-      if (fill) fill.style.left = _pPos + "%";
+      const f = document.getElementById("discogs-pb-fill");
+      if (f) f.style.left = _pPos + "%";
     }, 16);
+  }
+  function _setProgressPct(pct) {
+    const p = Math.max(0, Math.min(100, Number(pct) || 0));
+    clearInterval(_pInterval);
+    _pInterval = null;
+    const fill = document.getElementById("discogs-pb-fill");
+    if (!fill) return;
+    fill.style.left = "0";
+    fill.style.transition = "width 0.2s linear";
+    fill.style.width = p + "%";
   }
   function _hideBar() {
     clearInterval(_pInterval);
+    _pInterval = null;
     const pb = document.getElementById("discogs-pb");
     if (pb) pb.style.display = "none";
     const row2 = document.querySelector(".discogs-bar-row2");
@@ -1970,6 +1990,12 @@
     let done = 0;
     const inFlightNames = /* @__PURE__ */ new Set();
     function setProgress() {
+      if (entities.length > 0) {
+        try {
+          _setProgressPct(done / entities.length * 100);
+        } catch (_) {
+        }
+      }
       if (!progressLi) return;
       const remaining = entities.length - done;
       const checking = inFlightNames.size ? ` \u2014 checking <em>${[...inFlightNames].join(", ")}</em>` : "";
@@ -3158,6 +3184,10 @@ Leave empty to use the default (Discogs name, or MB's most-frequent existing cre
       const pct = Math.min(Math.round(done / est * 99), 99);
       const _pct = document.querySelector("#discogs-progress-pct");
       if (_pct) _pct.textContent = pct + "%";
+      try {
+        _setProgressPct(pct);
+      } catch (_) {
+      }
     }
     const recordingByGid = /* @__PURE__ */ new Map();
     const recordingByPosition = /* @__PURE__ */ new Map();

--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Discogs Credits
 // @namespace    majkinetor
-// @version      2026.5.27.173610
+// @version      2026.5.27.173611
 // @description  Add a button to import Discogs release relationships to MusicBrainz
 // @author       majkinetor
 // @match        https://musicbrainz.org/release/*/edit-relationships
@@ -3177,6 +3177,10 @@ Leave empty to use the default (Discogs name, or MB's most-frequent existing cre
       // NOT 'mastering' — MB deprecated artist→recording mastering (link type 136).
     ]);
     log.info(`Starting instant fill: ${companies.length} companies, ${artistRoles.length} release artist roles, ${tracklistRels.length} tracklist roles`);
+    try {
+      _showBar();
+    } catch (_) {
+    }
     const bar = document.querySelector(".discogs-bar");
     function tickProgress() {
       const done = added + skipped + failed;

--- a/userscripts/discogs_credits/src/dispatch.js
+++ b/userscripts/discogs_credits/src/dispatch.js
@@ -20,6 +20,7 @@ import {
 import { buildEditNote }                from './edit-note.js';
 import { ENTITY_TYPE_MAP }               from './data/entity-map.js';
 import { WORK_ONLY_ARTIST_RELS }         from './data/work-only-rels.js';
+import { _setProgressPct }               from './progress-bar.js';
 
 // Dedup options come in as a trailing object (default empty). Used by
 // `relAlreadyExists` to honor the maintainer-configurable rules from
@@ -123,6 +124,10 @@ export async function dispatchAllRelationships(companies, artistRoles, tracklist
         const pct = Math.min(Math.round((done / est) * 99), 99);
         const _pct = document.querySelector('#discogs-progress-pct');
         if (_pct) _pct.textContent = pct + '%';
+        // Push the actual fill width to the top-of-page progress bar
+        // (#82). Before this change the bar only animated marquee
+        // during the dispatch phase; only the inline % text moved.
+        try { _setProgressPct(pct); } catch (_) {}
     }
 
     // ── Build recording maps from MB editor state ────────────────────────────

--- a/userscripts/discogs_credits/src/dispatch.js
+++ b/userscripts/discogs_credits/src/dispatch.js
@@ -20,7 +20,7 @@ import {
 import { buildEditNote }                from './edit-note.js';
 import { ENTITY_TYPE_MAP }               from './data/entity-map.js';
 import { WORK_ONLY_ARTIST_RELS }         from './data/work-only-rels.js';
-import { _setProgressPct }               from './progress-bar.js';
+import { _showBar, _setProgressPct }     from './progress-bar.js';
 
 // Dedup options come in as a trailing object (default empty). Used by
 // `relAlreadyExists` to honor the maintainer-configurable rules from
@@ -116,6 +116,12 @@ export async function dispatchAllRelationships(companies, artistRoles, tracklist
     ]);
 
     log.info(`Starting instant fill: ${companies.length} companies, ${artistRoles.length} release artist roles, ${tracklistRels.length} tracklist roles`);
+
+    // The review-table code calls `_hideBar()` when it mounts; nothing
+    // re-shows the bar between the review-table tear-down and the
+    // dispatch loop start, so #82's fill-phase progress was invisible
+    // even though `tickProgress` was pushing percentages. Re-show here.
+    try { _showBar(); } catch (_) {}
 
     const bar = document.querySelector('.discogs-bar');
     function tickProgress() {

--- a/userscripts/discogs_credits/src/preflight.js
+++ b/userscripts/discogs_credits/src/preflight.js
@@ -28,6 +28,7 @@ import { mbThrottle }                       from './api-mb.js';
 import { readIdbRecord, writeIdbRecord }    from './storage.js';
 import { parseDiscogsUrl }                  from './api-discogs.js';
 import { ENTITY_TYPE_MAP }                  from './data/entity-map.js';
+import { _setProgressPct }                  from './progress-bar.js';
 
 // `kind`-specific tweaks. Tiny lookup table so the per-strategy code in
 // `resolveEntity` reads as one shared body.
@@ -312,6 +313,13 @@ export async function resolveAll(entities, opts) {
     const inFlightNames = new Set();
 
     function setProgress() {
+        // Push the bar to determinate mode at the current % (#82).
+        // Before this change preflight only updated the text line in
+        // the log; the top bar stayed in its rotating marquee. Now the
+        // bar shows real progress as entities resolve.
+        if (entities.length > 0) {
+            try { _setProgressPct((done / entities.length) * 100); } catch (_) {}
+        }
         if (!progressLi) return;
         const remaining = entities.length - done;
         const checking = inFlightNames.size

--- a/userscripts/discogs_credits/src/progress-bar.js
+++ b/userscripts/discogs_credits/src/progress-bar.js
@@ -1,11 +1,17 @@
-// Top-of-viewport "marquee" progress bar shown while a long-running task
-// (preflight, dispatch) is in flight. Module-level state because both the
-// UI bar (insertDiscogsBar) and the review table reach for `_showBar` /
-// `_hideBar` at different points.
+// Top-of-viewport progress bar shown while a long-running task
+// (preflight, dispatch) is in flight. Two modes:
 //
-// Single shared `<div id="discogs-pb">` element appended to `<body>` on
-// first `_showBar()`. The fill stripe (`#discogs-pb-fill`) is animated
-// across via a setInterval timer; `_hideBar` clears it and hides the bar.
+//   • indeterminate — the marquee animation, used when the script
+//                     doesn't yet know how much work is ahead.
+//   • determinate   — fill stripe pinned to the left, width = pct%.
+//                     Used when the caller knows done/total counts.
+//
+// `_showBar()` starts in indeterminate. `_setProgressPct(pct)` switches
+// to determinate at the current pct. `_hideBar()` clears whichever mode
+// is active.
+//
+// Issue #82: callers (preflight, dispatch) used to ignore the bar and
+// only write done/total text. Now they push real percentages here.
 
 let _pInterval = null;
 let _pPos = -40;
@@ -21,25 +27,55 @@ export function _showBar() {
         pb.style.cssText = 'position:fixed;left:0;right:0;height:5px;z-index:99999;background:#ddd;overflow:hidden;';
         const fill = document.createElement('div');
         fill.id = 'discogs-pb-fill';
-        fill.style.cssText = 'position:absolute;top:0;height:100%;width:40%;background:#e8771d;';
+        fill.style.cssText = 'position:absolute;top:0;height:100%;width:40%;background:#e8771d;transition:width 0.2s linear;';
         pb.appendChild(fill);
         document.body.appendChild(pb);
     }
     pb.style.top = r1h + 'px';
     pb.style.display = 'block';
     if (row2) row2.style.marginTop = (r1h + 5) + 'px';
+    // Reset to indeterminate marquee. Caller can flip to determinate
+    // via `_setProgressPct` once a real percent is known.
+    _startMarquee();
+}
+
+function _startMarquee() {
     clearInterval(_pInterval);
+    const fill = document.getElementById('discogs-pb-fill');
+    if (fill) {
+        fill.style.width = '40%';
+        fill.style.left  = _pPos + '%';
+        // Marquee slides hard, transition would lag the animation.
+        fill.style.transition = '';
+    }
     _pPos = -40;
     _pInterval = setInterval(() => {
         _pPos += 1.5;
         if (_pPos > 100) _pPos = -40;
-        const fill = document.getElementById('discogs-pb-fill');
-        if (fill) fill.style.left = _pPos + '%';
+        const f = document.getElementById('discogs-pb-fill');
+        if (f) f.style.left = _pPos + '%';
     }, 16);
+}
+
+// Switch the bar to determinate mode at `pct` ∈ [0, 100]. Called by
+// preflight + dispatch as they progress. Side-effects: clears the
+// marquee timer, pins the fill stripe to the left, sets its width.
+// Restores `transition` so consecutive percentages animate smoothly
+// instead of jumping.
+export function _setProgressPct(pct) {
+    const p = Math.max(0, Math.min(100, Number(pct) || 0));
+    clearInterval(_pInterval);
+    _pInterval = null;
+    const fill = document.getElementById('discogs-pb-fill');
+    if (!fill) return;
+    fill.style.left = '0';
+    fill.style.transition = 'width 0.2s linear';
+    fill.style.width = p + '%';
 }
 
 export function _hideBar() {
     clearInterval(_pInterval);
+    _pInterval = null;
     const pb = document.getElementById('discogs-pb');
     if (pb) pb.style.display = 'none';
     const row2 = document.querySelector('.discogs-bar-row2');


### PR DESCRIPTION
Closes #82. Maintainer confirmed: *"Works great now. PR/merge."*

Two commits:
- [`fb74cc9`](https://github.com/majkinetor/musicbrainz-userscripts/commit/fb74cc9) — `progress-bar.js` gets `_setProgressPct(pct)` (determinate mode). Preflight + dispatch both call it as they tick. Bar fills as work progresses instead of just rotating.
- [`6c0a50a`](https://github.com/majkinetor/musicbrainz-userscripts/commit/6c0a50a) — `dispatchAllRelationships` re-calls `_showBar()` at entry, since the review table called `_hideBar()` and nothing brought the bar back for the fill phase.

Build green; 5/5 small fixtures pass.
