### PR TITLE
discogs_credits: docs link in bar header (closes #90)

### DIFF
--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Discogs Credits
 // @namespace    majkinetor
-// @version      2026.5.27.173611
+// @version      2026.5.27.182151
 // @description  Add a button to import Discogs release relationships to MusicBrainz
 // @author       majkinetor
 // @match        https://musicbrainz.org/release/*/edit-relationships
@@ -15,7 +15,7 @@
 // @license      MIT
 // @downloadURL  https://update.greasyfork.org/scripts/578977/MusicBrainz%20-%20Import%20Discogs%20Credits.user.js
 // @updateURL    https://update.greasyfork.org/scripts/578977/MusicBrainz%20-%20Import%20Discogs%20Credits.meta.js
-// @homepageURL  https://github.com/majkinetor/musicbrainz-userscripts/tree/main/userscripts/discogs_credits
+// @homepageURL  https://github.com/majkinetor/musicbrainz-userscripts/blob/main/userscripts/discogs_credits/README.md
 // @supportURL   https://github.com/majkinetor/musicbrainz-userscripts/issues
 // @installURL   https://greasyfork.org/en/scripts/578977
 // @grant        unsafeWindow
@@ -3087,7 +3087,7 @@ Leave empty to use the default (Discogs name, or MB's most-frequent existing cre
   function buildEditNote(discogsUrl, opts, extraLines) {
     const s = GM_info.script;
     const mbUrl = location.href.replace(/\/edit-relationships$/, "");
-    const homepage = s.homepageURL || s.homepage || "https://github.com/majkinetor/musicbrainz-userscripts/tree/main/userscripts/discogs_credits";
+    const homepage = s.homepageURL || s.homepage || "https://github.com/majkinetor/musicbrainz-userscripts/blob/main/userscripts/discogs_credits/README.md";
     const header = s.name + " v" + s.version + " by " + s.author + " - " + homepage;
     const lines = [
       header,
@@ -3923,6 +3923,15 @@ Leave empty to use the default (Discogs name, or MB's most-frequent existing cre
     sourceSpan.className = "discogs-source";
     sourceSpan.innerHTML = `<a href="${discogsUrl}" target="_blank" rel="noopener noreferrer nofollow">${discogsUrl}</a>`;
     row1.appendChild(sourceSpan);
+    const docsHref = typeof GM_info !== "undefined" && (GM_info?.script?.homepageURL || GM_info?.script?.homepage) || "https://github.com/majkinetor/musicbrainz-userscripts/blob/main/userscripts/discogs_credits/README.md";
+    const docsLink = document.createElement("a");
+    docsLink.href = docsHref;
+    docsLink.target = "_blank";
+    docsLink.rel = "noopener noreferrer nofollow";
+    docsLink.textContent = "? Documentation";
+    docsLink.title = "Open the script's README in a new tab";
+    docsLink.style.cssText = "flex-shrink:0;font-size:0.82rem;color:#7a5000;text-decoration:none;padding:0.1rem 0.45rem;border:1px solid #d4b800;border-radius:0.25rem;background:#fff8e6;";
+    row1.appendChild(docsLink);
     bar.appendChild(row1);
     const row2 = document.createElement("div");
     row2.className = "discogs-bar-row2";

--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Discogs Credits
 // @namespace    majkinetor
-// @version      2026.5.27.182151
+// @version      2026.5.27.185619
 // @description  Add a button to import Discogs release relationships to MusicBrainz
 // @author       majkinetor
 // @match        https://musicbrainz.org/release/*/edit-relationships
@@ -3928,7 +3928,7 @@ Leave empty to use the default (Discogs name, or MB's most-frequent existing cre
     docsLink.href = docsHref;
     docsLink.target = "_blank";
     docsLink.rel = "noopener noreferrer nofollow";
-    docsLink.textContent = "? Documentation";
+    docsLink.textContent = "\u{1F4D6} Documentation";
     docsLink.title = "Open the script's README in a new tab";
     docsLink.style.cssText = "flex-shrink:0;font-size:0.82rem;color:#7a5000;text-decoration:none;padding:0.1rem 0.45rem;border:1px solid #d4b800;border-radius:0.25rem;background:#fff8e6;";
     row1.appendChild(docsLink);

--- a/userscripts/discogs_credits/src/edit-note.js
+++ b/userscripts/discogs_credits/src/edit-note.js
@@ -19,7 +19,7 @@
 export function buildEditNote(discogsUrl, opts, extraLines) {
     const s = GM_info.script;
     const mbUrl = location.href.replace(/\/edit-relationships$/, '');
-    const homepage = s.homepageURL || s.homepage || 'https://github.com/majkinetor/musicbrainz-userscripts/tree/main/userscripts/discogs_credits';
+    const homepage = s.homepageURL || s.homepage || 'https://github.com/majkinetor/musicbrainz-userscripts/blob/main/userscripts/discogs_credits/README.md';
     const header = s.name + ' v' + s.version + ' by ' + s.author + ' - ' + homepage;
     const lines = [
         header,

--- a/userscripts/discogs_credits/src/meta.txt
+++ b/userscripts/discogs_credits/src/meta.txt
@@ -15,7 +15,7 @@
 // @license      MIT
 // @downloadURL  https://update.greasyfork.org/scripts/578977/MusicBrainz%20-%20Import%20Discogs%20Credits.user.js
 // @updateURL    https://update.greasyfork.org/scripts/578977/MusicBrainz%20-%20Import%20Discogs%20Credits.meta.js
-// @homepageURL  https://github.com/majkinetor/musicbrainz-userscripts/tree/main/userscripts/discogs_credits
+// @homepageURL  https://github.com/majkinetor/musicbrainz-userscripts/blob/main/userscripts/discogs_credits/README.md
 // @supportURL   https://github.com/majkinetor/musicbrainz-userscripts/issues
 // @installURL   https://greasyfork.org/en/scripts/578977
 // @grant        unsafeWindow

--- a/userscripts/discogs_credits/src/ui-bar.js
+++ b/userscripts/discogs_credits/src/ui-bar.js
@@ -278,7 +278,7 @@ export function insertDiscogsBar(discogsUrl) {
     docsLink.href = docsHref;
     docsLink.target = '_blank';
     docsLink.rel = 'noopener noreferrer nofollow';
-    docsLink.textContent = '? Documentation';
+    docsLink.textContent = '📖 Documentation';
     docsLink.title = 'Open the script\'s README in a new tab';
     docsLink.style.cssText = 'flex-shrink:0;font-size:0.82rem;color:#7a5000;text-decoration:none;padding:0.1rem 0.45rem;border:1px solid #d4b800;border-radius:0.25rem;background:#fff8e6;';
     row1.appendChild(docsLink);

--- a/userscripts/discogs_credits/src/ui-bar.js
+++ b/userscripts/discogs_credits/src/ui-bar.js
@@ -267,6 +267,22 @@ export function insertDiscogsBar(discogsUrl) {
     sourceSpan.innerHTML = `<a href="${discogsUrl}" target="_blank" rel="noopener noreferrer nofollow">${discogsUrl}</a>`;
     row1.appendChild(sourceSpan);
 
+    // Documentation link on the far-right side of row1 (#90). URL falls
+    // back the same way `buildEditNote` resolves it: the manager-injected
+    // `@homepageURL`, then `@homepage`, then a hard-coded README.md link
+    // so the link works even if the userscript manager strips metadata.
+    const docsHref = (typeof GM_info !== 'undefined' && (
+        GM_info?.script?.homepageURL || GM_info?.script?.homepage
+    )) || 'https://github.com/majkinetor/musicbrainz-userscripts/blob/main/userscripts/discogs_credits/README.md';
+    const docsLink = document.createElement('a');
+    docsLink.href = docsHref;
+    docsLink.target = '_blank';
+    docsLink.rel = 'noopener noreferrer nofollow';
+    docsLink.textContent = '? Documentation';
+    docsLink.title = 'Open the script\'s README in a new tab';
+    docsLink.style.cssText = 'flex-shrink:0;font-size:0.82rem;color:#7a5000;text-decoration:none;padding:0.1rem 0.45rem;border:1px solid #d4b800;border-radius:0.25rem;background:#fff8e6;';
+    row1.appendChild(docsLink);
+
     bar.appendChild(row1);
 
     // ── Row 2: option toggles ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds a 📖 Documentation link on the far-right side of row1 in the import bar.
- URL resolution mirrors `buildEditNote`: `@homepageURL` → `@homepage` → hard-coded README.md fallback.
- `@homepageURL` updated in `meta.txt` (and the fallback in `edit-note.js`) to point directly at the README.

## Test plan
- [x] Bar loads on `/release/*/edit-relationships`, link visible right-aligned in the header
- [x] Click opens README.md in a new tab
- [x] `@homepage`-only managers (Tampermonkey) still get a working link via fallback chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)