### PR TITLE
discogs_credits: create-works mode picker + live-options at dispatch (closes #94)

### DIFF
--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Discogs Credits
 // @namespace    majkinetor
-// @version      2026.5.27.203005
+// @version      2026.5.27.205804
 // @description  Add a button to import Discogs release relationships to MusicBrainz
 // @author       majkinetor
 // @match        https://musicbrainz.org/release/*/edit-relationships
@@ -3217,7 +3217,7 @@ Leave empty to use the default (Discogs name, or MB's most-frequent existing cre
   ];
 
   // src/dispatch.js
-  async function dispatchAllRelationships(companies, artistRoles, tracklistRels, applyToTracks, createWorks, discogsTracklist, processTracklist, resolvedEntityTypes, confirmedMap, discogsUrl, dedupOpts) {
+  async function dispatchAllRelationships(companies, artistRoles, tracklistRels, applyToTracks, createWorksMode, discogsTracklist, processTracklist, resolvedEntityTypes, confirmedMap, discogsUrl, dedupOpts) {
     resolvedEntityTypes = resolvedEntityTypes || /* @__PURE__ */ new Map();
     confirmedMap = confirmedMap || /* @__PURE__ */ new Map();
     dedupOpts = dedupOpts || {};
@@ -3624,17 +3624,15 @@ Leave empty to use the default (Discogs name, or MB's most-frequent existing cre
         if (!workOnlyByGid.has(recEntity.gid)) workOnlyByGid.set(recEntity.gid, []);
         workOnlyByGid.get(recEntity.gid).push({ role, recEntity });
       }
-      if (createWorks) {
-        for (const role of artistRoles) {
-          if (!WORK_ONLY_ARTIST_RELS.includes(role.linkType)) continue;
-          for (const recEntity of recordingByGid.values()) {
-            const syntheticRole = { ...role, track: { position: "", title: recEntity.name || "" } };
-            if (!workOnlyByGid.has(recEntity.gid)) workOnlyByGid.set(recEntity.gid, []);
-            workOnlyByGid.get(recEntity.gid).push({ role: syntheticRole, recEntity });
-          }
+      for (const role of artistRoles) {
+        if (!WORK_ONLY_ARTIST_RELS.includes(role.linkType)) continue;
+        for (const recEntity of recordingByGid.values()) {
+          const syntheticRole = { ...role, track: { position: "", title: recEntity.name || "" } };
+          if (!workOnlyByGid.has(recEntity.gid)) workOnlyByGid.set(recEntity.gid, []);
+          workOnlyByGid.get(recEntity.gid).push({ role: syntheticRole, recEntity });
         }
       }
-      if (createWorks && recordingOfLinkTypeId) {
+      if (createWorksMode === "when-missing" && recordingOfLinkTypeId) {
         for (const recEntity of recordingByGid.values()) {
           if (!workOnlyByGid.has(recEntity.gid)) {
             workOnlyByGid.set(recEntity.gid, []);
@@ -3675,13 +3673,6 @@ Leave empty to use the default (Discogs name, or MB's most-frequent existing cre
         }
         if (!workEntity) workEntity = getWorkFromEditorState(recEntity);
         if (!workEntity) {
-          if (!createWorks) {
-            for (const { role } of entries) {
-              log.error(`Track ${trackPos} "${trackTitle}": no work exists for ${role.linkType} (${role.artist.name}) \u2014 enable "Create missing works" or add work manually`);
-              failed++;
-            }
-            continue;
-          }
           const newWorkId = re.getRelationshipStateId();
           workEntity = {
             _fromBatchCreateWorksDialog: true,
@@ -3788,7 +3779,7 @@ Leave empty to use the default (Discogs name, or MB's most-frequent existing cre
       const opts = [
         processTracklist !== void 0 ? `per-track:${processTracklist ? "on" : "off"}` : null,
         applyToTracks !== void 0 ? `move-to-tracks:${applyToTracks ? "on" : "off"}` : null,
-        createWorks !== void 0 ? `create-works:${createWorks ? "on" : "off"}` : null
+        createWorksMode !== void 0 ? `create-works:${createWorksMode}` : null
       ].filter(Boolean).join(", ");
       const trackCount2 = Array.isArray(discogsTracklist) ? discogsTracklist.length : 0;
       const inputStats = `Input: ${companies?.length || 0} companies, ${artistRoles?.length || 0} release credits, ${tracklistRels?.length || 0} tracklist credits on ${trackCount2} track${trackCount2 === 1 ? "" : "s"}`;
@@ -4086,6 +4077,27 @@ Leave empty to use the default (Discogs name, or MB's most-frequent existing cre
       row2.appendChild(lbl);
       return cb;
     }
+    function makeSelect(labelText, initialValue, options, tooltipText) {
+      const wrap = document.createElement("span");
+      wrap.className = "discogs-select-wrap";
+      wrap.style.cssText = "display:inline-flex;align-items:center;gap:0.3rem;font-size:0.8rem;color:#555;padding:0.15rem 0.2rem 0.15rem 0.55rem;border:1px solid #d8c8a0;border-radius:2rem;background:#fffdf7;";
+      const lbl = document.createElement("span");
+      lbl.textContent = labelText + ":";
+      wrap.appendChild(lbl);
+      const sel = document.createElement("select");
+      sel.style.cssText = "font-size:0.8rem;padding:0.05rem 0.3rem;border:1px solid #d8c8a0;border-radius:1rem;background:#fff8ee;cursor:pointer;color:#333;font-weight:600;";
+      options.forEach((opt) => {
+        const o = document.createElement("option");
+        o.value = opt.value;
+        o.textContent = opt.label;
+        if (opt.value === initialValue) o.selected = true;
+        sel.appendChild(o);
+      });
+      if (tooltipText) wrap.title = tooltipText;
+      wrap.appendChild(sel);
+      row2.appendChild(wrap);
+      return sel;
+    }
     const OPTS_KEY = "discogs-importer-opts";
     let savedOpts = {};
     try {
@@ -4103,11 +4115,15 @@ Leave empty to use the default (Discogs name, or MB's most-frequent existing cre
       bv("applyTracks", true),
       "Move performance credits from the release down to every recording."
     );
-    const createWorksCb = makeCheckbox(
-      "Create missing works",
-      bv("createWorks", true),
-      "Create a new inline work for recordings without one, and link composer/lyricist/writer credits to it."
+    const _legacyCreateWorks = savedOpts.createWorks;
+    const _initialCreateWorksMode = bv(
+      "createWorksMode",
+      _legacyCreateWorks === true ? "when-missing" : "when-needed"
     );
+    const createWorksMode = makeSelect("Create works", _initialCreateWorksMode, [
+      { value: "when-needed", label: "when needed" },
+      { value: "when-missing", label: "when missing" }
+    ], "when needed: create a work only when there is a composer/lyricist/writer credit to attach. when missing: create a work for every recording without one, regardless of credits.");
     const dedupSep = document.createElement("span");
     dedupSep.textContent = "Dedup:";
     dedupSep.style.cssText = "margin:0 0.2rem 0 0.6rem;color:#888;font-size:0.85rem;font-weight:600;";
@@ -4127,14 +4143,15 @@ Leave empty to use the default (Discogs name, or MB's most-frequent existing cre
         localStorage.setItem(OPTS_KEY, JSON.stringify({
           tracklist: tracklistCb.checked,
           applyTracks: applyTracksCb.checked,
-          createWorks: createWorksCb.checked,
+          createWorksMode: createWorksMode.value,
           dedupeEquivalenceSets: dedupeEqCb.checked,
           dedupeDuplicateRoles: dedupeDupCb.checked
         }));
       } catch (e) {
       }
     };
-    [tracklistCb, applyTracksCb, createWorksCb, dedupeEqCb, dedupeDupCb].forEach((cb) => cb.closest("label").addEventListener("click", () => setTimeout(saveOpts, 0)));
+    [tracklistCb, applyTracksCb, dedupeEqCb, dedupeDupCb].forEach((cb) => cb.closest("label").addEventListener("click", () => setTimeout(saveOpts, 0)));
+    createWorksMode.addEventListener("change", saveOpts);
     bar.appendChild(row2);
     const outputDiv = document.createElement("div");
     outputDiv.className = "discogs-output";
@@ -4262,14 +4279,14 @@ ${lines}
         if (pct !== null && pct >= 100) _hideBar();
       };
       requestAnimationFrame(_showBar);
-      const opts = `per-track:${tracklistCb.checked ? "on" : "off"}, move-to-tracks:${applyTracksCb.checked ? "on" : "off"}, create-works:${createWorksCb.checked ? "on" : "off"}`;
+      const opts = `per-track:${tracklistCb.checked ? "on" : "off"}, move-to-tracks:${applyTracksCb.checked ? "on" : "off"}, create-works:${createWorksMode.value}`;
       const editNote = buildEditNote(discogsUrl, opts);
       editNote.split("\n").forEach((line) => {
         if (!line.trim()) return;
         const html = line.replace(/(https?:\/\/[^\s]+)/g, '<a href="$1" target="_blank" rel="noopener noreferrer nofollow">$1</a>');
         log.info(html);
       });
-      runImport(discogsUrl, tracklistCb.checked, applyTracksCb.checked, createWorksCb.checked, dedupeEqCb.checked, dedupeDupCb.checked).finally(() => {
+      runImport(discogsUrl, tracklistCb.checked, applyTracksCb.checked, createWorksMode.value, dedupeEqCb.checked, dedupeDupCb.checked).finally(() => {
         importBtn.disabled = false;
         importBtn.textContent = "Import from Discogs";
         progressPct.textContent = "100%";
@@ -4305,7 +4322,7 @@ ${lines}
     } catch (e) {
     }
   })();
-  function runImport(discogsUrl, processTracklist, applyToTracks, createWorks, dedupeEquivalenceSets, dedupeDuplicateRoles) {
+  function runImport(discogsUrl, processTracklist, applyToTracks, createWorksMode, dedupeEquivalenceSets, dedupeDuplicateRoles) {
     return getDiscogsReleaseData(discogsUrl).then((json) => {
       let artistRoles = rolesFromDiscogsArtists(json.extraartists?.filter((artist) => !artist.tracks));
       if (!_logs2._releaseInfoAdded) {
@@ -4490,7 +4507,7 @@ ${lines}
           dedupeDuplicateRoles,
           creditOverrides: capturedConfirmedMap?.creditOverrides
         };
-        return dispatchAllRelationships(json.companies, artistRoles, tracklistRels, applyToTracks, createWorks, json.tracklist, processTracklist, resolvedEntityTypes, capturedConfirmedMap, discogsUrl, dedupOpts);
+        return dispatchAllRelationships(json.companies, artistRoles, tracklistRels, applyToTracks, createWorksMode, json.tracklist, processTracklist, resolvedEntityTypes, capturedConfirmedMap, discogsUrl, dedupOpts);
       });
     }).then(() => {
     });

--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Discogs Credits
 // @namespace    majkinetor
-// @version      2026.5.27.205804
+// @version      2026.5.27.212311
 // @description  Add a button to import Discogs release relationships to MusicBrainz
 // @author       majkinetor
 // @match        https://musicbrainz.org/release/*/edit-relationships
@@ -4279,14 +4279,22 @@ ${lines}
         if (pct !== null && pct >= 100) _hideBar();
       };
       requestAnimationFrame(_showBar);
-      const opts = `per-track:${tracklistCb.checked ? "on" : "off"}, move-to-tracks:${applyTracksCb.checked ? "on" : "off"}, create-works:${createWorksMode.value}`;
+      const getOpts = () => ({
+        processTracklist: tracklistCb.checked,
+        applyToTracks: applyTracksCb.checked,
+        createWorksMode: createWorksMode.value,
+        dedupeEquivalenceSets: dedupeEqCb.checked,
+        dedupeDuplicateRoles: dedupeDupCb.checked
+      });
+      const _click = getOpts();
+      const opts = `per-track:${_click.processTracklist ? "on" : "off"}, move-to-tracks:${_click.applyToTracks ? "on" : "off"}, create-works:${_click.createWorksMode}`;
       const editNote = buildEditNote(discogsUrl, opts);
       editNote.split("\n").forEach((line) => {
         if (!line.trim()) return;
         const html = line.replace(/(https?:\/\/[^\s]+)/g, '<a href="$1" target="_blank" rel="noopener noreferrer nofollow">$1</a>');
         log.info(html);
       });
-      runImport(discogsUrl, tracklistCb.checked, applyTracksCb.checked, createWorksMode.value, dedupeEqCb.checked, dedupeDupCb.checked).finally(() => {
+      runImport(discogsUrl, getOpts).finally(() => {
         importBtn.disabled = false;
         importBtn.textContent = "Import from Discogs";
         progressPct.textContent = "100%";
@@ -4322,7 +4330,9 @@ ${lines}
     } catch (e) {
     }
   })();
-  function runImport(discogsUrl, processTracklist, applyToTracks, createWorksMode, dedupeEquivalenceSets, dedupeDuplicateRoles) {
+  function runImport(discogsUrl, getOpts) {
+    const initial = getOpts();
+    const { processTracklist } = initial;
     return getDiscogsReleaseData(discogsUrl).then((json) => {
       let artistRoles = rolesFromDiscogsArtists(json.extraartists?.filter((artist) => !artist.tracks));
       if (!_logs2._releaseInfoAdded) {
@@ -4502,12 +4512,16 @@ ${lines}
             resolvedEntityTypes.set(r.entity.resource_url, r.entityType);
           }
         });
+        const live = getOpts();
+        if (live.processTracklist !== processTracklist) {
+          log.warn(`"Per-track credits" toggled during review (preflight ran with "${processTracklist ? "on" : "off"}", import will follow preflight). To change, restart the import.`);
+        }
         const dedupOpts = {
-          dedupeEquivalenceSets,
-          dedupeDuplicateRoles,
+          dedupeEquivalenceSets: live.dedupeEquivalenceSets,
+          dedupeDuplicateRoles: live.dedupeDuplicateRoles,
           creditOverrides: capturedConfirmedMap?.creditOverrides
         };
-        return dispatchAllRelationships(json.companies, artistRoles, tracklistRels, applyToTracks, createWorksMode, json.tracklist, processTracklist, resolvedEntityTypes, capturedConfirmedMap, discogsUrl, dedupOpts);
+        return dispatchAllRelationships(json.companies, artistRoles, tracklistRels, live.applyToTracks, live.createWorksMode, json.tracklist, processTracklist, resolvedEntityTypes, capturedConfirmedMap, discogsUrl, dedupOpts);
       });
     }).then(() => {
     });

--- a/userscripts/discogs_credits/src/dispatch.js
+++ b/userscripts/discogs_credits/src/dispatch.js
@@ -38,7 +38,7 @@ import { _showBar, _setProgressPct }     from './progress-bar.js';
 //                            for the resolved entity, the override wins
 //                            over the Discogs-side credit. Falls back to
 //                            the Discogs name when no override exists.
-export async function dispatchAllRelationships(companies, artistRoles, tracklistRels, applyToTracks, createWorks, discogsTracklist, processTracklist, resolvedEntityTypes, confirmedMap, discogsUrl, dedupOpts) {
+export async function dispatchAllRelationships(companies, artistRoles, tracklistRels, applyToTracks, createWorksMode, discogsTracklist, processTracklist, resolvedEntityTypes, confirmedMap, discogsUrl, dedupOpts) {
     resolvedEntityTypes = resolvedEntityTypes || new Map();
     confirmedMap = confirmedMap || new Map();
     dedupOpts = dedupOpts || {};
@@ -584,21 +584,22 @@ export async function dispatchAllRelationships(companies, artistRoles, tracklist
             workOnlyByGid.get(recEntity.gid).push({ role, recEntity });
         }
 
-        // Release-level work-only roles apply to all recordings — only when createWorks is on
-        if (createWorks) {
-            for (const role of artistRoles) {
-                if (!WORK_ONLY_ARTIST_RELS.includes(role.linkType)) continue;
-                for (const recEntity of recordingByGid.values()) {
-                    const syntheticRole = { ...role, track: { position: '', title: recEntity.name || '' } };
-                    if (!workOnlyByGid.has(recEntity.gid)) workOnlyByGid.set(recEntity.gid, []);
-                    workOnlyByGid.get(recEntity.gid).push({ role: syntheticRole, recEntity });
-                }
+        // Release-level work-only roles apply to all recordings (in both
+        // modes — release-level credits count as "needed").
+        for (const role of artistRoles) {
+            if (!WORK_ONLY_ARTIST_RELS.includes(role.linkType)) continue;
+            for (const recEntity of recordingByGid.values()) {
+                const syntheticRole = { ...role, track: { position: '', title: recEntity.name || '' } };
+                if (!workOnlyByGid.has(recEntity.gid)) workOnlyByGid.set(recEntity.gid, []);
+                workOnlyByGid.get(recEntity.gid).push({ role: syntheticRole, recEntity });
             }
         }
 
-        // When createWorks is ON, also ensure all recordings have a work —
-        // even those with no work-only artist relationships.
-        if (createWorks && recordingOfLinkTypeId) {
+        // #94: "when missing" mode also ensures EVERY recording has a work,
+        // even those with no work-only artist relationships. "when needed"
+        // (default) skips this step — recordings without an associated
+        // composer/lyricist/writer credit are left alone.
+        if (createWorksMode === 'when-missing' && recordingOfLinkTypeId) {
             for (const recEntity of recordingByGid.values()) {
                 if (!workOnlyByGid.has(recEntity.gid)) {
                     workOnlyByGid.set(recEntity.gid, []); // empty roles — work creation only
@@ -632,7 +633,7 @@ export async function dispatchAllRelationships(companies, artistRoles, tracklist
         }
 
         for (const [recGid, entries] of workOnlyByGid) {
-            // entries may be empty when createWorks adds all recordings (no work-only roles)
+            // entries may be empty when createWorksMode='when-missing' adds all recordings (no work-only roles)
             const recEntity  = entries[0]?.recEntity  ?? recordingByGid.get(recGid);
             const trackTitle = entries[0]?.role.track.title    ?? recEntity?.name ?? recGid;
             const trackPos   = entries[0]?.role.track.position ?? '';
@@ -653,17 +654,11 @@ export async function dispatchAllRelationships(companies, artistRoles, tracklist
             // Also check for works dispatched in this session (newly created ones)
             if (!workEntity) workEntity = getWorkFromEditorState(recEntity);
 
-            // No work found
+            // No work found — always create one (#94 removed the "off"
+            // option; the user picks between "when needed" and "when
+            // missing", both of which create works for the recordings in
+            // `workOnlyByGid`).
             if (!workEntity) {
-                if (!createWorks) {
-                    // Log as error — work-only rels cannot be applied without a work
-                    for (const { role } of entries) {
-                        log.error(`Track ${trackPos} "${trackTitle}": no work exists for ${role.linkType} (${role.artist.name}) — enable "Create missing works" or add work manually`);
-                        failed++;
-                    }
-                    continue;
-                }
-
                 // Use MB's own batch-create-works mechanism:
                 //   1. Build a work object matching MB's createWorkObject() output
                 //   2. Register it via mergeLinkedEntities so the editor knows about it
@@ -788,7 +783,7 @@ export async function dispatchAllRelationships(companies, artistRoles, tracklist
         const opts = [
             processTracklist !== undefined ? `per-track:${processTracklist ? 'on' : 'off'}` : null,
             applyToTracks   !== undefined ? `move-to-tracks:${applyToTracks ? 'on' : 'off'}` : null,
-            createWorks     !== undefined ? `create-works:${createWorks ? 'on' : 'off'}` : null,
+            createWorksMode !== undefined ? `create-works:${createWorksMode}` : null,
         ].filter(Boolean).join(', ');
         // Statistics (issues #56, follow-up) — surface input size, review
         // outcome (unresolved entities), and dispatch outcome in the edit

--- a/userscripts/discogs_credits/src/ui-bar.js
+++ b/userscripts/discogs_credits/src/ui-bar.js
@@ -358,6 +358,33 @@ export function insertDiscogsBar(discogsUrl) {
         return cb;
     }
 
+    // Inline label + native `<select>` for binary/enum option picks (#94).
+    // Read the chosen value via the returned element's `.value`. The wrapping
+    // `<span>` carries the tooltip and a class for hover/persist hooks; the
+    // returned element IS the `<select>` so callers don't have to drill into
+    // the wrapper.
+    function makeSelect(labelText, initialValue, options, tooltipText) {
+        const wrap = document.createElement('span');
+        wrap.className = 'discogs-select-wrap';
+        wrap.style.cssText = 'display:inline-flex;align-items:center;gap:0.3rem;font-size:0.8rem;color:#555;padding:0.15rem 0.2rem 0.15rem 0.55rem;border:1px solid #d8c8a0;border-radius:2rem;background:#fffdf7;';
+        const lbl = document.createElement('span');
+        lbl.textContent = labelText + ':';
+        wrap.appendChild(lbl);
+        const sel = document.createElement('select');
+        sel.style.cssText = 'font-size:0.8rem;padding:0.05rem 0.3rem;border:1px solid #d8c8a0;border-radius:1rem;background:#fff8ee;cursor:pointer;color:#333;font-weight:600;';
+        options.forEach(opt => {
+            const o = document.createElement('option');
+            o.value = opt.value;
+            o.textContent = opt.label;
+            if (opt.value === initialValue) o.selected = true;
+            sel.appendChild(o);
+        });
+        if (tooltipText) wrap.title = tooltipText;
+        wrap.appendChild(sel);
+        row2.appendChild(wrap);
+        return sel;
+    }
+
     const OPTS_KEY = 'discogs-importer-opts';
     let savedOpts = {};
     try { savedOpts = JSON.parse(localStorage.getItem(OPTS_KEY) || '{}'); } catch(e) {}
@@ -367,8 +394,20 @@ export function insertDiscogsBar(discogsUrl) {
         'Import per-track artist credits from Discogs.');
     const applyTracksCb  = makeCheckbox('Move release credits to tracks', bv('applyTracks', true),
         'Move performance credits from the release down to every recording.');
-    const createWorksCb  = makeCheckbox('Create missing works',           bv('createWorks', true),
-        'Create a new inline work for recordings without one, and link composer/lyricist/writer credits to it.');
+    // #94: "Create works" is now a binary mode picker, not a boolean toggle:
+    //   when-needed (default): create a work only when there's a
+    //                           composer/lyricist/writer credit to attach.
+    //   when-missing:          create a work for EVERY recording without one,
+    //                           credits or no credits (old `createWorks=true`).
+    // Migration: legacy `createWorks: true` → 'when-missing' (preserves the
+    // user's explicit always-create choice); anything else → 'when-needed'.
+    const _legacyCreateWorks = savedOpts.createWorks;
+    const _initialCreateWorksMode = bv('createWorksMode',
+        _legacyCreateWorks === true ? 'when-missing' : 'when-needed');
+    const createWorksMode = makeSelect('Create works', _initialCreateWorksMode, [
+        { value: 'when-needed',  label: 'when needed'  },
+        { value: 'when-missing', label: 'when missing' },
+    ], 'when needed: create a work only when there is a composer/lyricist/writer credit to attach. when missing: create a work for every recording without one, regardless of credits.');
 
     // ── Deduplication section (issue #62) ─────────────────────────────────
     // Two toggles that change how the dispatcher decides "this rel is
@@ -387,13 +426,14 @@ export function insertDiscogsBar(discogsUrl) {
     const saveOpts = () => {
         try { localStorage.setItem(OPTS_KEY, JSON.stringify({
             tracklist: tracklistCb.checked, applyTracks: applyTracksCb.checked,
-            createWorks: createWorksCb.checked,
+            createWorksMode: createWorksMode.value,
             dedupeEquivalenceSets: dedupeEqCb.checked,
             dedupeDuplicateRoles:  dedupeDupCb.checked,
         })); } catch(e) {}
     };
-    [tracklistCb, applyTracksCb, createWorksCb, dedupeEqCb, dedupeDupCb].forEach(cb =>
+    [tracklistCb, applyTracksCb, dedupeEqCb, dedupeDupCb].forEach(cb =>
         cb.closest('label').addEventListener('click', () => setTimeout(saveOpts, 0)));
+    createWorksMode.addEventListener('change', saveOpts);
 
     bar.appendChild(row2);
 
@@ -575,7 +615,7 @@ export function insertDiscogsBar(discogsUrl) {
         // Re-show progress bar
         requestAnimationFrame(_showBar);
 
-        const opts = `per-track:${tracklistCb.checked?'on':'off'}, move-to-tracks:${applyTracksCb.checked?'on':'off'}, create-works:${createWorksCb.checked?'on':'off'}`;
+        const opts = `per-track:${tracklistCb.checked?'on':'off'}, move-to-tracks:${applyTracksCb.checked?'on':'off'}, create-works:${createWorksMode.value}`;
         const editNote = buildEditNote(discogsUrl, opts);
         editNote.split('\n').forEach(line => {
             if (!line.trim()) return;
@@ -583,7 +623,7 @@ export function insertDiscogsBar(discogsUrl) {
             const html = line.replace(/(https?:\/\/[^\s]+)/g, '<a href="$1" target="_blank" rel="noopener noreferrer nofollow">$1</a>');
             log.info(html);
         });
-        runImport(discogsUrl, tracklistCb.checked, applyTracksCb.checked, createWorksCb.checked, dedupeEqCb.checked, dedupeDupCb.checked).finally(() => {
+        runImport(discogsUrl, tracklistCb.checked, applyTracksCb.checked, createWorksMode.value, dedupeEqCb.checked, dedupeDupCb.checked).finally(() => {
             importBtn.disabled = false;
             importBtn.textContent = 'Import from Discogs';
             progressPct.textContent = '100%';
@@ -625,7 +665,7 @@ export function insertDiscogsBar(discogsUrl) {
         keysToRemove.forEach(k => localStorage.removeItem(k));
     } catch(e) {}
 })();
-function runImport(discogsUrl, processTracklist, applyToTracks, createWorks, dedupeEquivalenceSets, dedupeDuplicateRoles) {
+function runImport(discogsUrl, processTracklist, applyToTracks, createWorksMode, dedupeEquivalenceSets, dedupeDuplicateRoles) {
     return getDiscogsReleaseData(discogsUrl)
         .then(json => {
             let artistRoles = rolesFromDiscogsArtists(json.extraartists?.filter(artist => !artist.tracks));
@@ -868,7 +908,7 @@ function runImport(discogsUrl, processTracklist, applyToTracks, createWorks, ded
                         dedupeDuplicateRoles,
                         creditOverrides: capturedConfirmedMap?.creditOverrides,
                     };
-                    return dispatchAllRelationships(json.companies, artistRoles, tracklistRels, applyToTracks, createWorks, json.tracklist, processTracklist, resolvedEntityTypes, capturedConfirmedMap, discogsUrl, dedupOpts);
+                    return dispatchAllRelationships(json.companies, artistRoles, tracklistRels, applyToTracks, createWorksMode, json.tracklist, processTracklist, resolvedEntityTypes, capturedConfirmedMap, discogsUrl, dedupOpts);
                 });
         })
         .then(() => { });

--- a/userscripts/discogs_credits/src/ui-bar.js
+++ b/userscripts/discogs_credits/src/ui-bar.js
@@ -615,7 +615,20 @@ export function insertDiscogsBar(discogsUrl) {
         // Re-show progress bar
         requestAnimationFrame(_showBar);
 
-        const opts = `per-track:${tracklistCb.checked?'on':'off'}, move-to-tracks:${applyTracksCb.checked?'on':'off'}, create-works:${createWorksMode.value}`;
+        // Options getter — read current control state on demand. `runImport`
+        // calls it once at preflight start and AGAIN right before dispatch,
+        // so toggling any option during the review-table phase (#94 follow-up
+        // from majkinetor) takes effect at dispatch time. Previously the
+        // values were captured at click time and frozen.
+        const getOpts = () => ({
+            processTracklist:        tracklistCb.checked,
+            applyToTracks:           applyTracksCb.checked,
+            createWorksMode:         createWorksMode.value,
+            dedupeEquivalenceSets:   dedupeEqCb.checked,
+            dedupeDuplicateRoles:    dedupeDupCb.checked,
+        });
+        const _click = getOpts();
+        const opts = `per-track:${_click.processTracklist?'on':'off'}, move-to-tracks:${_click.applyToTracks?'on':'off'}, create-works:${_click.createWorksMode}`;
         const editNote = buildEditNote(discogsUrl, opts);
         editNote.split('\n').forEach(line => {
             if (!line.trim()) return;
@@ -623,7 +636,7 @@ export function insertDiscogsBar(discogsUrl) {
             const html = line.replace(/(https?:\/\/[^\s]+)/g, '<a href="$1" target="_blank" rel="noopener noreferrer nofollow">$1</a>');
             log.info(html);
         });
-        runImport(discogsUrl, tracklistCb.checked, applyTracksCb.checked, createWorksMode.value, dedupeEqCb.checked, dedupeDupCb.checked).finally(() => {
+        runImport(discogsUrl, getOpts).finally(() => {
             importBtn.disabled = false;
             importBtn.textContent = 'Import from Discogs';
             progressPct.textContent = '100%';
@@ -665,7 +678,14 @@ export function insertDiscogsBar(discogsUrl) {
         keysToRemove.forEach(k => localStorage.removeItem(k));
     } catch(e) {}
 })();
-function runImport(discogsUrl, processTracklist, applyToTracks, createWorksMode, dedupeEquivalenceSets, dedupeDuplicateRoles) {
+function runImport(discogsUrl, getOpts) {
+    // Initial snapshot — used for the preflight phase (per-track decision is
+    // baked in here because it controls which entities are resolved). The
+    // OTHER options (move-to-tracks, create-works, dedup) are re-read just
+    // before dispatch so users can flip them during the review phase
+    // (#94 follow-up).
+    const initial = getOpts();
+    const { processTracklist } = initial;
     return getDiscogsReleaseData(discogsUrl)
         .then(json => {
             let artistRoles = rolesFromDiscogsArtists(json.extraartists?.filter(artist => !artist.tracks));
@@ -899,16 +919,26 @@ function runImport(discogsUrl, processTracklist, applyToTracks, createWorksMode,
                             resolvedEntityTypes.set(r.entity.resource_url, r.entityType);
                         }
                     });
+                    // Re-read options at dispatch time so toggles changed
+                    // during the review phase take effect (#94 follow-up).
+                    // `processTracklist` is the one exception — it controls
+                    // which entities got preflighted, so we honor the
+                    // initial value (changing it mid-flight can't
+                    // retroactively add or skip preflight work).
+                    const live = getOpts();
+                    if (live.processTracklist !== processTracklist) {
+                        log.warn(`"Per-track credits" toggled during review (preflight ran with "${processTracklist?'on':'off'}", import will follow preflight). To change, restart the import.`);
+                    }
                     // Bundle the dedup options + the Credited-as override
                     // map (the review table stashes it on confirmedMap as
                     // `creditOverrides`). `dispatchAllRelationships` reads
                     // them from a trailing opts arg per #62.
                     const dedupOpts = {
-                        dedupeEquivalenceSets,
-                        dedupeDuplicateRoles,
+                        dedupeEquivalenceSets: live.dedupeEquivalenceSets,
+                        dedupeDuplicateRoles:  live.dedupeDuplicateRoles,
                         creditOverrides: capturedConfirmedMap?.creditOverrides,
                     };
-                    return dispatchAllRelationships(json.companies, artistRoles, tracklistRels, applyToTracks, createWorksMode, json.tracklist, processTracklist, resolvedEntityTypes, capturedConfirmedMap, discogsUrl, dedupOpts);
+                    return dispatchAllRelationships(json.companies, artistRoles, tracklistRels, live.applyToTracks, live.createWorksMode, json.tracklist, processTracklist, resolvedEntityTypes, capturedConfirmedMap, discogsUrl, dedupOpts);
                 });
         })
         .then(() => { });


### PR DESCRIPTION
## Summary

Closes [#94](https://github.com/majkinetor/musicbrainz-userscripts/issues/94).

Two related changes:

1. **"Create works" is now a mode picker**, not a boolean. Two options:
   - `when needed` (new default) — only create a work when there's a composer/lyricist/writer credit to attach.
   - `when missing` (old `createWorks: true` behavior) — create a work for every recording without one.

   Legacy users with `createWorks: true` saved are migrated to `when missing` (preserves their explicit always-create choice). Everyone else gets `when needed`. The legacy "off" path is removed (both modes always create works for recordings they cover).

2. **Options are re-read at dispatch time**, not frozen at import-click. majkinetor's follow-up: *"Options should be taken into account if changed before fill phase. Currently, changing the option during review phase doesn't work."* `runImport` now takes a `getOpts` getter; the dispatch reads it fresh just before calling `dispatchAllRelationships`. `processTracklist` is the one exception — it controls preflight, so it stays the initial value with a warning if toggled mid-flight.

## Test plan
- [x] New "Create works: [ when needed | when missing ]" selector appears in the option row
- [x] Default is `when needed` for new installs; legacy `createWorks: true` migrates to `when missing`
- [x] Toggle move-to-tracks / create-works / dedup options during review → dispatch reflects current value
- [x] Toggle per-track-credits during review → warning logged, preflight value used

🤖 Generated with [Claude Code](https://claude.com/claude-code)