### PR TITLE
discogs_credits: [MB]/[D] quick-set buttons for "Credited as" (closes #108)

### DIFF
--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Discogs Credits
 // @namespace    majkinetor
-// @version      2026.5.28.175415
+// @version      2026.5.28.181839
 // @description  User interface for importing Discogs release credits to MusicBrainz relationships
 // @author       majkinetor
 // @match        https://musicbrainz.org/release/*/edit-relationships
@@ -2519,12 +2519,8 @@ Leave empty to use the default (Discogs name, or MB's most-frequent existing cre
         function refreshCredBtns() {
           const val = credInput.value;
           const mbName = currentMbName();
-          mbBtn.disabled = !mbName || val === mbName;
-          dBtn.disabled = val === displayName;
-          [mbBtn, dBtn].forEach((b) => {
-            b.style.opacity = b.disabled ? "0.4" : "1";
-            b.style.cursor = b.disabled ? "default" : "pointer";
-          });
+          mbBtn.style.display = !mbName || val === mbName ? "none" : "";
+          dBtn.style.display = val === displayName ? "none" : "";
         }
         function setCredViaButton(value) {
           credInput.value = value;

--- a/userscripts/discogs_credits/dist/discogs_credits.user.js
+++ b/userscripts/discogs_credits/dist/discogs_credits.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Import Discogs Credits
 // @namespace    majkinetor
-// @version      2026.5.28.162925
+// @version      2026.5.28.175415
 // @description  User interface for importing Discogs release credits to MusicBrainz relationships
 // @author       majkinetor
 // @match        https://musicbrainz.org/release/*/edit-relationships
@@ -2502,10 +2502,49 @@ Leave empty to use the default (Discogs name, or MB's most-frequent existing cre
         });
         credInput._activeMbUrl = r.mbUrl;
         if (r.mbUrl) creditOverrides.set(r.mbUrl, credInput.value);
+        const CRED_BTN_STYLE = "flex-shrink:0;padding:0.05rem 0.35rem;font-size:0.7rem;line-height:1;cursor:pointer;border:1px solid #c8a000;border-radius:3px;background:#fffbe6;color:#7a5000;";
+        const mbBtn = document.createElement("button");
+        mbBtn.type = "button";
+        mbBtn.textContent = "MB";
+        mbBtn.title = "Set Credited as to the MB entity name";
+        mbBtn.style.cssText = CRED_BTN_STYLE;
+        const dBtn = document.createElement("button");
+        dBtn.type = "button";
+        dBtn.textContent = "D";
+        dBtn.title = "Set Credited as to the Discogs name";
+        dBtn.style.cssText = CRED_BTN_STYLE;
+        function currentMbName() {
+          return rowState.get(_entityKey)?.mbName || r.mbName || null;
+        }
+        function refreshCredBtns() {
+          const val = credInput.value;
+          const mbName = currentMbName();
+          mbBtn.disabled = !mbName || val === mbName;
+          dBtn.disabled = val === displayName;
+          [mbBtn, dBtn].forEach((b) => {
+            b.style.opacity = b.disabled ? "0.4" : "1";
+            b.style.cursor = b.disabled ? "default" : "pointer";
+          });
+        }
+        function setCredViaButton(value) {
+          credInput.value = value;
+          credInput._userTouched = true;
+          credInput.dispatchEvent(new Event("input", { bubbles: true }));
+        }
+        mbBtn.addEventListener("click", () => {
+          const mbName = currentMbName();
+          if (mbName) setCredViaButton(mbName);
+        });
+        dBtn.addEventListener("click", () => setCredViaButton(displayName));
+        credInput.addEventListener("input", refreshCredBtns);
+        refreshCredBtns();
         credLine.appendChild(credLabel);
         credLine.appendChild(credInput);
+        credLine.appendChild(mbBtn);
+        credLine.appendChild(dBtn);
         tdDiscogs.appendChild(credLine);
         r._credInput = credInput;
+        r._refreshCredBtns = refreshCredBtns;
         const tdMb = document.createElement("td");
         tdMb.style.cssText = `padding:0.3rem 0.5rem;border:1px solid ${borderColor};min-width:240px;`;
         const candidateList = document.createElement("div");
@@ -2540,6 +2579,7 @@ Leave empty to use the default (Discogs name, or MB's most-frequent existing cre
             }
             creditOverrides.set(mbUrl, r._credInput.value);
             refreshCredBg();
+            if (r._refreshCredBtns) r._refreshCredBtns();
           }
           const _idbKey = r.entity?.resource_url ? parseDiscogsUrl(r.entity.resource_url)?.key : null;
           if (_idbKey) {

--- a/userscripts/discogs_credits/src/review-table.js
+++ b/userscripts/discogs_credits/src/review-table.js
@@ -542,12 +542,58 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
             });
             credInput._activeMbUrl = r.mbUrl;
             if (r.mbUrl) creditOverrides.set(r.mbUrl, credInput.value);
+
+            // [MB] / [D] quick-set buttons (#108): one click swaps the
+            // "Credited as" value to the MB entity name or the Discogs
+            // name. Disabled state: [MB] requires a resolved entity AND
+            // a value that isn't already the MB name; [D] is disabled
+            // when the value already equals the Discogs displayName.
+            const CRED_BTN_STYLE = 'flex-shrink:0;padding:0.05rem 0.35rem;font-size:0.7rem;line-height:1;cursor:pointer;border:1px solid #c8a000;border-radius:3px;background:#fffbe6;color:#7a5000;';
+            const mbBtn = document.createElement('button');
+            mbBtn.type = 'button';
+            mbBtn.textContent = 'MB';
+            mbBtn.title = 'Set Credited as to the MB entity name';
+            mbBtn.style.cssText = CRED_BTN_STYLE;
+            const dBtn = document.createElement('button');
+            dBtn.type = 'button';
+            dBtn.textContent = 'D';
+            dBtn.title = 'Set Credited as to the Discogs name';
+            dBtn.style.cssText = CRED_BTN_STYLE;
+            function currentMbName() {
+                return rowState.get(_entityKey)?.mbName || r.mbName || null;
+            }
+            function refreshCredBtns() {
+                const val = credInput.value;
+                const mbName = currentMbName();
+                mbBtn.disabled = !mbName || val === mbName;
+                dBtn.disabled  = val === displayName;
+                [mbBtn, dBtn].forEach(b => {
+                    b.style.opacity = b.disabled ? '0.4' : '1';
+                    b.style.cursor  = b.disabled ? 'default' : 'pointer';
+                });
+            }
+            function setCredViaButton(value) {
+                credInput.value = value;
+                credInput._userTouched = true;
+                credInput.dispatchEvent(new Event('input', { bubbles: true }));
+            }
+            mbBtn.addEventListener('click', () => {
+                const mbName = currentMbName();
+                if (mbName) setCredViaButton(mbName);
+            });
+            dBtn.addEventListener('click', () => setCredViaButton(displayName));
+            credInput.addEventListener('input', refreshCredBtns);
+            refreshCredBtns();
+
             credLine.appendChild(credLabel);
             credLine.appendChild(credInput);
+            credLine.appendChild(mbBtn);
+            credLine.appendChild(dBtn);
             tdDiscogs.appendChild(credLine);
             // Stash so other parts (search picker, refresh) can re-target
             // the override key when the row's mbUrl changes.
             r._credInput = credInput;
+            r._refreshCredBtns = refreshCredBtns;
 
             // ── Col 2: MB artist / search ──────────────────────────────────────
             const tdMb = document.createElement('td');
@@ -601,6 +647,7 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
                     }
                     creditOverrides.set(mbUrl, r._credInput.value);
                     refreshCredBg();
+                    if (r._refreshCredBtns) r._refreshCredBtns();
                 }
                 // Persist to IDB immediately so selection survives even without clicking Start import
                 const _idbKey = r.entity?.resource_url ? parseDiscogsUrl(r.entity.resource_url)?.key : null;

--- a/userscripts/discogs_credits/src/review-table.js
+++ b/userscripts/discogs_credits/src/review-table.js
@@ -565,12 +565,11 @@ export async function showReviewTable(allResults, rolesMap, companiesRolesMap, o
             function refreshCredBtns() {
                 const val = credInput.value;
                 const mbName = currentMbName();
-                mbBtn.disabled = !mbName || val === mbName;
-                dBtn.disabled  = val === displayName;
-                [mbBtn, dBtn].forEach(b => {
-                    b.style.opacity = b.disabled ? '0.4' : '1';
-                    b.style.cursor  = b.disabled ? 'default' : 'pointer';
-                });
+                // Hide rather than disable — disabled chips next to every
+                // row looked spammy. Buttons disappear entirely when the
+                // action would be a no-op (#108 follow-up).
+                mbBtn.style.display = (!mbName || val === mbName) ? 'none' : '';
+                dBtn.style.display  = (val === displayName) ? 'none' : '';
             }
             function setCredViaButton(value) {
                 credInput.value = value;


### PR DESCRIPTION
Adds two small `[MB]` / `[D]` buttons next to the Credited as input. Buttons are **hidden** (not just disabled) when the action would be a no-op — per the follow-up feedback that disabled chips on every row looked spammy.

- `[MB]` — sets the field to the MB entity name. Hidden when entity isn't resolved, or when the field already equals the MB name.
- `[D]` — sets the field to the Discogs name. Hidden when the field already equals the Discogs name.

Click goes through the existing input event path, so background highlight + debounced IDB save + re-render of the buttons themselves all fire unchanged. Picking a different MB entity via the row's search also refreshes the button state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)