### PR TITLE
discogs_credits: cap new-entity tab close delay (closes #97)

### DIFF
--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Discogs Credits
 // @namespace    majkinetor
-// @version      2026.5.27.212320
+// @version      2026.5.27.213202
 // @description  Add a button to import Discogs release relationships to MusicBrainz
 // @author       majkinetor
 // @match        https://musicbrainz.org/release/*/edit-relationships
@@ -5122,25 +5122,21 @@ ${lines}
     const pending = sessionStorage.getItem(pendingKey);
     if (!pending) return;
     sessionStorage.removeItem(pendingKey);
-    fetch(`//musicbrainz.org/ws/2/${entityType}/${mbid}?fmt=json`).then((r) => r.json()).then((json) => {
+    const NAME_FETCH_TIMEOUT_MS = 1e3;
+    const CLOSE_DELAY_MS = 50;
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), NAME_FETCH_TIMEOUT_MS);
+    fetch(`//musicbrainz.org/ws/2/${entityType}/${mbid}?fmt=json`, { signal: ctrl.signal }).then((r) => r.json()).then((json) => ({ name: json.name || "", disambiguation: json.disambiguation || "" })).catch(() => ({ name: "", disambiguation: "" })).then(({ name, disambiguation }) => {
+      clearTimeout(timer);
       DISCOGS_CHANNEL.postMessage({
         type: "artist-created",
         // keep same message type for compatibility
         id: mbid,
-        name: json.name || "",
-        disambiguation: json.disambiguation || "",
+        name,
+        disambiguation,
         resourceUrl: pending
       });
-      setTimeout(() => window.close(), 800);
-    }).catch(() => {
-      DISCOGS_CHANNEL.postMessage({
-        type: "artist-created",
-        id: mbid,
-        name: "",
-        disambiguation: "",
-        resourceUrl: pending
-      });
-      setTimeout(() => window.close(), 800);
+      setTimeout(() => window.close(), CLOSE_DELAY_MS);
     });
   })();
   $(document).ready(function() {

--- a/userscripts/discogs_credits/src/discogs_credits.user.js
+++ b/userscripts/discogs_credits/src/discogs_credits.user.js
@@ -45,28 +45,33 @@ import                                './storage.js';   // opens IndexedDB on lo
 
     sessionStorage.removeItem(pendingKey);
 
-    // Fetch entity name to send back
-    fetch(`//musicbrainz.org/ws/2/${entityType}/${mbid}?fmt=json`)
+    // Fetch entity name to send back, but cap the wait so a slow
+    // `/ws/2/<type>/<mbid>` response doesn't keep the new-entity tab
+    // open for many seconds (#97). If the fetch beats the timeout, we
+    // get the real name + disambiguation; otherwise post with empty
+    // strings — the opener tab can backfill via its own state once it
+    // sees the `artist-created` message. Closing was previously gated
+    // on the fetch promise + a flat 800ms delay; this raced to 10s+
+    // whenever MB was slow (which #87 showed is more common than we
+    // thought). New worst case: ~1.1s.
+    const NAME_FETCH_TIMEOUT_MS = 1000;
+    const CLOSE_DELAY_MS = 50; // tiny grace for BroadcastChannel delivery
+    const ctrl  = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), NAME_FETCH_TIMEOUT_MS);
+    fetch(`//musicbrainz.org/ws/2/${entityType}/${mbid}?fmt=json`, { signal: ctrl.signal })
         .then(r => r.json())
-        .then(json => {
+        .then(json => ({ name: json.name || '', disambiguation: json.disambiguation || '' }))
+        .catch(() => ({ name: '', disambiguation: '' }))
+        .then(({ name, disambiguation }) => {
+            clearTimeout(timer);
             DISCOGS_CHANNEL.postMessage({
                 type: 'artist-created',  // keep same message type for compatibility
                 id: mbid,
-                name: json.name || '',
-                disambiguation: json.disambiguation || '',
+                name,
+                disambiguation,
                 resourceUrl: pending,
             });
-            setTimeout(() => window.close(), 800);
-        })
-        .catch(() => {
-            DISCOGS_CHANNEL.postMessage({
-                type: 'artist-created',
-                id: mbid,
-                name: '',
-                disambiguation: '',
-                resourceUrl: pending,
-            });
-            setTimeout(() => window.close(), 800);
+            setTimeout(() => window.close(), CLOSE_DELAY_MS);
         });
 })();
 


### PR DESCRIPTION
## Summary

Closes [#97](https://github.com/majkinetor/musicbrainz-userscripts/issues/97). Tab opened by the "Create in MB" button sometimes took 10s+ to close after save, or never closed at all.

Root cause: `window.close()` was gated on `fetch('/ws/2/<type>/<mbid>?fmt=json')` resolving, plus an 800ms flat timer. When MB's `/ws/2` stalled (which the [#87](https://github.com/majkinetor/musicbrainz-userscripts/issues/87) work showed isn't rare), the close inherited that delay.

Fix:
- Wrap the name fetch in an `AbortController` with a 1s cap; on timeout, post `artist-created` with empty `name`/`disambiguation`. The opener tab already has the MBID and can backfill.
- Drop the 800ms artificial close delay; keep 50ms for cooperative `BroadcastChannel` delivery.

New worst case: ~1.1s vs the old 10s+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)