### PR TITLE
discogs_credits: faster preflight + backpressure + diagnostics (closes #87)

### DIFF
--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Discogs Credits
 // @namespace    majkinetor
-// @version      2026.5.27.181707
+// @version      2026.5.27.183526
 // @description  Add a button to import Discogs release relationships to MusicBrainz
 // @author       majkinetor
 // @match        https://musicbrainz.org/release/*/edit-relationships
@@ -125,7 +125,7 @@
     return res.json();
   }
   var mbThrottle = /* @__PURE__ */ (() => {
-    const MAX_CONCURRENT = 8;
+    const MAX_CONCURRENT = 4;
     let _running = 0;
     let _pauseUntil = 0;
     const _queue = [];
@@ -2029,8 +2029,8 @@
   }
   async function resolveAll(entities, opts) {
     const { kindOf, progressLi, bypassIdb, progressLabel } = opts;
-    const CONCURRENCY = 10;
-    const MIN_GAP_MS = 20;
+    const CONCURRENCY = 5;
+    const MIN_GAP_MS = 50;
     let done = 0;
     const inFlightNames = /* @__PURE__ */ new Set();
     function setProgress() {

--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Discogs Credits
 // @namespace    majkinetor
-// @version      2026.5.27.173611
+// @version      2026.5.27.181228
 // @description  Add a button to import Discogs release relationships to MusicBrainz
 // @author       majkinetor
 // @match        https://musicbrainz.org/release/*/edit-relationships
@@ -95,7 +95,7 @@
     return res.json();
   }
   var mbThrottle = /* @__PURE__ */ (() => {
-    const MAX_CONCURRENT = 4;
+    const MAX_CONCURRENT = 8;
     let _running = 0;
     let _pauseUntil = 0;
     const _queue = [];
@@ -1985,8 +1985,8 @@
   }
   async function resolveAll(entities, opts) {
     const { kindOf, progressLi, bypassIdb, progressLabel } = opts;
-    const CONCURRENCY = 5;
-    const MIN_GAP_MS = 50;
+    const CONCURRENCY = 10;
+    const MIN_GAP_MS = 20;
     let done = 0;
     const inFlightNames = /* @__PURE__ */ new Set();
     function setProgress() {

--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Discogs Credits
 // @namespace    majkinetor
-// @version      2026.5.27.183959
+// @version      2026.5.27.185521
 // @description  Add a button to import Discogs release relationships to MusicBrainz
 // @author       majkinetor
 // @match        https://musicbrainz.org/release/*/edit-relationships
@@ -95,7 +95,7 @@
     const details = document.createElement("details");
     details.style.cssText = "margin:0.3rem 0;";
     const summary = document.createElement("summary");
-    summary.textContent = "Preflight diagnostics (collapsed)";
+    summary.textContent = "Preflight diagnostics";
     summary.style.cssText = "cursor:pointer;font-size:0.8rem;color:#888;user-select:none;";
     details.appendChild(summary);
     const ul = document.createElement("ul");
@@ -150,7 +150,7 @@
       }
     }
     let _diagReqSeq = 0;
-    const REQUEST_TIMEOUT_MS = 15e3;
+    const REQUEST_TIMEOUT_MS = 1e4;
     async function _run(item) {
       const tag = `req#${++_diagReqSeq}`;
       const shortUrl = item.url.replace("//musicbrainz.org", "").replace(/^https:/, "");
@@ -184,8 +184,16 @@
           return;
         } catch (e) {
           const elapsed = Date.now() - t0;
-          const reason = e?.name === "AbortError" ? `timed out after ${REQUEST_TIMEOUT_MS}ms` : `${e?.message || e}`;
-          logDebug(`${tag} threw in ${elapsed}ms: ${reason}`);
+          const isTimeout = e?.name === "AbortError";
+          const reason = isTimeout ? `timed out after ${REQUEST_TIMEOUT_MS}ms` : `${e?.message || e}`;
+          if (isTimeout) {
+            _rateLimited++;
+            const waitMs = Math.min(1e3 * Math.pow(2, attempt), 8e3);
+            _pauseUntil = Math.max(_pauseUntil, Date.now() + waitMs);
+            logDebug(`${tag} threw in ${elapsed}ms: ${reason}; shared pause pushed to +${waitMs}ms`);
+          } else {
+            logDebug(`${tag} threw in ${elapsed}ms: ${reason}`);
+          }
           if (attempt === item.retries) {
             item.resolve(null);
             return;
@@ -4345,12 +4353,14 @@ ${lines}
         }
       });
       function runPreflight(bypassIdb = false) {
+        log.info(`Starting preflight: ${uniqueArtists.length} artist(s), ${uniqueCompanies.length} label(s)/place(s).`);
         const artistProgressLi = document.createElement("li");
         artistProgressLi.textContent = `Checking ${uniqueArtists.length} artist(s) against MusicBrainz\u2026`;
         _logs2.appendChild(artistProgressLi);
         const companyProgressLi = document.createElement("li");
         companyProgressLi.textContent = `Checking ${uniqueCompanies.length} label(s)/place(s) against MusicBrainz\u2026`;
         _logs2.appendChild(companyProgressLi);
+        const t0 = performance.now();
         return (async () => {
           const artistResults = await resolveAll(uniqueArtists, {
             progressLi: artistProgressLi,
@@ -4364,6 +4374,8 @@ ${lines}
             kindOf: COMPANY_KIND,
             bypassIdb
           });
+          const elapsed = (performance.now() - t0) / 1e3;
+          log.info(`Preflight done in ${elapsed.toFixed(1)}s.`);
           return [...artistResults.allResults, ...companyResults.allResults].filter(Boolean);
         })();
       }

--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Discogs Credits
 // @namespace    majkinetor
-// @version      2026.5.27.183526
+// @version      2026.5.27.183959
 // @description  Add a button to import Discogs release relationships to MusicBrainz
 // @author       majkinetor
 // @match        https://musicbrainz.org/release/*/edit-relationships
@@ -150,6 +150,7 @@
       }
     }
     let _diagReqSeq = 0;
+    const REQUEST_TIMEOUT_MS = 15e3;
     async function _run(item) {
       const tag = `req#${++_diagReqSeq}`;
       const shortUrl = item.url.replace("//musicbrainz.org", "").replace(/^https:/, "");
@@ -159,8 +160,10 @@
         const attemptTag = attempt === 0 ? "" : ` (retry ${attempt})`;
         logDebug(`${tag} [running=${_running} queued=${_queue.length}] GET ${shortUrl}${attemptTag}`);
         const t0 = Date.now();
+        const ctrl = new AbortController();
+        const timer = setTimeout(() => ctrl.abort(), REQUEST_TIMEOUT_MS);
         try {
-          const res = await fetch(item.url);
+          const res = await fetch(item.url, { signal: ctrl.signal });
           const elapsed = Date.now() - t0;
           if (res.status === 429 || res.status === 503) {
             _rateLimited++;
@@ -181,12 +184,15 @@
           return;
         } catch (e) {
           const elapsed = Date.now() - t0;
-          logDebug(`${tag} threw in ${elapsed}ms: ${e?.message || e}`);
+          const reason = e?.name === "AbortError" ? `timed out after ${REQUEST_TIMEOUT_MS}ms` : `${e?.message || e}`;
+          logDebug(`${tag} threw in ${elapsed}ms: ${reason}`);
           if (attempt === item.retries) {
             item.resolve(null);
             return;
           }
           await new Promise((r) => setTimeout(r, 500));
+        } finally {
+          clearTimeout(timer);
         }
       }
       item.resolve(null);
@@ -4345,20 +4351,21 @@ ${lines}
         const companyProgressLi = document.createElement("li");
         companyProgressLi.textContent = `Checking ${uniqueCompanies.length} label(s)/place(s) against MusicBrainz\u2026`;
         _logs2.appendChild(companyProgressLi);
-        return Promise.all([
-          resolveAll(uniqueArtists, {
+        return (async () => {
+          const artistResults = await resolveAll(uniqueArtists, {
             progressLi: artistProgressLi,
             progressLabel: "Checking artists against MusicBrainz",
             kindOf: ARTIST_KIND,
             bypassIdb
-          }),
-          resolveAll(uniqueCompanies, {
+          });
+          const companyResults = await resolveAll(uniqueCompanies, {
             progressLi: companyProgressLi,
             progressLabel: "Checking labels/places against MusicBrainz",
             kindOf: COMPANY_KIND,
             bypassIdb
-          })
-        ]).then(([artistResults, companyResults]) => [...artistResults.allResults, ...companyResults.allResults].filter(Boolean));
+          });
+          return [...artistResults.allResults, ...companyResults.allResults].filter(Boolean);
+        })();
       }
       function annotateRoles(allResults) {
         allResults.forEach((r) => {

--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Discogs Credits
 // @namespace    majkinetor
-// @version      2026.5.27.193334
+// @version      2026.5.27.202912
 // @description  Add a button to import Discogs release relationships to MusicBrainz
 // @author       majkinetor
 // @match        https://musicbrainz.org/release/*/edit-relationships
@@ -2967,11 +2967,7 @@ Leave empty to use the default (Discogs name, or MB's most-frequent existing cre
         }
       }
       updateImportBtn();
-      importBtn.addEventListener("click", () => {
-        const confirmedMap = /* @__PURE__ */ new Map();
-        rowState.forEach((s, key) => {
-          if (s.mbUrl) confirmedMap.set(key, s.mbUrl);
-        });
+      function buildStaticTableLi() {
         const tbl = document.createElement("table");
         tbl.style.cssText = "border-collapse:collapse;width:100%;font-size:0.78rem;margin:0.4rem 0;";
         const thRow = document.createElement("tr");
@@ -3020,7 +3016,14 @@ Leave empty to use the default (Discogs name, or MB's most-frequent existing cre
         const tblLi = document.createElement("li");
         tblLi.style.cssText = "list-style:none;margin:0;padding:0;";
         tblLi.appendChild(tbl);
-        getLogContainer().appendChild(tblLi);
+        return tblLi;
+      }
+      importBtn.addEventListener("click", () => {
+        const confirmedMap = /* @__PURE__ */ new Map();
+        rowState.forEach((s, key) => {
+          if (s.mbUrl) confirmedMap.set(key, s.mbUrl);
+        });
+        getLogContainer().appendChild(buildStaticTableLi());
         const unresolvedCount = allResults.filter((r) => {
           const _k = r.entity?.resource_url || r.entity?._syntheticKey || `_nourl_${r.entity?.name || r.displayName}`;
           return !rowState.get(_k)?.confirmed;
@@ -3042,6 +3045,8 @@ Leave empty to use the default (Discogs name, or MB's most-frequent existing cre
       panel.appendChild(btnRow);
       const panelLi = document.createElement("li");
       panelLi.style.cssText = "list-style:none;margin:0;padding:0;";
+      panelLi.classList.add("discogs-review-panel-li");
+      panelLi._buildStaticTableLi = buildStaticTableLi;
       panelLi.appendChild(panel);
       getLogContainer().appendChild(panelLi);
       getLogContainer().scrollIntoView({ behavior: "smooth", block: "nearest" });
@@ -4133,14 +4138,15 @@ Leave empty to use the default (Discogs name, or MB's most-frequent existing cre
               const sum = node.querySelector("summary");
               const sumText = sum ? [...sum.childNodes].map((n) => {
                 if (n.nodeType === Node.TEXT_NODE) return n.textContent;
-                if (n.tagName?.toLowerCase() === "strong") return "**" + n.textContent + "**";
+                const t = n.tagName?.toLowerCase();
+                if (t === "button" || t === "input") return "";
                 return n.textContent;
-              }).join("") : "";
+              }).join("").trim() : "";
               if (skipDiscogsJson && /raw Discogs JSON/i.test(sumText)) {
                 return "";
               }
               const body = [...node.childNodes].filter((n) => n !== sum).map(nodeToMd).join("");
-              return "<details><summary>" + sumText + "</summary>\n\n" + body + "\n</details>";
+              return "\n\n<details><summary>" + sumText + "</summary>\n\n" + body + "\n</details>\n\n";
             }
             if (tag === "summary") return "";
             if (tag === "span") return inner;
@@ -4163,6 +4169,9 @@ Leave empty to use the default (Discogs name, or MB's most-frequent existing cre
           return _md.startsWith("\n\n") || _md.endsWith("\n\n") ? _md : _md.replace(/^\n/, "").replace(/\n$/, "");
         }
         const lines = [..._logs2.querySelectorAll("li")].map((li) => {
+          if (li.classList?.contains("discogs-review-panel-li") && typeof li._buildStaticTableLi === "function") {
+            return htmlToMd(li._buildStaticTableLi());
+          }
           const md = htmlToMd(li);
           if (!md) return "";
           if (md.startsWith("\n\n|") || md.startsWith("<details>")) return md;

--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Discogs Credits
 // @namespace    majkinetor
-// @version      2026.5.27.185521
+// @version      2026.5.27.193334
 // @description  Add a button to import Discogs release relationships to MusicBrainz
 // @author       majkinetor
 // @match        https://musicbrainz.org/release/*/edit-relationships
@@ -336,6 +336,20 @@
         getReq.onerror = () => resolve(null);
       } catch (e) {
         resolve(null);
+      }
+    });
+  }
+  function deleteIdbRecord(key) {
+    return new Promise((resolve) => {
+      if (!key || !db) return resolve(false);
+      try {
+        const tx = db.transaction([STORE], "readwrite");
+        const store = tx.objectStore(STORE);
+        const req = store.delete(key);
+        req.onsuccess = () => resolve(true);
+        req.onerror = () => resolve(false);
+      } catch (e) {
+        resolve(false);
       }
     });
   }
@@ -1902,6 +1916,9 @@
     async function fetchMbEntityInfo(et, mbid) {
       const json = await mbThrottle.fetchJson(`//musicbrainz.org/ws/2/${et}/${mbid}?fmt=json`);
       return json ? { name: json.name || null, disambiguation: json.disambiguation || "" } : { name: null, disambiguation: "" };
+    }
+    if (bypassIdb && key) {
+      await deleteIdbRecord(key);
     }
     if (!bypassIdb && key) {
       const cachedRec = await readIdbRecord(key);

--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Discogs Credits
 // @namespace    majkinetor
-// @version      2026.5.27.181228
+// @version      2026.5.27.181707
 // @description  Add a button to import Discogs release relationships to MusicBrainz
 // @author       majkinetor
 // @match        https://musicbrainz.org/release/*/edit-relationships
@@ -87,6 +87,36 @@
     warn: (msg) => _emit(`<span style="color:orange">WARN ${msg}</span>`, `WARN ${msg}`),
     error: (msg) => _emit(`<span style="color:red">ERR ${msg}</span>`, `ERR ${msg}`)
   };
+  var _debugUl = null;
+  var _debugStartT = null;
+  function _ensureDebugUl() {
+    if (_debugUl) return _debugUl;
+    if (!_logs) return null;
+    const details = document.createElement("details");
+    details.style.cssText = "margin:0.3rem 0;";
+    const summary = document.createElement("summary");
+    summary.textContent = "Preflight diagnostics (collapsed)";
+    summary.style.cssText = "cursor:pointer;font-size:0.8rem;color:#888;user-select:none;";
+    details.appendChild(summary);
+    const ul = document.createElement("ul");
+    ul.style.cssText = "list-style:none;margin:0.3rem 0;padding:0.4rem 0.6rem;background:#f7f7f7;border-radius:0.25rem;font-family:ui-monospace,Menlo,Consolas,monospace;font-size:0.72rem;color:#444;max-height:24rem;overflow-y:auto;";
+    details.appendChild(ul);
+    const li = document.createElement("li");
+    li.style.listStyle = "none";
+    li.appendChild(details);
+    _logs.appendChild(li);
+    _debugUl = ul;
+    _debugStartT = performance.now();
+    return _debugUl;
+  }
+  function logDebug(line) {
+    const ul = _ensureDebugUl();
+    if (!ul) return;
+    const t = Math.round(performance.now() - _debugStartT);
+    const row = document.createElement("div");
+    row.textContent = `[+${t}ms] ${line}`;
+    ul.appendChild(row);
+  }
 
   // src/api-mb.js
   async function fetchMBEntity(mbid) {
@@ -102,7 +132,9 @@
     let _totalRequests = 0;
     let _rateLimited = 0;
     async function _waitForPause() {
-      let wait;
+      let wait = _pauseUntil - Date.now();
+      if (wait <= 0) return;
+      logDebug(`throttle: waiting ${wait}ms for shared pause`);
       while ((wait = _pauseUntil - Date.now()) > 0) {
         await new Promise((r) => setTimeout(r, wait));
       }
@@ -117,27 +149,39 @@
         });
       }
     }
+    let _diagReqSeq = 0;
     async function _run(item) {
+      const tag = `req#${++_diagReqSeq}`;
+      const shortUrl = item.url.replace("//musicbrainz.org", "").replace(/^https:/, "");
       for (let attempt = 0; attempt <= item.retries; attempt++) {
         await _waitForPause();
         _totalRequests++;
+        const attemptTag = attempt === 0 ? "" : ` (retry ${attempt})`;
+        logDebug(`${tag} [running=${_running} queued=${_queue.length}] GET ${shortUrl}${attemptTag}`);
+        const t0 = Date.now();
         try {
           const res = await fetch(item.url);
+          const elapsed = Date.now() - t0;
           if (res.status === 429 || res.status === 503) {
             _rateLimited++;
             const ra = parseInt(res.headers.get("Retry-After"), 10);
             const waitMs = ra > 0 ? ra * 1e3 : Math.min(1e3 * Math.pow(2, attempt), 3e4);
             _pauseUntil = Math.max(_pauseUntil, Date.now() + waitMs);
+            logDebug(`${tag} <- ${res.status} in ${elapsed}ms; shared pause pushed to +${waitMs}ms`);
             continue;
           }
           if (!res.ok) {
+            logDebug(`${tag} <- ${res.status} (give up) in ${elapsed}ms`);
             item.resolve(null);
             return;
           }
           const data = item.wantJson ? await res.json() : res;
+          logDebug(`${tag} <- ${res.status} in ${elapsed}ms`);
           item.resolve(data);
           return;
         } catch (e) {
+          const elapsed = Date.now() - t0;
+          logDebug(`${tag} threw in ${elapsed}ms: ${e?.message || e}`);
           if (attempt === item.retries) {
             item.resolve(null);
             return;
@@ -2006,11 +2050,15 @@
     const results = new Array(entities.length);
     setProgress();
     async function worker(slotIndex) {
+      const tag = `worker#${slotIndex}`;
+      logDebug(`${tag} starting (stagger ${slotIndex * MIN_GAP_MS}ms)`);
       await delay(slotIndex * MIN_GAP_MS);
+      let processed = 0;
       while (queue.length > 0) {
         const { entity, index } = queue.shift();
         const kind = kindOf(entity);
         if (!kind) {
+          logDebug(`${tag} skip "${entity?.name || "?"}" \u2014 no resolvable kind`);
           done++;
           setProgress();
           continue;
@@ -2018,14 +2066,24 @@
         const displayName = kind === "artist" ? entity.anv && entity.anv.trim() || entity.name : entity.name;
         inFlightNames.add(displayName);
         setProgress();
+        const t0 = Date.now();
+        logDebug(`${tag} resolving "${displayName}" (${kind})`);
         results[index] = await resolveEntity(entity, kind, { bypassIdb });
+        const elapsed = Date.now() - t0;
+        const r = results[index];
+        const outcome = r?.type === "resolved" ? `resolved via ${r.logEntry?.via || "?"}${r.logEntry?.fromCache ? " (cache)" : ""}` : r?.type === "attention" ? `unresolved (${r.nameMatches?.length || 0} candidates)` : "skipped";
+        logDebug(`${tag} "${displayName}" -> ${outcome} in ${elapsed}ms`);
         inFlightNames.delete(displayName);
         done++;
+        processed++;
         setProgress();
       }
+      logDebug(`${tag} finished (${processed} entit${processed === 1 ? "y" : "ies"})`);
     }
     const slots = Math.min(CONCURRENCY, entities.length);
+    logDebug(`resolveAll: ${entities.length} entit${entities.length === 1 ? "y" : "ies"}, ${slots} worker slot(s)`);
     if (slots > 0) await Promise.all(Array.from({ length: slots }, (_, i) => worker(i)));
+    logDebug(`resolveAll: done`);
     return { allResults: results.filter(Boolean) };
   }
   var ARTIST_KIND = () => "artist";

--- a/userscripts/discogs_credits/eslint.config.mjs
+++ b/userscripts/discogs_credits/eslint.config.mjs
@@ -26,6 +26,7 @@ export default [
                 clearTimeout:           'readonly',
                 setInterval:            'readonly',
                 clearInterval:          'readonly',
+                performance:            'readonly',
                 requestAnimationFrame:  'readonly',
                 cancelAnimationFrame:   'readonly',
                 localStorage:           'readonly',

--- a/userscripts/discogs_credits/eslint.config.mjs
+++ b/userscripts/discogs_credits/eslint.config.mjs
@@ -26,6 +26,7 @@ export default [
                 clearTimeout:           'readonly',
                 setInterval:            'readonly',
                 clearInterval:          'readonly',
+                AbortController:        'readonly',
                 performance:            'readonly',
                 requestAnimationFrame:  'readonly',
                 cancelAnimationFrame:   'readonly',

--- a/userscripts/discogs_credits/src/api-mb.js
+++ b/userscripts/discogs_credits/src/api-mb.js
@@ -74,10 +74,11 @@ export const mbThrottle = (() => {
     // Per-request hard timeout. The browser will happily wait many tens of
     // seconds on a stuck connection (#87 follow-up: observed a `/ws/2/url`
     // fetch that hung for 40 213ms before the network layer gave up). One
-    // hung request blocks a throttle slot for that whole time. 15s is well
+    // hung request blocks a throttle slot for that whole time. 10s is well
     // beyond MB's normal response time (<500ms typical) but short enough
-    // that a stuck connection retries promptly.
-    const REQUEST_TIMEOUT_MS = 15000;
+    // that a stuck connection retries promptly. Lowered from 15s after a
+    // log from majkinetor showed ~30 stuck requests each burning 15s.
+    const REQUEST_TIMEOUT_MS = 10000;
 
     async function _run(item) {
         const tag = `req#${++_diagReqSeq}`;
@@ -118,10 +119,24 @@ export const mbThrottle = (() => {
                 return;
             } catch (e) {
                 const elapsed = Date.now() - t0;
-                const reason = (e?.name === 'AbortError')
+                const isTimeout = e?.name === 'AbortError';
+                const reason = isTimeout
                     ? `timed out after ${REQUEST_TIMEOUT_MS}ms`
                     : `${e?.message || e}`;
-                logDebug(`${tag} threw in ${elapsed}ms: ${reason}`);
+                // Treat AbortError (network-layer timeout) as cooperative
+                // backpressure. In the #87 logs, timeouts came in clusters of
+                // 3-5 within a few hundred ms — that pattern is MB-side
+                // overload (silently dropping requests instead of returning
+                // 503), not random socket stalls. Bump the shared pause so
+                // the rest of the pool pauses before piling on again.
+                if (isTimeout) {
+                    _rateLimited++;
+                    const waitMs = Math.min(1000 * Math.pow(2, attempt), 8000);
+                    _pauseUntil = Math.max(_pauseUntil, Date.now() + waitMs);
+                    logDebug(`${tag} threw in ${elapsed}ms: ${reason}; shared pause pushed to +${waitMs}ms`);
+                } else {
+                    logDebug(`${tag} threw in ${elapsed}ms: ${reason}`);
+                }
                 if (attempt === item.retries) { item.resolve(null); return; }
                 await new Promise(r => setTimeout(r, 500));
             } finally {

--- a/userscripts/discogs_credits/src/api-mb.js
+++ b/userscripts/discogs_credits/src/api-mb.js
@@ -3,8 +3,8 @@
 // chokepoint for everything that hits musicbrainz.org/ws/2 (and /ws/js), so
 // rate-limit handling lives in one place.
 
-import { pageWindow } from './constants.js';
-import { log }        from './log.js';
+import { pageWindow }    from './constants.js';
+import { log, logDebug } from './log.js';
 
 /**
  * Fetch a full MB entity from the internal `/ws/js/entity/{mbid}` endpoint.
@@ -47,7 +47,11 @@ export const mbThrottle = (() => {
     let _rateLimited     = 0;
 
     async function _waitForPause() {
-        let wait;
+        let wait = _pauseUntil - Date.now();
+        if (wait <= 0) return;
+        // #87 diagnostic: announce every wait so we can see in the log
+        // "worker X paused 1500ms" pile up under a 503 storm.
+        logDebug(`throttle: waiting ${wait}ms for shared pause`);
         while ((wait = _pauseUntil - Date.now()) > 0) {
             await new Promise(r => setTimeout(r, wait));
         }
@@ -61,12 +65,27 @@ export const mbThrottle = (() => {
         }
     }
 
+    // Per-logical-request diagnostic id (independent of `_totalRequests`,
+    // which counts HTTP attempts incl. retries for stats). One `req#N`
+    // covers all retries of the same call, so the user can read the
+    // story end-to-end in the diagnostic log.
+    let _diagReqSeq = 0;
+
     async function _run(item) {
+        const tag = `req#${++_diagReqSeq}`;
+        const shortUrl = item.url.replace('//musicbrainz.org', '').replace(/^https:/, '');
         for (let attempt = 0; attempt <= item.retries; attempt++) {
             await _waitForPause();
             _totalRequests++;
+            const attemptTag = attempt === 0 ? '' : ` (retry ${attempt})`;
+            // #87 diagnostic: log request start with in-flight + queued
+            // snapshot so the user can see contention in the log:
+            //   req#7 [running=8 queued=3] GET /ws/2/artist?query=...
+            logDebug(`${tag} [running=${_running} queued=${_queue.length}] GET ${shortUrl}${attemptTag}`);
+            const t0 = Date.now();
             try {
                 const res = await fetch(item.url);
+                const elapsed = Date.now() - t0;
                 if (res.status === 429 || res.status === 503) {
                     _rateLimited++;
                     const ra = parseInt(res.headers.get('Retry-After'), 10);
@@ -75,13 +94,21 @@ export const mbThrottle = (() => {
                     // Push forward only — never backward — so concurrent 503s
                     // from sibling workers don't shorten an already-pending pause.
                     _pauseUntil = Math.max(_pauseUntil, Date.now() + waitMs);
+                    logDebug(`${tag} <- ${res.status} in ${elapsed}ms; shared pause pushed to +${waitMs}ms`);
                     continue;
                 }
-                if (!res.ok) { item.resolve(null); return; }
+                if (!res.ok) {
+                    logDebug(`${tag} <- ${res.status} (give up) in ${elapsed}ms`);
+                    item.resolve(null);
+                    return;
+                }
                 const data = item.wantJson ? await res.json() : res;
+                logDebug(`${tag} <- ${res.status} in ${elapsed}ms`);
                 item.resolve(data);
                 return;
             } catch (e) {
+                const elapsed = Date.now() - t0;
+                logDebug(`${tag} threw in ${elapsed}ms: ${e?.message || e}`);
                 if (attempt === item.retries) { item.resolve(null); return; }
                 await new Promise(r => setTimeout(r, 500));
             }

--- a/userscripts/discogs_credits/src/api-mb.js
+++ b/userscripts/discogs_credits/src/api-mb.js
@@ -32,7 +32,14 @@ export async function fetchMBEntity(mbid) {
 // produced (issue #30) while keeping the burst throughput that gave that
 // approach its speed advantage over the strict serial chain it replaced.
 export const mbThrottle = (() => {
-    const MAX_CONCURRENT = 4;       // simultaneous in-flight requests
+    // 8 concurrent in-flight requests. Bumped from 4 per #87 ("Slow
+    // entity fetch ... I rarely see any 503's") — the previous cap was
+    // leaving MB headroom unused. With preflight running 10 workers
+    // (each emitting 2 parallel requests — name + URL — per entity), 8
+    // is the natural saturation point for MB's anonymous endpoint; the
+    // `_pauseUntil` cooperative backoff still kicks in if MB does
+    // return 429/503, so spikes self-correct.
+    const MAX_CONCURRENT = 8;       // simultaneous in-flight requests
     let _running         = 0;
     let _pauseUntil      = 0;        // unix-ms; workers idle until this time
     const _queue         = [];        // pending { url, retries, wantJson, resolve }

--- a/userscripts/discogs_credits/src/api-mb.js
+++ b/userscripts/discogs_credits/src/api-mb.js
@@ -32,14 +32,14 @@ export async function fetchMBEntity(mbid) {
 // produced (issue #30) while keeping the burst throughput that gave that
 // approach its speed advantage over the strict serial chain it replaced.
 export const mbThrottle = (() => {
-    // 8 concurrent in-flight requests. Bumped from 4 per #87 ("Slow
-    // entity fetch ... I rarely see any 503's") — the previous cap was
-    // leaving MB headroom unused. With preflight running 10 workers
-    // (each emitting 2 parallel requests — name + URL — per entity), 8
-    // is the natural saturation point for MB's anonymous endpoint; the
-    // `_pauseUntil` cooperative backoff still kicks in if MB does
-    // return 429/503, so spikes self-correct.
-    const MAX_CONCURRENT = 8;       // simultaneous in-flight requests
+    // 4 concurrent in-flight requests. Briefly bumped to 8 per #87 in
+    // an attempt to use MB's headroom, but a real-world test (Tricky -
+    // Back To Mine, 46+38 entities) showed MB returning a stream of
+    // 503s with `Retry-After: 9` once we sustained 8 in-flight + the
+    // two-parallel-`resolveAll` burst (artists + companies). The 9-second
+    // shared pause cascaded across every worker — the run ended up
+    // SLOWER than the previous shape. Reverted: original sizing was right.
+    const MAX_CONCURRENT = 4;       // simultaneous in-flight requests
     let _running         = 0;
     let _pauseUntil      = 0;        // unix-ms; workers idle until this time
     const _queue         = [];        // pending { url, retries, wantJson, resolve }

--- a/userscripts/discogs_credits/src/api-mb.js
+++ b/userscripts/discogs_credits/src/api-mb.js
@@ -71,6 +71,14 @@ export const mbThrottle = (() => {
     // story end-to-end in the diagnostic log.
     let _diagReqSeq = 0;
 
+    // Per-request hard timeout. The browser will happily wait many tens of
+    // seconds on a stuck connection (#87 follow-up: observed a `/ws/2/url`
+    // fetch that hung for 40 213ms before the network layer gave up). One
+    // hung request blocks a throttle slot for that whole time. 15s is well
+    // beyond MB's normal response time (<500ms typical) but short enough
+    // that a stuck connection retries promptly.
+    const REQUEST_TIMEOUT_MS = 15000;
+
     async function _run(item) {
         const tag = `req#${++_diagReqSeq}`;
         const shortUrl = item.url.replace('//musicbrainz.org', '').replace(/^https:/, '');
@@ -83,8 +91,10 @@ export const mbThrottle = (() => {
             //   req#7 [running=8 queued=3] GET /ws/2/artist?query=...
             logDebug(`${tag} [running=${_running} queued=${_queue.length}] GET ${shortUrl}${attemptTag}`);
             const t0 = Date.now();
+            const ctrl = new AbortController();
+            const timer = setTimeout(() => ctrl.abort(), REQUEST_TIMEOUT_MS);
             try {
-                const res = await fetch(item.url);
+                const res = await fetch(item.url, { signal: ctrl.signal });
                 const elapsed = Date.now() - t0;
                 if (res.status === 429 || res.status === 503) {
                     _rateLimited++;
@@ -108,9 +118,14 @@ export const mbThrottle = (() => {
                 return;
             } catch (e) {
                 const elapsed = Date.now() - t0;
-                logDebug(`${tag} threw in ${elapsed}ms: ${e?.message || e}`);
+                const reason = (e?.name === 'AbortError')
+                    ? `timed out after ${REQUEST_TIMEOUT_MS}ms`
+                    : `${e?.message || e}`;
+                logDebug(`${tag} threw in ${elapsed}ms: ${reason}`);
                 if (attempt === item.retries) { item.resolve(null); return; }
                 await new Promise(r => setTimeout(r, 500));
+            } finally {
+                clearTimeout(timer);
             }
         }
         item.resolve(null);

--- a/userscripts/discogs_credits/src/log.js
+++ b/userscripts/discogs_credits/src/log.js
@@ -67,3 +67,67 @@ export const log = {
     error: msg => _emit(`<span style="color:red">ERR ${msg}</span>`,     `ERR ${msg}`),
 };
 
+// ── Debug log (issue #87) ───────────────────────────────────────────────────
+// Diagnostic per-worker / per-request log used by `mbThrottle` and
+// `preflight` to surface "why is this slow?" data WITHOUT hijacking
+// the main log. Rendered into a lazy-created `<details>` block titled
+// "Preflight diagnostics" appended to the same `<ul>` container the
+// main log uses, but inside a single `<li>` so it stays out of the
+// way unless the user expands it.
+//
+// Output shape: one `<div>` per line, monospace, muted color,
+// timestamped relative to the first `logDebug` call this session so
+// you can read "this worker waited 230ms before its first request"
+// at a glance.
+
+let _debugUl     = null;
+let _debugStartT = null;
+
+function _ensureDebugUl() {
+    if (_debugUl) return _debugUl;
+    if (!_logs) return null;
+    const details = document.createElement('details');
+    details.style.cssText = 'margin:0.3rem 0;';
+    const summary = document.createElement('summary');
+    summary.textContent = 'Preflight diagnostics (collapsed)';
+    summary.style.cssText = 'cursor:pointer;font-size:0.8rem;color:#888;user-select:none;';
+    details.appendChild(summary);
+    const ul = document.createElement('ul');
+    ul.style.cssText = 'list-style:none;margin:0.3rem 0;padding:0.4rem 0.6rem;'
+                     + 'background:#f7f7f7;border-radius:0.25rem;'
+                     + 'font-family:ui-monospace,Menlo,Consolas,monospace;font-size:0.72rem;'
+                     + 'color:#444;max-height:24rem;overflow-y:auto;';
+    details.appendChild(ul);
+    const li = document.createElement('li');
+    li.style.listStyle = 'none';
+    li.appendChild(details);
+    _logs.appendChild(li);
+    _debugUl     = ul;
+    _debugStartT = performance.now();
+    return _debugUl;
+}
+
+/**
+ * Append one diagnostic line to the collapsed "Preflight diagnostics"
+ * section. Safe to call before the log container exists — silent no-op.
+ *
+ * Lines are timestamped relative to the first `logDebug` call:
+ *
+ *   [+0ms]    worker#0 starting
+ *   [+1ms]    req#1 GET https://musicbrainz.org/ws/2/artist?query=…
+ *   [+312ms]  req#1 ← 200 OK in 311ms
+ *   [+312ms]  worker#0 resolved "Jamie Saft" via name in 312ms
+ *
+ * Use for high-volume / noisy info — the user has to opt in by
+ * expanding the `<details>`, so we can be verbose without drowning
+ * the main log.
+ */
+export function logDebug(line) {
+    const ul = _ensureDebugUl();
+    if (!ul) return;
+    const t = Math.round(performance.now() - _debugStartT);
+    const row = document.createElement('div');
+    row.textContent = `[+${t}ms] ${line}`;
+    ul.appendChild(row);
+}
+

--- a/userscripts/discogs_credits/src/log.js
+++ b/userscripts/discogs_credits/src/log.js
@@ -89,7 +89,7 @@ function _ensureDebugUl() {
     const details = document.createElement('details');
     details.style.cssText = 'margin:0.3rem 0;';
     const summary = document.createElement('summary');
-    summary.textContent = 'Preflight diagnostics (collapsed)';
+    summary.textContent = 'Preflight diagnostics';
     summary.style.cssText = 'cursor:pointer;font-size:0.8rem;color:#888;user-select:none;';
     details.appendChild(summary);
     const ul = document.createElement('ul');

--- a/userscripts/discogs_credits/src/preflight.js
+++ b/userscripts/discogs_credits/src/preflight.js
@@ -29,6 +29,7 @@ import { readIdbRecord, writeIdbRecord }    from './storage.js';
 import { parseDiscogsUrl }                  from './api-discogs.js';
 import { ENTITY_TYPE_MAP }                  from './data/entity-map.js';
 import { _setProgressPct }                  from './progress-bar.js';
+import { logDebug }                         from './log.js';
 
 // `kind`-specific tweaks. Tiny lookup table so the per-strategy code in
 // `resolveEntity` reads as one shared body.
@@ -346,25 +347,47 @@ export async function resolveAll(entities, opts) {
     setProgress();
 
     async function worker(slotIndex) {
-        await delay(slotIndex * MIN_GAP_MS);  // stagger slot starts
+        // #87 diagnostic per worker — slot start + lifecycle entries
+        // land in the collapsed "Preflight diagnostics" section.
+        const tag = `worker#${slotIndex}`;
+        logDebug(`${tag} starting (stagger ${slotIndex * MIN_GAP_MS}ms)`);
+        await delay(slotIndex * MIN_GAP_MS);
+        let processed = 0;
         while (queue.length > 0) {
             const { entity, index } = queue.shift();
             const kind = kindOf(entity);
-            if (!kind) { done++; setProgress(); continue; }
+            if (!kind) {
+                logDebug(`${tag} skip "${entity?.name || '?'}" — no resolvable kind`);
+                done++; setProgress(); continue;
+            }
             const displayName = kind === 'artist'
                 ? (entity.anv && entity.anv.trim()) || entity.name
                 : entity.name;
             inFlightNames.add(displayName);
             setProgress();
+            const t0 = Date.now();
+            logDebug(`${tag} resolving "${displayName}" (${kind})`);
             results[index] = await resolveEntity(entity, kind, { bypassIdb });
+            const elapsed = Date.now() - t0;
+            const r = results[index];
+            const outcome = r?.type === 'resolved'
+                ? `resolved via ${r.logEntry?.via || '?'}${r.logEntry?.fromCache ? ' (cache)' : ''}`
+                : r?.type === 'attention'
+                    ? `unresolved (${r.nameMatches?.length || 0} candidates)`
+                    : 'skipped';
+            logDebug(`${tag} "${displayName}" -> ${outcome} in ${elapsed}ms`);
             inFlightNames.delete(displayName);
             done++;
+            processed++;
             setProgress();
         }
+        logDebug(`${tag} finished (${processed} entit${processed === 1 ? 'y' : 'ies'})`);
     }
 
     const slots = Math.min(CONCURRENCY, entities.length);
+    logDebug(`resolveAll: ${entities.length} entit${entities.length === 1 ? 'y' : 'ies'}, ${slots} worker slot(s)`);
     if (slots > 0) await Promise.all(Array.from({ length: slots }, (_, i) => worker(i)));
+    logDebug(`resolveAll: done`);
 
     return { allResults: results.filter(Boolean) };
 }

--- a/userscripts/discogs_credits/src/preflight.js
+++ b/userscripts/discogs_credits/src/preflight.js
@@ -308,18 +308,18 @@ async function resolveEntity(entity, kind, opts) {
  */
 export async function resolveAll(entities, opts) {
     const { kindOf, progressLi, bypassIdb, progressLabel } = opts;
-    // 10 workers, each emitting up to 2 parallel MB requests (name +
-    // URL) per entity. Bumped from 5 per #87 — maintainer reported the
-    // entity-fetch phase felt slow with few 503s, meaning we were
-    // under-utilising MB's headroom. `mbThrottle` (MAX_CONCURRENT=8)
-    // is the real cap; the worker count just keeps the queue full.
-    const CONCURRENCY = 10;
-    // Slot-start stagger trimmed 50ms → 20ms. The original was a
-    // precaution against a thundering herd of simultaneous TCP
-    // connections; with `mbThrottle`'s cooperative backoff that's no
-    // longer needed at this scale, but a small delay still smooths the
-    // open-socket spike at preflight start.
-    const MIN_GAP_MS  = 20;
+    // 5 workers, each emitting up to 2 parallel MB requests (name +
+    // URL) per entity. Briefly bumped to 10 per #87, then reverted: a
+    // single import calls `resolveAll` twice in parallel (artists +
+    // companies), so 10 workers per call = 20 total competing for
+    // `mbThrottle`'s 4 slots. The resulting burst tripped MB's rate
+    // limiter and cascaded 9-second `Retry-After` pauses across every
+    // worker. 5 keeps the queue full without piling on the burst.
+    const CONCURRENCY = 5;
+    // 50ms slot-start stagger to smooth the initial open-socket spike;
+    // raising to 20ms made the burst noticeably worse during the same
+    // #87 test, so it's back where it was.
+    const MIN_GAP_MS  = 50;
     let done = 0;
     const inFlightNames = new Set();
 

--- a/userscripts/discogs_credits/src/preflight.js
+++ b/userscripts/discogs_credits/src/preflight.js
@@ -25,7 +25,7 @@
 //   { type: 'attention', entity, nameMatches: [...] }
 
 import { mbThrottle }                       from './api-mb.js';
-import { readIdbRecord, writeIdbRecord }    from './storage.js';
+import { readIdbRecord, writeIdbRecord, deleteIdbRecord } from './storage.js';
 import { parseDiscogsUrl }                  from './api-discogs.js';
 import { ENTITY_TYPE_MAP }                  from './data/entity-map.js';
 import { _setProgressPct }                  from './progress-bar.js';
@@ -117,6 +117,17 @@ async function resolveEntity(entity, kind, opts) {
     }
 
     // ── 1. IDB cache ─────────────────────────────────────────────────────────
+    // Refresh-from-MB: wipe the existing record up-front so this entity
+    // genuinely starts from scratch. Earlier we only skipped the read
+    // and let the post-resolution write overwrite — but the write path
+    // can land on "attention" (no single match / disagreement) and
+    // silently overwrite a previously-resolved MBID with `mbid: null`.
+    // That made refresh quietly destructive on flaky MB days. Wiping
+    // first means the worst-case outcome is "no cache entry", not
+    // "cache entry downgraded".
+    if (bypassIdb && key) {
+        await deleteIdbRecord(key);
+    }
     if (!bypassIdb && key) {
         const cachedRec = await readIdbRecord(key);
         if (cachedRec?.mbid && cachedRec?.entityType) {

--- a/userscripts/discogs_credits/src/preflight.js
+++ b/userscripts/discogs_credits/src/preflight.js
@@ -307,8 +307,18 @@ async function resolveEntity(entity, kind, opts) {
  */
 export async function resolveAll(entities, opts) {
     const { kindOf, progressLi, bypassIdb, progressLabel } = opts;
-    const CONCURRENCY = 5;
-    const MIN_GAP_MS  = 50;
+    // 10 workers, each emitting up to 2 parallel MB requests (name +
+    // URL) per entity. Bumped from 5 per #87 — maintainer reported the
+    // entity-fetch phase felt slow with few 503s, meaning we were
+    // under-utilising MB's headroom. `mbThrottle` (MAX_CONCURRENT=8)
+    // is the real cap; the worker count just keeps the queue full.
+    const CONCURRENCY = 10;
+    // Slot-start stagger trimmed 50ms → 20ms. The original was a
+    // precaution against a thundering herd of simultaneous TCP
+    // connections; with `mbThrottle`'s cooperative backoff that's no
+    // longer needed at this scale, but a small delay still smooths the
+    // open-socket spike at preflight start.
+    const MIN_GAP_MS  = 20;
     let done = 0;
     const inFlightNames = new Set();
 

--- a/userscripts/discogs_credits/src/review-table.js
+++ b/userscripts/discogs_credits/src/review-table.js
@@ -1129,13 +1129,20 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
         }
         updateImportBtn();
 
-        importBtn.addEventListener('click', () => {
-            const confirmedMap = new Map();
-            rowState.forEach((s, key) => {
-                if (s.mbUrl) confirmedMap.set(key, s.mbUrl);
-            });
-
-            // ── Log summary table ──────────────────────────────────────
+        // Build the static "log summary" table from the current `rowState` and
+        // wrap it in an `<li>` ready to append to the log. Used in two places:
+        //   1. importBtn click — replaces the interactive panel with this
+        //      static snapshot before dispatch.
+        //   2. mid-review "Copy log" (#87 nitpick #2) — the interactive panel
+        //      doesn't translate to clean markdown, so `buildCopyText` calls
+        //      this builder via the `_buildStaticTableLi` closure stashed on
+        //      `panelLi` and substitutes its output in the copy.
+        // Captures `allResults`/`rowState`/`rolesMap`/`companiesRolesMap`/
+        // `viaCfg` from the enclosing `showReviewTable` scope, so the table
+        // always reflects the user's current picks (selecting a different MB
+        // entity in the panel updates `rowState`, which the next builder call
+        // reads).
+        function buildStaticTableLi() {
             const tbl = document.createElement('table');
             tbl.style.cssText = 'border-collapse:collapse;width:100%;font-size:0.78rem;margin:0.4rem 0;';
             const thRow = document.createElement('tr');
@@ -1191,7 +1198,17 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
             const tblLi = document.createElement('li');
             tblLi.style.cssText = 'list-style:none;margin:0;padding:0;';
             tblLi.appendChild(tbl);
-            getLogContainer().appendChild(tblLi);
+            return tblLi;
+        }
+
+        importBtn.addEventListener('click', () => {
+            const confirmedMap = new Map();
+            rowState.forEach((s, key) => {
+                if (s.mbUrl) confirmedMap.set(key, s.mbUrl);
+            });
+
+            // ── Log summary table ──────────────────────────────────────
+            getLogContainer().appendChild(buildStaticTableLi());
             // ─────────────────────────────────────────────────────────
 
             // Add unresolved count line after the table
@@ -1222,6 +1239,13 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
 
         const panelLi = document.createElement('li');
         panelLi.style.cssText = 'list-style:none;margin:0;padding:0;';
+        // Marker class so `buildCopyText` in ui-bar.js can find the
+        // interactive review panel in the log and swap in the static-table
+        // form via `_buildStaticTableLi` (nitpick #2). Without the swap,
+        // copying the log mid-review produces unintelligible button/select
+        // text instead of a clean markdown table.
+        panelLi.classList.add('discogs-review-panel-li');
+        panelLi._buildStaticTableLi = buildStaticTableLi;
         panelLi.appendChild(panel);
         getLogContainer().appendChild(panelLi);
         getLogContainer().scrollIntoView({ behavior: 'smooth', block: 'nearest' });

--- a/userscripts/discogs_credits/src/storage.js
+++ b/userscripts/discogs_credits/src/storage.js
@@ -153,3 +153,22 @@ export function writeIdbRecord(key, partial) {
         } catch(e) { resolve(null); }
     });
 }
+
+/**
+ * Delete a single record from `entity_cache`. Resolves to true on success,
+ * false otherwise. Never rejects. Used by the "Refresh from MB" path so a
+ * refresh truly starts from a clean slate — see the comment at
+ * `preflight.js:resolveEntity` for why we wipe instead of merge-write.
+ */
+export function deleteIdbRecord(key) {
+    return new Promise(resolve => {
+        if (!key || !db) return resolve(false);
+        try {
+            const tx    = db.transaction([STORE], 'readwrite');
+            const store = tx.objectStore(STORE);
+            const req   = store.delete(key);
+            req.onsuccess = () => resolve(true);
+            req.onerror   = () => resolve(false);
+        } catch(e) { resolve(false); }
+    });
+}

--- a/userscripts/discogs_credits/src/ui-bar.js
+++ b/userscripts/discogs_credits/src/ui-bar.js
@@ -685,6 +685,8 @@ function runImport(discogsUrl, processTracklist, applyToTracks, createWorks, ded
             // "🔄 Refresh from MB" button so the user can re-resolve when a
             // cached entry is stale (entity got merged, renamed, etc.).
             function runPreflight(bypassIdb = false) {
+                log.info(`Starting preflight: ${uniqueArtists.length} artist(s), ${uniqueCompanies.length} label(s)/place(s).`);
+
                 const artistProgressLi = document.createElement('li');
                 artistProgressLi.textContent = `Checking ${uniqueArtists.length} artist(s) against MusicBrainz…`;
                 _logs.appendChild(artistProgressLi);
@@ -701,6 +703,7 @@ function runImport(discogsUrl, processTracklist, applyToTracks, createWorks, ded
                 // #87 (a stream of 503s with `Retry-After: 9`). Serialised,
                 // the total time is the same (throttle-bound) but the
                 // request rate is smooth and burst-free.
+                const t0 = performance.now();
                 return (async () => {
                     const artistResults  = await resolveAll(uniqueArtists, {
                         progressLi:    artistProgressLi,
@@ -714,6 +717,8 @@ function runImport(discogsUrl, processTracklist, applyToTracks, createWorks, ded
                         kindOf:        COMPANY_KIND,
                         bypassIdb,
                     });
+                    const elapsed = (performance.now() - t0) / 1000;
+                    log.info(`Preflight done in ${elapsed.toFixed(1)}s.`);
                     return [...artistResults.allResults, ...companyResults.allResults].filter(Boolean);
                 })();
             }

--- a/userscripts/discogs_credits/src/ui-bar.js
+++ b/userscripts/discogs_credits/src/ui-bar.js
@@ -693,21 +693,29 @@ function runImport(discogsUrl, processTracklist, applyToTracks, createWorks, ded
                 companyProgressLi.textContent = `Checking ${uniqueCompanies.length} label(s)/place(s) against MusicBrainz…`;
                 _logs.appendChild(companyProgressLi);
 
-                return Promise.all([
-                    resolveAll(uniqueArtists, {
+                // Sequential, not parallel. Both `resolveAll` calls share
+                // the same `mbThrottle` (one chokepoint, one MB server), so
+                // running them in parallel just doubles the worker count
+                // competing for the throttle's 4 slots and bursts harder
+                // at startup — exactly what tripped MB's rate limiter in
+                // #87 (a stream of 503s with `Retry-After: 9`). Serialised,
+                // the total time is the same (throttle-bound) but the
+                // request rate is smooth and burst-free.
+                return (async () => {
+                    const artistResults  = await resolveAll(uniqueArtists, {
                         progressLi:    artistProgressLi,
                         progressLabel: 'Checking artists against MusicBrainz',
                         kindOf:        ARTIST_KIND,
                         bypassIdb,
-                    }),
-                    resolveAll(uniqueCompanies, {
+                    });
+                    const companyResults = await resolveAll(uniqueCompanies, {
                         progressLi:    companyProgressLi,
                         progressLabel: 'Checking labels/places against MusicBrainz',
                         kindOf:        COMPANY_KIND,
                         bypassIdb,
-                    }),
-                ]).then(([artistResults, companyResults]) =>
-                    [...artistResults.allResults, ...companyResults.allResults].filter(Boolean));
+                    });
+                    return [...artistResults.allResults, ...companyResults.allResults].filter(Boolean);
+                })();
             }
 
             // Annotate each result with its Discogs roles. Used both on the

--- a/userscripts/discogs_credits/src/ui-bar.js
+++ b/userscripts/discogs_credits/src/ui-bar.js
@@ -401,11 +401,19 @@ export function insertDiscogsBar(discogsUrl) {
                     }
                     if (tag === 'details') {
                         const sum = node.querySelector('summary');
+                        // Plain-text summary only. Markdown inside `<details><summary>`
+                        // is not rendered by GitHub, and interactive elements like
+                        // `<button>` (e.g. "Copy JSON") don't belong in the copy. So
+                        // skip `<button>`/`<input>` entirely and strip markdown
+                        // wrappers like `<strong>` to their text content. (Nitpick
+                        // #1 from majkinetor on #87: previously the summary read
+                        // `**...** Copy JSON`.)
                         const sumText = sum ? [...sum.childNodes].map(n => {
                             if (n.nodeType === Node.TEXT_NODE) return n.textContent;
-                            if (n.tagName?.toLowerCase() === 'strong') return '**' + n.textContent + '**';
+                            const t = n.tagName?.toLowerCase();
+                            if (t === 'button' || t === 'input') return '';
                             return n.textContent;
-                        }).join('') : '';
+                        }).join('').trim() : '';
                         // The raw-Discogs-JSON block is itself a `<details>`
                         // whose summary contains "raw Discogs JSON" — skip the
                         // whole thing (including the summary) when the user
@@ -415,7 +423,11 @@ export function insertDiscogsBar(discogsUrl) {
                         }
                         // Get non-summary children
                         const body = [...node.childNodes].filter(n => n !== sum).map(nodeToMd).join('');
-                        return '<details><summary>' + sumText + '</summary>\n\n' + body + '\n</details>';
+                        // Surround the block with blank lines so GitHub treats it
+                        // as its own paragraph. Without them, neighbouring log
+                        // lines collapse into the HTML block and lose their
+                        // markdown line breaks (nitpick #3).
+                        return '\n\n<details><summary>' + sumText + '</summary>\n\n' + body + '\n</details>\n\n';
                     }
                     if (tag === 'summary') return ''; // handled by details
                     if (tag === 'span') return inner;
@@ -437,6 +449,17 @@ export function insertDiscogsBar(discogsUrl) {
                 const _md = nodeToMd(el); return _md.startsWith('\n\n') || _md.endsWith('\n\n') ? _md : _md.replace(/^\n/, '').replace(/\n$/, '');
             }
             const lines = [..._logs.querySelectorAll('li')].map(li => {
+                // Swap the interactive review-panel `<li>` for the static
+                // markdown-table form when copying mid-review (nitpick #2 on
+                // #87). `review-table.js` stashes a `_buildStaticTableLi`
+                // closure on the panel `<li>`; calling it returns a fresh
+                // `<li>` containing the table with the user's current picks,
+                // which we feed through `htmlToMd` instead of the panel.
+                // Post-import the panel is gone and the static table lives
+                // in the log on its own, so this branch never fires then.
+                if (li.classList?.contains('discogs-review-panel-li') && typeof li._buildStaticTableLi === 'function') {
+                    return htmlToMd(li._buildStaticTableLi());
+                }
                 const md = htmlToMd(li);
                 if (!md) return ''; // skipped details emit empty — drop the line
                 // Add trailing two-spaces for markdown line breaks, except tables/details


### PR DESCRIPTION
## Summary

Closes #87 — slow entity fetch on large releases.

Throttle and worker layout reverted to the pre-bump shape (`MAX_CONCURRENT=4`, preflight `CONCURRENCY=5`, `MIN_GAP_MS=50`) after a real-world test on Tricky · Back To Mine (84 entities) showed the bumped sizing triggered cascading 9-second `Retry-After: 9` pauses from MB.

Beyond the revert, the branch carries:

- **Diagnostic log section** — collapsed `<details>` with per-worker / per-request timings, in-flight + queue snapshot per request, response status, retries. Toggled via `logDebug`.
- **Main-log start/end markers** — `Starting preflight: N artist(s), M label(s)/place(s).` and `Preflight done in X.Xs.`
- **15s→10s per-request timeout** via `AbortController`. A stuck connection no longer holds a throttle slot for the network-layer's default ~30-40s.
- **Network-timeout as cooperative backpressure** — `AbortError` bumps the shared pause the same way a 503 does (clusters of timeouts in the log indicated MB-side overload silently dropping requests).
- **Serialised the two `resolveAll` calls** — artists then companies, not `Promise.all`. Same throttle, no parallelism benefit; the parallel form just bursted at startup and tripped MB's rate limiter.
- **Refresh-from-MB now deletes the IDB record up-front** instead of overwriting after resolution. Worst-case of a failed refresh is "no cache entry" rather than "good MBID overwritten with null" (the old overwrite path was silently destructive on flaky MB days).
- **Copy-log markdown fixes** (majkinetor's nitpicks):
  1. `<details><summary>` no longer copies as `**...**Copy JSON` — strip markdown wrappers and skip buttons inside the summary.
  2. Mid-review "Copy log" now substitutes the static markdown table for the interactive review panel (the panel exposes `_buildStaticTableLi()` for `buildCopyText` to call).
  3. `<details>` blocks in copied markdown lead and trail with blank lines so GitHub treats them as their own paragraphs (previously neighbouring log lines collapsed into the HTML block).

## Test plan

- [x] Import a fresh release with 80+ entities — preflight start/end markers visible in main log
- [x] Diagnostics `<details>` populated with per-worker + per-request lines
- [x] Refresh-from-MB during MB rate-limiting — no entries lose their cached MBID (worst case: no cache entry, fresh resolve next time)
- [x] Copy log before clicking Import — output has the static markdown table, not the interactive panel
- [x] Copy log after Import — output unchanged from prior
- [x] `<details>` block in copied output has blank lines around it on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)