### PR TITLE
discogs_credits: session cache wins over stale preflight urlLinkedIds (refs #78)

### DIFF
--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Discogs Credits
 // @namespace    majkinetor
-// @version      2026.5.27.193438
+// @version      2026.5.27.200252
 // @description  Add a button to import Discogs release relationships to MusicBrainz
 // @author       majkinetor
 // @match        https://musicbrainz.org/release/*/edit-relationships
@@ -2531,6 +2531,8 @@ Leave empty to use the default (Discogs name, or MB's most-frequent existing cre
             if (!discogsHref) {
               linkSlot.textContent = "\u26A0 No Discogs page";
               linkSlot.style.color = "#c80";
+            } else if (urlCheckCached !== null) {
+              applyUrlCheckResult(urlCheckCached);
             } else if (Array.isArray(r.urlLinkedIds)) {
               const result = r.urlLinkedIds.includes(selected.id) ? "linked" : r.urlLinkedIds.length > 0 ? "other" : "none";
               _urlCheckSessionCache.set(urlCheckCacheKey, result);
@@ -2539,8 +2541,6 @@ Leave empty to use the default (Discogs name, or MB's most-frequent existing cre
               } catch (e2) {
               }
               applyUrlCheckResult(result);
-            } else if (urlCheckCached !== null) {
-              applyUrlCheckResult(urlCheckCached);
             } else {
               queuedUrlCheck(
                 () => fetchWithRetry(`//musicbrainz.org/ws/2/url?resource=${encodeURIComponent(discogsHref)}&inc=${entityType}-rels&fmt=json`).then((json) => {

--- a/userscripts/discogs_credits/src/review-table.js
+++ b/userscripts/discogs_credits/src/review-table.js
@@ -708,6 +708,20 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
                         // No Discogs URL — skip URL check entirely
                         linkSlot.textContent = '⚠ No Discogs page';
                         linkSlot.style.color = '#c80';
+                    } else if (urlCheckCached !== null) {
+                        // Session-cache always takes precedence over the
+                        // preflight `urlLinkedIds` snapshot. The cache is
+                        // updated by: per-row MB checks, the
+                        // recheckUrlBypassCache focus-return flow, and the
+                        // `*-created` BroadcastChannel pre-seed (#78). The
+                        // `urlLinkedIds` array is captured ONCE during
+                        // preflight and is stale the moment the user adds
+                        // the link or creates a new entity. Reading
+                        // urlLinkedIds first (the old order) clobbered the
+                        // #78 pre-seed of `'linked'` with `'none'` derived
+                        // from the empty preflight snapshot — that's why
+                        // the 🔗 chip kept flashing after entity creation.
+                        applyUrlCheckResult(urlCheckCached);
                     } else if (Array.isArray(r.urlLinkedIds)) {
                         // Preflight already harvested the Discogs-URL → MB-entity
                         // relations (parallel with name search). Compute the row's
@@ -720,8 +734,6 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
                         _urlCheckSessionCache.set(urlCheckCacheKey, result);
                         try { localStorage.setItem(urlCheckLsKey, JSON.stringify({ date: urlCheckToday, result })); } catch(e) {}
                         applyUrlCheckResult(result);
-                    } else if (urlCheckCached !== null) {
-                        applyUrlCheckResult(urlCheckCached);
                     } else {
                         queuedUrlCheck(() =>
                             fetchWithRetry(`//musicbrainz.org/ws/2/url?resource=${encodeURIComponent(discogsHref)}&inc=${entityType}-rels&fmt=json`)


### PR DESCRIPTION
## Summary

Reopens the fix for [#78](https://github.com/majkinetor/musicbrainz-userscripts/issues/78). The first attempt (commit [`2eede81`](https://github.com/majkinetor/musicbrainz-userscripts/commit/2eede81), merged via [#83](https://github.com/majkinetor/musicbrainz-userscripts/pull/83)) pre-seeded the session URL-check cache to `'linked'` before `setRowResolved`, but the seed was never read — `renderActions` checked `r.urlLinkedIds` first and overwrote the cache with `'none'` derived from the preflight snapshot. For a freshly-created entity, preflight's `urlLinkedIds` is `[]` (entity didn't exist yet), so the chip rendered 🔗 every time.

Fix: reorder branches in `renderActions` so the session cache wins over the one-time preflight snapshot. The cache is updated by every flow that knows current state (per-row MB checks, focus-return rechecks, the `*-created` BroadcastChannel pre-seed); `urlLinkedIds` is captured once and goes stale the moment a user adds a link or creates a new entity. Trusting fresher data is correct in general, not just for this bug.

Issue is already closed — this PR exists to land the fix in main since the close-without-merge would leave main without the patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)