### PR TITLE
discogs_credits: restore "never" as third "Create works" option

### DIFF
--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Discogs Credits
 // @namespace    majkinetor
-// @version      2026.5.27.223723
+// @version      2026.5.27.233806
 // @description  User interface for importing Discogs release credits to MusicBrainz relationships
 // @author       majkinetor
 // @match        https://musicbrainz.org/release/*/edit-relationships
@@ -3680,6 +3680,13 @@ Leave empty to use the default (Discogs name, or MB's most-frequent existing cre
           if (!workEntity.gid && !workEntity.id) continue;
         }
         if (!workEntity) workEntity = getWorkFromEditorState(recEntity);
+        if (!workEntity && createWorksMode === "never") {
+          for (const { role } of entries) {
+            log.error(`Track ${trackPos} "${trackTitle}": no work exists for ${role.linkType} (${role.artist.name}) \u2014 "Create works" is set to "never". Add the work manually or change the mode.`);
+            failed++;
+          }
+          continue;
+        }
         if (!workEntity) {
           const newWorkId = re.getRelationshipStateId();
           workEntity = {
@@ -4139,12 +4146,13 @@ Leave empty to use the default (Discogs name, or MB's most-frequent existing cre
     const _legacyCreateWorks = savedOpts.createWorks;
     const _initialCreateWorksMode = bv(
       "createWorksMode",
-      _legacyCreateWorks === true ? "when-missing" : "when-needed"
+      _legacyCreateWorks === true ? "when-missing" : _legacyCreateWorks === false ? "never" : "when-needed"
     );
     const createWorksMode = makeSelect("Create works", _initialCreateWorksMode, [
       { value: "when-needed", label: "when needed" },
-      { value: "when-missing", label: "when missing" }
-    ], "when needed: create a work only when there is a composer/lyricist/writer credit to attach. when missing: create a work for every recording without one, regardless of credits.");
+      { value: "when-missing", label: "when missing" },
+      { value: "never", label: "never" }
+    ], "when needed: create a work only when there is a composer/lyricist/writer credit to attach. when missing: create a work for every recording without one. never: do not create works \u2014 work-only credits with no existing work are logged and skipped.");
     const dedupSep = document.createElement("span");
     dedupSep.textContent = "Dedup:";
     dedupSep.style.cssText = "margin:0 0.2rem 0 0.6rem;color:#888;font-size:0.85rem;font-weight:600;";

--- a/userscripts/discogs_credits/src/dispatch.js
+++ b/userscripts/discogs_credits/src/dispatch.js
@@ -664,10 +664,17 @@ export async function dispatchAllRelationships(companies, artistRoles, tracklist
             // Also check for works dispatched in this session (newly created ones)
             if (!workEntity) workEntity = getWorkFromEditorState(recEntity);
 
-            // No work found — always create one (#94 removed the "off"
-            // option; the user picks between "when needed" and "when
-            // missing", both of which create works for the recordings in
-            // `workOnlyByGid`).
+            // No work found. In `never` mode we refuse to create one and
+            // log the work-only credits as errors (legacy `createWorks: false`
+            // behaviour, restored as a third picker option). Otherwise
+            // (`when-needed` / `when-missing`) we create a new work below.
+            if (!workEntity && createWorksMode === 'never') {
+                for (const { role } of entries) {
+                    log.error(`Track ${trackPos} "${trackTitle}": no work exists for ${role.linkType} (${role.artist.name}) — "Create works" is set to "never". Add the work manually or change the mode.`);
+                    failed++;
+                }
+                continue;
+            }
             if (!workEntity) {
                 // Use MB's own batch-create-works mechanism:
                 //   1. Build a work object matching MB's createWorkObject() output

--- a/userscripts/discogs_credits/src/ui-bar.js
+++ b/userscripts/discogs_credits/src/ui-bar.js
@@ -412,20 +412,27 @@ export function insertDiscogsBar(discogsUrl) {
         'Import per-track artist credits from Discogs.');
     const applyTracksCb  = makeCheckbox('Move release credits to tracks', bv('applyTracks', true),
         'Move performance credits from the release down to every recording.');
-    // #94: "Create works" is now a binary mode picker, not a boolean toggle:
+    // "Create works" mode picker (#94, "never" option restored later):
     //   when-needed (default): create a work only when there's a
     //                           composer/lyricist/writer credit to attach.
     //   when-missing:          create a work for EVERY recording without one,
     //                           credits or no credits (old `createWorks=true`).
-    // Migration: legacy `createWorks: true` → 'when-missing' (preserves the
-    // user's explicit always-create choice); anything else → 'when-needed'.
+    //   never:                  create no works at all (old `createWorks=false`).
+    //                           Work-only credits that need a work that doesn't
+    //                           exist are logged and skipped.
+    // Migration: legacy `createWorks: true` → 'when-missing'; `createWorks: false`
+    // → 'never' (the explicit opt-out path the #94 picker lost); otherwise
+    // 'when-needed'.
     const _legacyCreateWorks = savedOpts.createWorks;
     const _initialCreateWorksMode = bv('createWorksMode',
-        _legacyCreateWorks === true ? 'when-missing' : 'when-needed');
+        _legacyCreateWorks === true  ? 'when-missing' :
+        _legacyCreateWorks === false ? 'never' :
+                                       'when-needed');
     const createWorksMode = makeSelect('Create works', _initialCreateWorksMode, [
         { value: 'when-needed',  label: 'when needed'  },
         { value: 'when-missing', label: 'when missing' },
-    ], 'when needed: create a work only when there is a composer/lyricist/writer credit to attach. when missing: create a work for every recording without one, regardless of credits.');
+        { value: 'never',        label: 'never'        },
+    ], 'when needed: create a work only when there is a composer/lyricist/writer credit to attach. when missing: create a work for every recording without one. never: do not create works — work-only credits with no existing work are logged and skipped.');
 
     // ── Deduplication section (issue #62) ─────────────────────────────────
     // Two toggles that change how the dispatcher decides "this rel is


### PR DESCRIPTION
## Summary

The [#94](https://github.com/majkinetor/musicbrainz-userscripts/issues/94) picker dropped the legacy `createWorks: false` opt-out. Re-adds it as a third option in the existing selector.

- **when needed** (default) — create only when a credit needs one.
- **when missing** — create for every recording without a work.
- **never** — do not create any new works. Work-only credits whose recording has no existing work are logged and skipped. Existing works on recordings are still attached (matches the pre-#94 `createWorks: false` behaviour exactly).

Migration: legacy `createWorks: false` saved-opts now map to `never` (previously got coerced to `when-needed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)