### PR TITLE
discogs_credits: "Searching…" placeholder in entity search (closes #98)

### DIFF
--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Discogs Credits
 // @namespace    majkinetor
-// @version      2026.5.27.212320
+// @version      2026.5.27.214123
 // @description  Add a button to import Discogs release relationships to MusicBrainz
 // @author       majkinetor
 // @match        https://musicbrainz.org/release/*/edit-relationships
@@ -2876,8 +2876,12 @@ Leave empty to use the default (Discogs name, or MB's most-frequent existing cre
             });
             return;
           }
+          candidateList.innerHTML = '<div style="font-size:0.82rem;color:#888;font-style:italic;">Searching\u2026</div>';
           mbThrottle.fetchJson(`//musicbrainz.org/ws/2/${entityType}?query=${encodeURIComponent(q)}&fmt=json&limit=8`).then((json) => {
-            if (!json) return;
+            if (!json) {
+              candidateList.innerHTML = '<div style="font-size:0.82rem;color:#c00;">Search failed \u2014 MB unavailable</div>';
+              return;
+            }
             candidateList.innerHTML = "";
             const resultKey = entityType === "label" ? "labels" : entityType === "place" ? "places" : "artists";
             if (!json[resultKey] || json[resultKey].length === 0) {
@@ -2889,6 +2893,7 @@ Leave empty to use the default (Discogs name, or MB's most-frequent existing cre
               json[resultKey].forEach((a) => candidateList.appendChild(makeCandidateRow(a)));
             }
           }).catch(() => {
+            candidateList.innerHTML = '<div style="font-size:0.82rem;color:#c00;">Search failed</div>';
           });
         }
         let searchTimer;

--- a/userscripts/discogs_credits/src/review-table.js
+++ b/userscripts/discogs_credits/src/review-table.js
@@ -1042,9 +1042,17 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
                         });
                     return;
                 }
+                // #98: show an immediate progress indicator so the user
+                // knows the search button took effect. Without it the
+                // candidate list looks dead for 1–3s while MB responds
+                // (longer when MB is rate-limiting us, see #87).
+                candidateList.innerHTML = '<div style="font-size:0.82rem;color:#888;font-style:italic;">Searching…</div>';
                 mbThrottle.fetchJson(`//musicbrainz.org/ws/2/${entityType}?query=${encodeURIComponent(q)}&fmt=json&limit=8`)
                     .then(json => {
-                        if (!json) return;
+                        if (!json) {
+                            candidateList.innerHTML = '<div style="font-size:0.82rem;color:#c00;">Search failed — MB unavailable</div>';
+                            return;
+                        }
                         candidateList.innerHTML = '';
                         const resultKey = entityType === 'label' ? 'labels' : entityType === 'place' ? 'places' : 'artists';
                         if (!json[resultKey] || json[resultKey].length === 0) {
@@ -1055,7 +1063,10 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
                         } else {
                             json[resultKey].forEach(a => candidateList.appendChild(makeCandidateRow(a)));
                         }
-                    }).catch(() => {});
+                    })
+                    .catch(() => {
+                        candidateList.innerHTML = '<div style="font-size:0.82rem;color:#c00;">Search failed</div>';
+                    });
             }
 
             let searchTimer;


### PR DESCRIPTION
## Summary

Closes [#98](https://github.com/majkinetor/musicbrainz-userscripts/issues/98). Pressing the search (🔍) button on a review-table row showed nothing for the 1–3s it took MB to respond — longer when MB was rate-limiting. Looked like the click hadn't registered.

The MBID-input branch of `doSearch` already showed "Looking up MBID…"; the name-query branch (the common case) didn't. Add an immediate italic "Searching…" placeholder before the fetch, and switch the silent `.catch(() => {})` to render a visible "Search failed" so MB errors don't disappear into a dead UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)